### PR TITLE
small suggestions cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -435,6 +435,7 @@ export async function install(
       // Display posix-style on all environments, mainly to help with CI :)
       const fileName = path.posix.relative(cwd, loc.file);
       logError(`${chalk.bold('snowpack')} could not import ${fileName}. ${suggestion}`);
+      return;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
   DependencyStats,
 } from './rollup-plugin-dependency-info.js';
 import {scanImports, scanDepList, InstallTarget} from './scan-imports.js';
-import {resolveDependencyManifest, fileExtSuggestions} from './util.js';
+import {resolveDependencyManifest, MISSING_PLUGIN_SUGGESTIONS} from './util.js';
 
 import zlib from 'zlib';
 
@@ -416,28 +416,25 @@ export async function install(
     chunkFileNames: 'common/[name]-[hash].js',
   };
   if (Object.keys(depObject).length > 0) {
-    // Main Snowpack Install 🚀
     try {
       const packageBundle = await rollup.rollup(inputOptions);
       await packageBundle.write(outputOptions);
     } catch (err) {
-      // Main Snowpack Install error handling
-      const {loc} = err as rollup.RollupError; // Note: err contains a ton of useful information for error handling
-
-      // if there’s a suggestion based on the file extension, show it
-      const invalidFile = loc.file || ''; // Rollup erred on this exact file
-      const suggestion = fileExtSuggestions[path.extname(invalidFile)];
-      if (suggestion) {
-        const relativeName = invalidFile.replace(cwd, '').replace(/\\/g, '/'); // use forward slashes for display
-        logError(
-          `${chalk.bold('snowpack')} encountered an error importing ${relativeName}. ${suggestion}`,
-        );
-        return;
+      const {loc} = err as rollup.RollupError;
+      if (!loc || !loc.file) {
+        throw err;
       }
-
-      // otherwise, show the error message
-      logError(`${chalk.bold('snowpack')} encountered an error: ${err.message}`);
-      return;
+      // NOTE: Rollup will fail instantly on error. Because of that, we can
+      // only report one error at a time. `err.watchFiles` also exists, but
+      // for now `err.loc.file` has all the information that we need.
+      const failedExtension = path.extname(loc.file);
+      const suggestion = MISSING_PLUGIN_SUGGESTIONS[failedExtension];
+      if (!suggestion) {
+        throw err;
+      }
+      // Display posix-style on all environments, mainly to help with CI :)
+      const fileName = path.posix.relative(cwd, loc.file);
+      logError(`${chalk.bold('snowpack')} could not import ${fileName}. ${suggestion}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -433,7 +433,7 @@ export async function install(
         throw err;
       }
       // Display posix-style on all environments, mainly to help with CI :)
-      const fileName = path.posix.relative(cwd, loc.file);
+      const fileName = loc.file.replace(cwd + path.sep, '').replace(/\\/g, '/');
       logError(`${chalk.bold('snowpack')} could not import ${fileName}. ${suggestion}`);
       return;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,10 +55,9 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
  * If Rollup erred parsing a particular file, show suggestions based on its
  * file extension (note: lowercase is fine).
  */
-export const fileExtSuggestions: {[ext: string]: string} = {
+export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.css':
     'Try installing rollup-plugin-postcss and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
-  '.jsx': 'Try installing @babel/preset-react and enabling Babel (https://www.snowpack.dev/#babel)',
   '.svelte':
     'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
   '.vue':

--- a/test/integration/error-file-ext/expected-output.txt
+++ b/test/integration/error-file-ext/expected-output.txt
@@ -1,4 +1,4 @@
 - snowpack installing...
 ⠼ snowpack installing... @zeit-ui/style, deepmerge
-✖ snowpack encountered an error importing /node_modules/@zeit-ui/style/dist/style.css. Try installing rollup-plugin-postcss and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)
+✖ snowpack could not import node_modules/@zeit-ui/style/dist/style.css. Try installing rollup-plugin-postcss and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)
 ⚠ Finished with warnings.


### PR DESCRIPTION
/cc @dangodev I realized I was unclear about what info I wanted documented in the code, so I took a quick stab at it myself. Also cleaned up a few bits of code, mainly:

- removed the JSX suggestion: we don't actually read your .babelrc in the current babel plugin, and I think it would be a mess to figure out which babel plugins should run on deps and which are meant for source. Lets remove for now.
- ~~path.posix.relative() instead of custom relativeUrl creator (I forgot that this existed!)~~ Nvm, didn't work as well as I'd expected :)
- tried to simplify the error reporting flow to be a bit more lax about just throwing errors if we can't suggest (we still have a top-level catch to log `err.loc.file`, followed by the full stacktrace which can be helpful)