### PR TITLE
Fix: babel-plugin had missing variable declaration

### DIFF
--- a/assets/babel-plugin.js
+++ b/assets/babel-plugin.js
@@ -29,7 +29,7 @@ function readImportMapFile(explicitPath, webModulesDir) {
 
 function getImportMap(explicitPath, webModulesDir) {
   const fileContents = readImportMapFile(explicitPath, webModulesDir);
-  importMapJson = JSON.parse(fileContents);
+  const importMapJson = JSON.parse(fileContents);
   return importMapJson;
 }
 


### PR DESCRIPTION
I found this issue on LGTM.com:
https://lgtm.com/projects/g/pikapkg/snowpack/?mode=list