### PR TITLE
Add @babel/syntax-plugin-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -596,7 +596,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
       "integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.6.4",
+    "@babel/plugin-syntax-typescript": "^7.8.3",
     "@babel/plugin-transform-react-jsx": "^7.9.4",
     "@babel/preset-env": "^7.6.3",
     "@babel/types": "^7.6.3",


### PR DESCRIPTION
Tiny PR. Tried building a Preact app with `--include 'src/**/*.tsx'` and got this error:

```
Error: Cannot find module '@babel/plugin-syntax-typescript'
```

This just adds that to `dependencies` (which I saw `@babel/plugin-transform-react-jsx` was already there)

Alternative route: we could _not_ include these as deps and throw a warning asking people to install them themselves (or as peerDeps). That’d cut down weight (`@babel/plugin-transform-react-jsx` is beefy), but at the expense of friendliness / DX. At any rate, the package included in this library is super-tiny so this PR doesn’t affect weight significantly.