### PR TITLE
fix nomodule path resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -408,11 +408,15 @@ export async function install(
     }
     try {
       const noModuleBundle = await rollup.rollup({
-        input: nomodule,
+        input: path.resolve(cwd, nomodule),
         inlineDynamicImports: true,
         plugins: [...inputOptions.plugins, rollupResolutionHelper()],
       });
-      await noModuleBundle.write({file: path.resolve(destLoc, nomoduleOutput), format: 'iife'});
+      await noModuleBundle.write({
+        file: path.resolve(destLoc, nomoduleOutput),
+        format: 'iife',
+        name: 'App',
+      });
       const nomoduleEnd = Date.now() - nomoduleStart;
       spinner.info(
         `${chalk.bold(


### PR DESCRIPTION
user-provided "nomodule" paths were being detected as package imports  ("src/a/b.js")  instead of on-disk files (`/a/b/src/app.js`). I think Rollup handled this automatically for us, until we added that deep-package import detection plugin which tried to treat it as a package.