### PR TITLE
fix bad dynamic import scanning

### DIFF
--- a/test/integration/include/src/d.tsx
+++ b/test/integration/include/src/d.tsx
@@ -1,4 +1,9 @@
 // test 4: dynamic export
+import(`bad:${'template'}-string`);
+
+const badVariable = 'bad:cant-scan-a-variable';
+import(badVariable);
+
 import('/web_modules/http-vue-loader/src/httpVueLoader.js').then((httpVueLoader) => {
   Vue.use(httpVueLoader);
 

--- a/test/integration/include/src/e.js
+++ b/test/integration/include/src/e.js
@@ -1,0 +1,4 @@
+// test 5: import.meta
+// Just testing that our parser doesnt die!
+
+console.log(import.meta.url);


### PR DESCRIPTION
We weren't checking that dynamic imports actually contained a string, before accepting them as valid. Now, we check first and ignore if you're dynamically importing anything other than a string literal.

Resolves https://www.pika.dev/npm/snowpack/discuss/125
/cc @nandoflorestan