### PR TITLE
Add file path to `--stat` output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import loadConfig, {SnowpackConfig} from './config.js';
 import {
   rollupPluginDependencyStats,
   DependencyStatsOutput,
+  DependencyStats,
 } from './rollup-plugin-dependency-info.js';
 import {scanImports, scanDepList, InstallTarget} from './scan-imports.js';
 import {resolveDependencyManifest} from './util.js';
@@ -91,7 +92,12 @@ function formatDelta(delta) {
   return chalk[color](`Δ ${delta > 0 ? '+' : ''}${kb} KB`);
 }
 
-function formatFileInfo(filename, stats, padEnd, isLastFile) {
+function formatFileInfo(
+  filename: string,
+  stats: DependencyStats,
+  padEnd: number,
+  isLastFile: boolean,
+): string {
   const lineGlyph = chalk.dim(isLastFile ? '└─' : '├─');
   const lineName = filename.padEnd(padEnd);
   const lineSize = chalk.dim('[') + formatSize(stats.size) + chalk.dim(']');
@@ -99,11 +105,11 @@ function formatFileInfo(filename, stats, padEnd, isLastFile) {
   return `    ${lineGlyph} ${lineName} ${lineSize}${lineDelta}`;
 }
 
-function formatFiles(files, title) {
+function formatFiles(files: [string, DependencyStats][], title: string) {
   const strippedFiles = files.map(([filename, stats]) => [
     filename.replace(/^common\//, ''),
     stats,
-  ]);
+  ]) as [string, DependencyStats][];
   const maxFileNameLength = strippedFiles.reduce(
     (max, [filename]) => Math.max(filename.length, max),
     0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,27 +91,36 @@ function formatDelta(delta) {
   return chalk[color](`Δ ${delta > 0 ? '+' : ''}${kb} KB`);
 }
 
-function formatFileInfo(file, padEnd, isLastFile) {
+function formatFileInfo(filename, stats, padEnd, isLastFile) {
   const lineGlyph = chalk.dim(isLastFile ? '└─' : '├─');
-  const lineName = file.fileName.padEnd(padEnd);
-  const lineSize = chalk.dim('[') + formatSize(file.size) + chalk.dim(']');
-  const lineDelta = file.delta ? chalk.dim(' [') + formatDelta(file.delta) + chalk.dim(']') : '';
+  const lineName = filename.padEnd(padEnd);
+  const lineSize = chalk.dim('[') + formatSize(stats.size) + chalk.dim(']');
+  const lineDelta = stats.delta ? chalk.dim(' [') + formatDelta(stats.delta) + chalk.dim(']') : '';
   return `    ${lineGlyph} ${lineName} ${lineSize}${lineDelta}`;
 }
 
 function formatFiles(files, title) {
-  const maxFileNameLength = files.reduce((max, file) => Math.max(file.fileName.length, max), 0);
+  const strippedFiles = files.map(([filename, stats]) => [
+    filename.replace(/^common\//, ''),
+    stats,
+  ]);
+  const maxFileNameLength = strippedFiles.reduce(
+    (max, [filename]) => Math.max(filename.length, max),
+    0,
+  );
   return `  ⦿ ${chalk.bold(title)}
-${files
-  .map((file, index) => formatFileInfo(file, maxFileNameLength, index >= files.length - 1))
+${strippedFiles
+  .map(([filename, stats], index) =>
+    formatFileInfo(filename, stats, maxFileNameLength, index >= files.length - 1),
+  )
   .join('\n')}`;
 }
 
 function formatDependencyStats(): string {
   let output = '';
   const {direct, common} = dependencyStats;
-  const allDirect = Object.values(direct);
-  const allCommon = Object.values(common);
+  const allDirect = Object.entries(direct);
+  const allCommon = Object.entries(common);
   output += formatFiles(allDirect, 'web_modules/');
   if (Object.values(common).length > 0) {
     output += `\n${formatFiles(allCommon, 'web_modules/common/ (Shared)')}`;

--- a/src/rollup-plugin-dependency-info.ts
+++ b/src/rollup-plugin-dependency-info.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import {OutputOptions, OutputBundle} from 'rollup';
 
 type DependencyStats = {
-  fileName: string;
   size: number;
   delta?: number;
 };
@@ -36,7 +35,6 @@ export function rollupPluginDependencyStats(cb: (dependencyInfo: DependencyStats
       const filePath = path.join(outputDir, file);
       const {size} = fs.statSync(filePath);
       output[type][file] = {
-        fileName: path.basename(file),
         size,
       };
 

--- a/src/rollup-plugin-dependency-info.ts
+++ b/src/rollup-plugin-dependency-info.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import {OutputOptions, OutputBundle} from 'rollup';
 
-type DependencyStats = {
+export type DependencyStats = {
   size: number;
   delta?: number;
 };

--- a/test/integration/stat-output/expected-install/has-working-bind-x/dist/has-working-bind-x.esm.js
+++ b/test/integration/stat-output/expected-install/has-working-bind-x/dist/has-working-bind-x.esm.js
@@ -1,4 +1,4 @@
-import { n as noop } from './common/noop-x.esm-e72ec11e.js';
+import { n as noop } from '../../common/noop-x.esm-e72ec11e.js';
 
 var bind = noop.bind;
 

--- a/test/integration/stat-output/expected-install/import-map.json
+++ b/test/integration/stat-output/expected-install/import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "cached-constructors-x": "./cached-constructors-x.js",
-    "has-working-bind-x": "./has-working-bind-x.js"
+    "has-working-bind-x/dist/has-working-bind-x.esm.js": "./has-working-bind-x/dist/has-working-bind-x.esm.js"
   }
 }

--- a/test/integration/stat-output/expected-output.txt
+++ b/test/integration/stat-output/expected-output.txt
@@ -1,8 +1,8 @@
 - snowpack installing...
-✔ snowpack installed: cached-constructors-x, has-working-bind-x.
+✔ snowpack installed: cached-constructors-x, has-working-bind-x/dist/has-working-bind-x.esm.js.
 
   ⦿ web_modules/
-    ├─ cached-constructors-x.js []
-    └─ has-working-bind-x.js    []
+    ├─ cached-constructors-x.js                          []
+    └─ has-working-bind-x/dist/has-working-bind-x.esm.js []
   ⦿ web_modules/common/ (Shared)
     └─ noop-x.esm.js []

--- a/test/integration/stat-output/package.json
+++ b/test/integration/stat-output/package.json
@@ -6,7 +6,7 @@
   "snowpack": {
     "webDependencies": [
       "cached-constructors-x",
-      "has-working-bind-x"
+      "has-working-bind-x/dist/has-working-bind-x.esm.js"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
- Adds full file path to `--stat` output when a specific file is defined as a web dependency
- Strips `common/` from the file path to remove clutter on common dependency output
- Updates test cases to include appropriate scenario