### PR TITLE
fix: when import in .js, transform error

### DIFF
--- a/assets/babel-plugin.js
+++ b/assets/babel-plugin.js
@@ -32,7 +32,12 @@ function getImportMap(explicitPath, dir) {
 function rewriteImport(importMap, imp, dir, shouldAddMissingExtension) {
   const isSourceImport = imp.startsWith('/') || imp.startsWith('.') || imp.startsWith('\\');
   const isRemoteImport = imp.startsWith('http://') || imp.startsWith('https://');
-  const mappedImport = importMap.imports[imp];
+  const extname = path.extname(imp);
+  let tempImp = imp;
+  if (extname) {
+    tempImp = imp.replace(extname, '');
+  }
+  const mappedImport = importMap.imports[tempImp];
   if (mappedImport) {
     if (mappedImport.startsWith('http://') || mappedImport.startsWith('https://')) {
       return mappedImport;
@@ -47,7 +52,7 @@ function rewriteImport(importMap, imp, dir, shouldAddMissingExtension) {
     console.log(`warn: bare import "${imp}" not found in import map, ignoring...`);
     return imp;
   }
-  if (isSourceImport && shouldAddMissingExtension && !path.extname(imp)) {
+  if (isSourceImport && shouldAddMissingExtension && !extname) {
     return imp + '.js';
   }
   return imp;


### PR DESCRIPTION
source
```javascript
import React, { useState } from "react";
import ReactDOM from "react-dom";
import Button from '@material-ui/core/Button/index.js';
```

when use `snowpack`, will generate a map, such as 
```javascript
{
  "imports": {
    "react": "./react.js",
    "react-dom": "./react-dom.js",
    "@material-ui/core/Button/index": "./@material-ui/core/Button/index.js"
  }
}
```
but target file will become 
```javascript
import React, { useState } from "/web_modules/react.js";
import ReactDOM from "/web_modules/react-dom.js";
import Button from "@material-ui/core/Button/index.js"; 
```
the `imp` was `@material-ui/core/Button/index.js` so skip from the map.

This pr will fix it and Output correct value.

```javascript
import React, { useState } from "/web_modules/react.js";
import ReactDOM from "/web_modules/react-dom.js";
import Button from "/web_modules/@material-ui/core/Button/index.js"; 
```

