### PR TITLE
Fix jest-haste-map warning on test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  modulePathIgnorePatterns: ['<rootDir>/pkg'],
+};


### PR DESCRIPTION
Fix warning on `npm test` below.

```
jest-haste-map: Haste module naming collision: snowpack
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>\package.json
    * <rootDir>\pkg\package.json
```