### PR TITLE
Use Servor in quickstart guide

### DIFF
--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -15,6 +15,7 @@ npx snowpack
 Snowpack is agnostic to how you serve your site during development. If you have a static dev server that you already like, use it to serve your Snowpack app. Otherwise, we recommend one of the following for local development:
 
 - [`serve`](https://www.npmjs.com/package/serve) (popular, easy to use)
+- [`servor`](https://www.npmjs.com/package/servor) (dependency free, has live-reload by default)
 - [`live-server`](https://www.npmjs.com/package/live-server) (popular, easy to use, has live-reload)
 - [`lite-server`](https://www.npmjs.com/package/lite-server) (has live-reload, built for SPAs)
 - [`browser-sync`](https://www.npmjs.com/package/browser-sync) (popular, battle-tested)


### PR DESCRIPTION
This PR replaces the example in the quick-start guide that uses `serve` for hosting the snowpack'd application. I've proposed using [servor](https://github.com/lukejacksonn/servor) instead, which describes itself as a "close to the metal and dependency free server". I believe using servor allows for a more streamlined dev experience as the page will automatically refresh when any changes are made, whilst still being a slim and unobtrusive package (As I believe describes the snowpack ethos).

I'd love to know your thoughts on this!