### PR TITLE
fix import scanner

### DIFF
--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -11,9 +11,9 @@ const WEB_MODULES_TOKEN_LENGTH = WEB_MODULES_TOKEN.length;
 // [@\w] - Match a word-character or @ (valid package name)
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
-const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/;
-const SPLIT_NAMED_IMPORTS_REGEX = /\bas\s\w+|,/;
-const DEFAULT_IMPORT_REGEX = /import\s(\w)+(,\s\{[\w\s]*\})?\s+from/;
+const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
+const SPLIT_NAMED_IMPORTS_REGEX = /\bas\s+\w+|,/s;
+const DEFAULT_IMPORT_REGEX = /import\s+(\w)+(,\s\{[\w\s]*\})?\s+from/s;
 
 /**
  * An install target represents information about a dependency to install.
@@ -117,7 +117,6 @@ function getInstallTargetsForFile(filePath: string, code: string): InstallTarget
   const allImports: InstallTarget[] = imports
     .map(imp => parseImportStatement(code, imp))
     .filter(isTruthy);
-
   return allImports;
 }
 

--- a/test/integration/include/a.js
+++ b/test/integration/include/a.js
@@ -1,5 +1,8 @@
-// test 1: sub-module
+// test a1: sub-module
 import Vue from '/web_modules/vue/dist/vue.esm.browser.js';
 
-// test 2: default export
-import VueRouter from '/web_modules/vue-router.js';
+// test a2: default export + odd whitespace
+import
+  VueRouter
+from
+  '/web_modules/vue-router.js';

--- a/test/integration/include/b.js
+++ b/test/integration/include/b.js
@@ -1,5 +1,7 @@
-// test 3: named export
-import {flatten} from '/web_modules/array-flatten.js';
+// test b1: named export + odd whitespace
+import {
+  flatten
+}
+from
+  '/web_modules/array-flatten.js';
 flatten([1, [2, [3, [4, [5], 6], 7], 8], 9]);
-
-Vue.use(VueRouter);

--- a/test/integration/include/c.js
+++ b/test/integration/include/c.js
@@ -1,4 +1,4 @@
-// test 4: dynamic export
+// test c1: dynamic export
 import('/web_modules/http-vue-loader/src/httpVueLoader.js').then(httpVueLoader => {
   Vue.use(httpVueLoader);
 


### PR DESCRIPTION
Our new import scanner regex was too strict about whitespace, and wasn't properly matching newline characters in statements like these:

```
import {
    SvelteComponent as e,
    create_component as t,
    destroy_component as n,
    init as o,
    mount_component as r,
    noop as s,
    safe_not_equal as m,
    transition_in as l,
    transition_out as u,
} from '/web_modules/svelte/internal.js';
```

The `/s` regex flag does most of the work in this PR, along with some other Regex fixes.

meta point: we're very integration-test heavy (which I like!) but this would be a good area to invest in unit tests of the actual scanner itself.