### PR TITLE
Add support for absolute path to babel plugin

### DIFF
--- a/assets/babel-plugin.js
+++ b/assets/babel-plugin.js
@@ -5,10 +5,9 @@ function readImportMapFile(explicitPath, dir) {
   if (explicitPath) {
     if(path.isAbsolute(explicitPath)){
       return fs.readFileSync(explicitPath, {encoding: 'utf8'});
-    } else {
-      const explicitImportMap = path.join(process.cwd(), dir, explicitPath);
-      return fs.readFileSync(explicitImportMap, {encoding: 'utf8'});
-    }
+    } 
+    const explicitImportMap = path.join(process.cwd(), dir, explicitPath);
+    return fs.readFileSync(explicitImportMap, {encoding: 'utf8'});
   }
   const localImportMap = path.join(process.cwd(), dir, `import-map.local.json`);
   const defaultImportMap = path.join(process.cwd(), dir, `import-map.json`);

--- a/assets/babel-plugin.js
+++ b/assets/babel-plugin.js
@@ -3,9 +3,9 @@ const path = require('path');
 
 function readImportMapFile(explicitPath, dir) {
   if (explicitPath) {
-    if(path.isAbsolute(explicitPath)){
+    if (path.isAbsolute(explicitPath)) {
       return fs.readFileSync(explicitPath, {encoding: 'utf8'});
-    } 
+    }
     const explicitImportMap = path.join(process.cwd(), dir, explicitPath);
     return fs.readFileSync(explicitImportMap, {encoding: 'utf8'});
   }

--- a/assets/babel-plugin.js
+++ b/assets/babel-plugin.js
@@ -3,8 +3,12 @@ const path = require('path');
 
 function readImportMapFile(explicitPath, dir) {
   if (explicitPath) {
-    const explicitImportMap = path.join(process.cwd(), dir, explicitPath);
-    return fs.readFileSync(explicitImportMap, {encoding: 'utf8'});
+    if(path.isAbsolute(explicitPath)){
+      return fs.readFileSync(explicitPath, {encoding: 'utf8'});
+    } else {
+      const explicitImportMap = path.join(process.cwd(), dir, explicitPath);
+      return fs.readFileSync(explicitImportMap, {encoding: 'utf8'});
+    }
   }
   const localImportMap = path.join(process.cwd(), dir, `import-map.local.json`);
   const defaultImportMap = path.join(process.cwd(), dir, `import-map.json`);

--- a/test/babel-plugin/cwd/web_modules/import-map-absolute.test.json
+++ b/test/babel-plugin/cwd/web_modules/import-map-absolute.test.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "example-dep": "./example-dep.js?from=import-map-absolute.test.json"
+  }
+}

--- a/test/babel-plugin/fixtures-absolute/importMapAbsolutePath/code.js
+++ b/test/babel-plugin/fixtures-absolute/importMapAbsolutePath/code.js
@@ -1,0 +1,1 @@
+import module from 'example-dep';

--- a/test/babel-plugin/fixtures-absolute/importMapAbsolutePath/output.js
+++ b/test/babel-plugin/fixtures-absolute/importMapAbsolutePath/output.js
@@ -1,0 +1,1 @@
+import module from '/web_modules/example-dep.js?from=import-map-absolute.test.json';

--- a/test/babel-plugin/runner.js
+++ b/test/babel-plugin/runner.js
@@ -9,3 +9,12 @@ pluginTester({
   pluginName: 'snowpack/assets/babel-plugin.js',
   fixtures: path.join(__dirname, 'fixtures'),
 });
+
+pluginTester({
+  plugin: babelPlugin,
+  pluginName: 'snowpack/assets/babel-plugin.js',
+  fixtures: path.join(__dirname, 'fixtures-absolute'),
+  pluginOptions: {
+    importMap: path.resolve(process.cwd(), 'web_modules/import-map-absolute.test.json'),
+  },
+});


### PR DESCRIPTION
When using Snowpack with a custom output directory like: `snowpack --dest public/web_modules`, the babel plugin can't use a path that looks like `public/web_modules/import-map.json` (like in this example) because you end up with `./web_modules/public/web_modules/import-map.json`.

```js
const path = require("path");
module.exports = {
  plugins: [
    [
      require.resolve("./forked-snowpack.js"),
      {
        importMap: "public/web_modules/import-map.json"
      }
    ]
  ]
};
```

This is because [`dir` is automatically added to the path to require the import map](https://github.com/pikapkg/snowpack/blob/7de70a5afa11bd52e314d8c11f4ca8ef860c9d94/assets/babel-plugin.js#L6) in the plugin, even though the path to the import map isn't related to the web server web_modules path location at all (as far as I can tell).

This PR adds a backwards-compatible solution that lets people use an absolute path instead of a relative path. I think the better solution is to not use `dir` at all to construct the import path, but to remove that would be a breaking change so I opted for this solution, which is enough for my needs.

If this is useful and a good approach for y'all I can add test fixtures to the PR as well.