### PR TITLE
add new example project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ npm install --save-dev snowpack
 - Preact, JSX, Fragment, Router, CSS Grid, Typescript, Babel: [[Source]](https://github.com/crra/snowpack-doodle)
 - React, JSX, Material-UI and super basic routing: [[Source]](https://github.com/jmetev1/snowpackJSXreact)
 - A basic svelte setup powered by svelvet: [[Source]](https://github.com/jakedeichert/svelvet)
+- React Component Library w/Storybook! (React, Typescript, Material-UI): [[Source]](https://github.com/snikas/React-Component-Library)
 - 🙋‍♀️ Have a great example you'd like to share? Create it on [CodeSandbox](https://codesandbox.io/), [Glitch](https://glitch.com), or [GitHub](https://github.com/new). Then add it here via PR.


### PR DESCRIPTION
I've been LOVING snowpack since I first heard about it on syntax. I've successfully proposed it to my company and we are officially going to adopt it as anti-build system.

I've put together this starter example for using snowpack for development of a component library using storybook. Rollup has been introduced as the final build step since the final build is a node library and not a web app.

I think this is a unique example compared to the others. I'd love to include it if possible!
of course feedback would be appreciated if not.

Thanks!

Steven