### PR TITLE
Fix references to @snowpack/plugin-babel

### DIFF
--- a/docs/04-scripts.md
+++ b/docs/04-scripts.md
@@ -102,7 +102,7 @@ There are a few reasons you may want to use a build plugin instead of a normal "
 ```js
 "scripts": {
   // Speed: The build plugin is ~10x faster than using the Babel CLI directly
-  "plugin:babel": "@snowpack/plugin-babel",
+  "plugin:js,jsx": "@snowpack/plugin-babel",
 }
 ```
 

--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -50,7 +50,7 @@ Babel will automatically read plugins & presets from your local project `babel.c
 
 ```js
 "scripts": { 
-  "plugin:js,jsx": "babel"
+  "plugin:js,jsx": "@snowpack/plugin-babel"
 }
 ```
 
@@ -81,7 +81,7 @@ Note that while TypeScript is a great type checker, we recommend using Babel to 
 
 ```js
 "scripts": { 
-  "plugin:ts,tsx": "babel",
+  "plugin:ts,tsx": "@snowpack/plugin-babel",
   "lintall:ts,tsx": "tsc --noEmit",
   "lintall:ts,tsx::watch": "$1 --watch"
 }


### PR DESCRIPTION
As discussed here https://www.pika.dev/npm/snowpack/discuss/147#comment-6239

You always have to refer to the babel plugin as `@snowpack/plugin-babel`, like this: 

```
"plugin:js,jsx": "@snowpack/plugin-babel"
```

Using the shorthand "babel" does not work:

```
"plugin:js,jsx": "babel"
```