### PR TITLE
consider all external packages as pure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,7 @@ export async function install(
   const inputOptions: InputOptions = {
     input: installEntrypoints,
     external: externalPackages,
+    treeshake: {moduleSideEffects: 'no-external'},
     plugins: [
       rollupPluginEntrypointAlias({cwd}),
       source === 'pika' && rollupPluginDependencyCache({log: url => logUpdate(chalk.dim(url))}),


### PR DESCRIPTION
This shouldn't affect anyone since I don't think anyone else is using `--external-package`, but is needed for some other Pika tooling to strip unused imports