### PR TITLE
prettify stat output

### DIFF
--- a/__tests__/integration/stat-output/expected-output.txt
+++ b/__tests__/integration/stat-output/expected-output.txt
@@ -1,7 +1,8 @@
 - snowpack installing...
 ✔ snowpack installed: cached-constructors-x, has-working-bind-x.
-Direct dependencies: web_modules/
-├─ cached-constructors-x.js []
-└─ has-working-bind-x.js []
-Shared dependencies: web_modules/common/
-└─ noop-x.esm.js []
+
+  ⦿ web_modules/
+    ├─ cached-constructors-x.js []
+    └─ has-working-bind-x.js    []
+  ⦿ web_modules/common/ (Shared)
+    └─ noop-x.esm.js []

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,31 +102,35 @@ function formatSize(size) {
 function formatDelta(delta) {
   const kb = Math.round(delta * 100) / 100;
   const color = delta > 0 ? 'red' : 'green';
-  return `Δ ${chalk[color](`${delta > 0 ? '+' : ''}${kb}`)} KB`;
+  return chalk[color](`Δ ${delta > 0 ? '+' : ''}${kb} KB`);
 }
 
-function formatFileInfo(file, lastFile) {
-  const lineGlyph = lastFile ? '└─' : '├─';
-  const lineName = chalk.cyan(file.fileName);
-  const lineSize = formatSize(file.size);
-  const lineDelta = file.delta ? `,  ${formatDelta(file.delta)}` : '';
-  return `${lineGlyph} ${lineName} [${lineSize}${lineDelta}]`;
+function formatFileInfo(file, padEnd, isLastFile) {
+  const lineGlyph = chalk.dim(isLastFile ? '└─' : '├─');
+  const lineName = file.fileName.padEnd(padEnd);
+  const lineSize = chalk.dim('[') + formatSize(file.size) + chalk.dim(']');
+  const lineDelta = file.delta ? chalk.dim(' [') + formatDelta(file.delta) + chalk.dim(']') : '';
+  return `    ${lineGlyph} ${lineName} ${lineSize}${lineDelta}`;
 }
 
 function formatFiles(files, title) {
-  return `${title}
-${files.map((file, index) => formatFileInfo(file, index >= files.length - 1)).join('\n')}`;
+  const maxFileNameLength = files.reduce((max, file) => Math.max(file.fileName.length, max), 0);
+  return `  ⦿ ${chalk.bold(title)}
+${files
+  .map((file, index) => formatFileInfo(file, maxFileNameLength, index >= files.length - 1))
+  .join('\n')}`;
 }
 
 function formatDependencyStats(): string {
   let output = '';
   const {direct, common} = dependencyStats;
-
-  output += formatFiles(Object.values(direct), 'Direct dependencies: web_modules/');
+  const allDirect = Object.values(direct);
+  const allCommon = Object.values(common);
+  output += formatFiles(allDirect, 'web_modules/');
   if (Object.values(common).length > 0) {
-    output += `\n${formatFiles(Object.values(common), 'Shared dependencies: web_modules/common/')}`;
+    output += `\n${formatFiles(allCommon, 'web_modules/common/ (Shared)')}`;
   }
-  return output;
+  return `\n${output}\n`;
 }
 
 function logError(msg) {


### PR DESCRIPTION
A follow up to #190 

I took a pass to stylize the `--stat` output. No core logic changes were made, but some small output logic changes were. Most of the diff is just from chalk being added/removed from different lines.

## Before

<img width="402" alt="Screen Shot 2020-02-07 at 5 39 49 PM" src="https://user-images.githubusercontent.com/622227/74077448-aa765e80-49d4-11ea-9db6-31ef99f8a401.png">


## After

<img width="698" alt="Screen Shot 2020-02-07 at 6 03 23 PM" src="https://user-images.githubusercontent.com/622227/74077436-99c5e880-49d4-11ea-8a02-ce40f46c6cf6.png">
<img width="521" alt="Screen Shot 2020-02-07 at 6 03 08 PM" src="https://user-images.githubusercontent.com/622227/74077440-9d596f80-49d4-11ea-90df-3688f60fb296.png">

/cc @alex-saunders would love your review