### PR TITLE
[wip] support aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1630,6 +1630,21 @@
       "integrity": "sha512-1ZsOHGc0qJDofO+/98PfchHJqJjtfZL3liVGi4QZ28GtLmTVuZ4SUJFa5NgbsYawnrr//pdNOfx9JiaLFKpzrA==",
       "dev": true
     },
+    "@rollup/plugin-alias": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.0.1.tgz",
+      "integrity": "sha512-ReSy6iPl3GsWLMNeshXAfgItZFMoMOTYC7MZQQM5va4pqxiGgwl1xZUZfHW6zGyZPK+k8TBadxx+kdmepiUa+g==",
+      "requires": {
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+        }
+      }
+    },
     "@rollup/plugin-commonjs": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
     "@babel/types": "^7.6.3",
+    "@rollup/plugin-alias": "^3.0.1",
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-node-resolve": "^7.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,23 @@ const configSchema = {
   type: 'object',
   properties: {
     source: {type: 'string'},
-    webDependencies: {type: 'array', items: {type: 'string'}},
+    webDependencies: {
+      type: 'array',
+      items: {
+        anyOf: [
+          {type: 'string'},
+          {
+            type: 'array',
+            items: [
+              {
+                type: 'string',
+              },
+              {type: 'string'},
+            ],
+          },
+        ],
+      },
+    },
     dedupe: {
       type: 'array',
       items: {type: 'string'},

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,6 @@ export async function install(
   {hasBrowserlistConfig, isExplicit, lockfile}: InstallOptions,
   config: SnowpackConfig,
 ) {
-  // throw new Error('typescript sucks'); // @ts-ignore
   const {
     dedupe,
     namedExports,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import rollupPluginCommonjs from '@rollup/plugin-commonjs';
 import rollupPluginJson from '@rollup/plugin-json';
 import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
 import rollupPluginReplace from '@rollup/plugin-replace';
+import rollupPluginAlias from '@rollup/plugin-alias';
 import chalk from 'chalk';
 import fs from 'fs';
 import hasha from 'hasha';
@@ -324,6 +325,11 @@ export async function install(
         rollupPluginReplace({
           'process.env.NODE_ENV': isOptimized ? '"production"' : '"development"',
         }),
+      rollupPluginAlias({
+        entries: Array.from(allInstallSpecifiers)
+          .filter(spec => Array.isArray(spec))
+          .map(([alias, mod]) => ({find: alias, replacement: mod})),
+      }),
       rollupPluginNodeResolve({
         mainFields: ['browser:module', 'module', 'browser', !isStrict && 'main'].filter(isTruthy),
         modulesOnly: isStrict, // Default: false

--- a/src/resolve-remote.ts
+++ b/src/resolve-remote.ts
@@ -91,7 +91,10 @@ export async function resolveTargetsFromRemoteCDN(
   const newLockfile: ImportMap = {imports: {}};
 
   const allInstallSpecifiers = new Set(installTargets.map(dep => dep.specifier));
-  for (const installSpecifier of allInstallSpecifiers) {
+  for (const installSpecifierOrArr of allInstallSpecifiers) {
+    const installSpecifier = Array.isArray(installSpecifierOrArr)
+      ? installSpecifierOrArr[1]
+      : installSpecifierOrArr;
     const installSemver: string =
       (pkgManifest.dependencies || {})[installSpecifier] ||
       (pkgManifest.devDependencies || {})[installSpecifier] ||


### PR DESCRIPTION
This adds support for `webDependencies` alias support. For example, we can alias `react` to `preact/compat`.

```json
{
 "snowpack": {
    "webDependencies": [
      "preact",
      "@emotion/preact-core",
      [
        "react",
        "preact/compat"
      ]
    ]
  }
}
```

---

I still need to get some local tests passing and go back over the code to make sure it's doing what I think it is.

## TODO:

- [ ] fix: source-pika tests (node 13 only?)
- [x] fix: export tests (node 13 only?) [fixed by rebasing]
- [ ] write: alias tests