### PR TITLE
Fix horizontal scrolling issue on mobile docs

### DIFF
--- a/www/css/github-markdown.css
+++ b/www/css/github-markdown.css
@@ -961,3 +961,7 @@
 .markdown-body .pl-12 {
   padding-left: 128px!important;
 }
+
+.markdown-body iframe {
+  max-width: 100%;
+}


### PR DESCRIPTION
Previously on mobile devices, the video would cause a large amount of
overflow leading to a horizontally scrollable site

![Horizontal scroll mobile issue](https://user-images.githubusercontent.com/8593744/78388921-bef06500-75d9-11ea-8c78-d588a7deb4f2.png)


