### PR TITLE
Revert "remove check for custom react esm build (#243)"

### DIFF
--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -110,13 +110,15 @@ const html = htm.bind(h);
 import React, { useState } from '/web_modules/react.js';
 ```
 
+**Important:** Depending on how you use Snowpack, you may run into the issue that [React is not yet published with ES Module support](https://github.com/facebook/react/issues/11503). This isn't a problem for most packages, but due to the way that the React package is written it is impossible for Snowpack to install normally (*"Error: '__moduleExports' is not exported by node_modules/react/index.js"*). 
+
 To use React with Snowpack, you can either:
 
 1. **Recommended:** use the [`--source pika`](#skipping-npm-install) flag to install your web dependencies directly from the Pika CDN. The CDN's version of React is built to support ESM, and all npm packages should be supported.
 
-2. **Alternatively:** If you run into an issue with `--source pika`, you can use our actively-maintained ESM-alternative package of [React-DOM](https://www.npmjs.com/package/@pika/react-dom) along with React 16.13.0 or later. This package includes the same code as the original, but published within an ESM wrapper so that build tools like Snowpack can benefit from the easier-to-analyze code.
+2. **Alternatively:** If you run into an issue with `--source pika`, you can use our actively-maintained ESM-alternative packages of [React](https://www.npmjs.com/package/@pika/react) & [React-DOM](https://www.npmjs.com/package/@pika/react). These packages include the same code as the originals, but published within an ESM wrapper so that build tools like Snowpack can benefit from the easier-to-analyze code.
 
-You can install the ESM-alternative package in your project under an alias:
+You can install both ESM-alternative packages in your project under an alias:
 
 ```
 npm install react@npm:@pika/react react-dom@npm:@pika/react-dom

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,13 +177,16 @@ function resolveWebDependency(dep: string, isExplicit: boolean): DependencyLoc {
   if (!foundEntrypoint && isExplicit) {
     foundEntrypoint = depManifest.main || 'index.js';
   }
-  if (dep === 'react-dom' && (!foundEntrypoint || foundEntrypoint === 'index.js')) {
+  if (
+    (dep === 'react' || dep === 'react-dom') &&
+    (!foundEntrypoint || foundEntrypoint === 'index.js')
+  ) {
     throw new ErrorWithHint(
       chalk.bold(`Dependency "${dep}" has no native "module" entrypoint.`) +
         `
-  To continue, install our drop-in, ESM-ready build of "react-dom" to your project:
-    npm: npm install react-dom@npm:@pika/react-dom
-    yarn: yarn add react-dom@npm:@pika/react-dom`,
+  To continue, install our drop-in, ESM-ready builds of "react" & "react-dom" to your project:
+    npm: npm install react@npm:@pika/react react-dom@npm:@pika/react-dom
+    yarn: yarn add react@npm:@pika/react react-dom@npm:@pika/react-dom`,
       chalk.italic(`See ${chalk.underline('https://www.snowpack.dev/#react')} for more info.`),
     );
   }

--- a/test/integration/error-react/expected-output.txt
+++ b/test/integration/error-react/expected-output.txt
@@ -1,6 +1,6 @@
 - snowpack installing...
-⠼ snowpack installing... react-dom
-✖ Dependency "react-dom" has no native "module" entrypoint.
+⠼ snowpack installing... react
+✖ Dependency "react" has no native "module" entrypoint.
   To continue, install our drop-in, ESM-ready builds of "react" & "react-dom" to your project:
     npm: npm install react@npm:@pika/react react-dom@npm:@pika/react-dom
     yarn: yarn add react@npm:@pika/react react-dom@npm:@pika/react-dom

--- a/test/integration/error-react/node_modules/react/index.js
+++ b/test/integration/error-react/node_modules/react/index.js
@@ -1,0 +1,1 @@
+// This mimics the react package.

--- a/test/integration/error-react/node_modules/react/package.json
+++ b/test/integration/error-react/node_modules/react/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react",
+  "version": "16.12.0",
+  "dependencies": {},
+  "main": "index.js"
+}

--- a/test/integration/error-react/package.json
+++ b/test/integration/error-react/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "TEST": "node ../../../pkg/dist-node/index.bin.js"
+  },
+  "dependencies": {
+    "react": "latest"
+  }
+}

--- a/test/integration/source-pika-with-fallback/snowpack.lock.json
+++ b/test/integration/source-pika-with-fallback/snowpack.lock.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "async": "https://cdn.pika.dev/async@v3.1.0-ENwq8gsjdqg55EqedqGF"
+  }
+}

--- a/test/integration/source-pika/snowpack.lock.json
+++ b/test/integration/source-pika/snowpack.lock.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "async": "https://cdn.pika.dev/async@v3.1.0-ENwq8gsjdqg55EqedqGF"
+  }
+}


### PR DESCRIPTION
This reverts #243. Unfortunately we still see issues with react + react-dom. I think that these issues are still fixable, but it will just require some additional work before it's ready for master. Reverting now so that we can publish a new version.

/cc @matthoffner