### PR TITLE
Typo

### DIFF
--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -1,4 +1,4 @@
-b## Guides
+## Guides
 
 Snowpack dramatically speeds up your development time by removing the need for a web application bundler. But you can still use build tools like Babel or TypeScript and get the same speed improvements without the bundler. On every change, your build tool will only need to update a single file, instead of entire bundles.
 


### PR DESCRIPTION
There was an extra "b" at the start of the Guide section