### PR TITLE
Update & fix react messaging

### DIFF
--- a/__tests__/integration/error-react-explicit/expected-output.txt
+++ b/__tests__/integration/error-react-explicit/expected-output.txt
@@ -1,0 +1,8 @@
+- snowpack installing...
+⠼ snowpack installing... react-dom
+✖ Dependency "react-dom" has no native "module" entrypoint.
+  To continue, install our drop-in, ESM-ready builds of "react" & "react-dom" to your project:
+    npm: npm install react@npm:@pika/react react-dom@npm:@pika/react-dom
+    yarn: yarn add react@npm:@pika/react react-dom@npm:@pika/react-dom
+See https://www.snowpack.dev/#react for more info.
+⚠ Finished with warnings.

--- a/__tests__/integration/error-react-explicit/node_modules/react-dom/index.js
+++ b/__tests__/integration/error-react-explicit/node_modules/react-dom/index.js
@@ -1,0 +1,1 @@
+// This mimics the react-dom package.

--- a/__tests__/integration/error-react-explicit/node_modules/react-dom/package.json
+++ b/__tests__/integration/error-react-explicit/node_modules/react-dom/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react-dom",
+  "version": "16.12.0",
+  "dependencies": {},
+  "main": "index.js"
+}

--- a/__tests__/integration/error-react-explicit/package.json
+++ b/__tests__/integration/error-react-explicit/package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "TEST": "node ../../../pkg/dist-node/index.bin.js"
+  },
+  "snowpack": {
+    "webDependencies": [
+      "react-dom"
+    ]
+  },
+  "dependencies": {
+    "react-dom": "latest"
+  }
+}

--- a/__tests__/integration/error-react/expected-output.txt
+++ b/__tests__/integration/error-react/expected-output.txt
@@ -1,0 +1,8 @@
+- snowpack installing...
+⠼ snowpack installing... react
+✖ Dependency "react" has no native "module" entrypoint.
+  To continue, install our drop-in, ESM-ready builds of "react" & "react-dom" to your project:
+    npm: npm install react@npm:@pika/react react-dom@npm:@pika/react-dom
+    yarn: yarn add react@npm:@pika/react react-dom@npm:@pika/react-dom
+See https://www.snowpack.dev/#react for more info.
+⚠ Finished with warnings.

--- a/__tests__/integration/error-react/node_modules/react/index.js
+++ b/__tests__/integration/error-react/node_modules/react/index.js
@@ -1,0 +1,1 @@
+// This mimics the react package.

--- a/__tests__/integration/error-react/node_modules/react/package.json
+++ b/__tests__/integration/error-react/node_modules/react/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react",
+  "version": "16.12.0",
+  "dependencies": {},
+  "main": "index.js"
+}

--- a/__tests__/integration/error-react/package.json
+++ b/__tests__/integration/error-react/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "TEST": "node ../../../pkg/dist-node/index.bin.js"
+  },
+  "dependencies": {
+    "react": "latest"
+  }
+}

--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -110,14 +110,14 @@ const html = htm.bind(h);
 import React, { useState } from '/web_modules/react.js';
 ```
 
-**Important:** React is [not yet published with ES Module support](https://github.com/facebook/react/issues/11503), and due to the way it's written, it's impossible to install as a dependency (*"Error: '__moduleExports' is not exported by node_modules/react/index.js"*). **However**, it is still possible to use React with Snowpack thanks to [@sdegutis](https://github.com/sdegutis)'s [@reactesm](https://www.npmjs.com/org/reactesm) project & npm/yarn's alias feature:
+**Important:** React is [not yet published with ES Module support](https://github.com/facebook/react/issues/11503), and the way that it's written makes it impossible to install as a dependency (*"Error: '__moduleExports' is not exported by node_modules/react/index.js"*). **However**, React is still supported thanks to our actively-maintained ESM builds of [React](https://www.npmjs.com/package/@pika/react) & [React-DOM](https://www.npmjs.com/package/@pika/react). You can install them both in your project under an alias like so:
 
 ```
 npm install react@npm:@reactesm/react react-dom@npm:@reactesm/react-dom
    yarn add react@npm:@reactesm/react react-dom@npm:@reactesm/react-dom
 ```
 
-When installed under the usual react/react-dom alias, Snowpack will install these easier-to-optimize ESM distributions into your `web_modules/` directory.
+When installed under the react/react-dom alias, all tooling (including Snowpack) will benefit from these easier-to-analyze ESM distributions of the popular packages.
 
 
 


### PR DESCRIPTION
For the Pika CDN, we now actively maintain ESM versions of React & React-DOM. So now we can start pointing to those in our docs instead of [@sdegutis](https://github.com/sdegutis)'s (which were great, but no longer appear to be maintained).

While doing that, I discovered that in many cases these custom messages weren't being displayed. I fixed that, and added some tests.

