### PR TITLE
Config: don't deep merge array options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -215,12 +215,11 @@ export default function loadConfig(flags: CLIFlags, pkgManifest: any) {
   });
 
   // if valid, apply config over defaults
-  const mergedConfig = merge<SnowpackConfig>([
-    DEFAULT_CONFIG,
-    {webDependencies: pkgManifest.webDependencies},
-    config,
-    cliConfig as any,
-  ]);
+  const overwriteMerge = (destinationArray, sourceArray, options) => sourceArray;
+  const mergedConfig = merge<SnowpackConfig>(
+    [DEFAULT_CONFIG, {webDependencies: pkgManifest.webDependencies}, config, cliConfig as any],
+    {arrayMerge: overwriteMerge},
+  );
 
   // if CLI flags present, apply those as overrides
   return {


### PR DESCRIPTION
`deepmerge.all` concats array options by default. This became a problem
when I wanted to control the `exclude` option. The value I provided was
concatted with the default option for `exclude` instead of replacing it.