### PR TITLE
ci: Make GitHub Actions run on pushes to master

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,12 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
The project build status shows as failing because CI doesn't run on pushes to master

I use a browser extension https://github.com/sindresorhus/refined-github that (among many other things) shows current build status in the top of the page on github. This is what I see for this project:

![image](https://user-images.githubusercontent.com/2111701/78704944-b5694480-78da-11ea-9cb4-44465825512d.png)
