### PR TITLE
Add a warning to use a dummy build script with plugins

### DIFF
--- a/docs/04-scripts.md
+++ b/docs/04-scripts.md
@@ -95,6 +95,16 @@ Note that `$1` can be used with a script modifier to reference the original scri
 
 For a more powerful integration, you can also write build scripts using JavaScript to create *build plugins*. Each plugin is loaded as a JavaScript module that exports custom `build()` and `lint()` functions that are run on matching files.
 
+**NOTE: Due to a bug, the "scripts" section must include at least one "build" script.** You can work around this issue by using a dummy build script, like this:
+
+```js
+"scripts": {
+  "build:dummy": "cat",
+  "plugin:js,jsx": "@snowpack/plugin-babel",
+}
+
+```
+
 There are a few reasons you may want to use a build plugin instead of a normal "build:" or "lint:" CLI command script:
 
 **Speed:** Some CLIs may have a slower start-up time, which may become a problem as your site grows. Plugins can be faster across many files since they only need to be loaded & initialized once and not once for every file.

--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -32,6 +32,16 @@ To author code using JSX & `.jsx` files in your `src/` directory, [connect Babel
 }
 ```
 
+**NOTE: Due to a bug, the "scripts" section must include at least one "build" script.** You can work around this issue by using a dummy build script, like this:
+
+```js
+"scripts": {
+  "build:dummy": "cat",
+  "plugin:vue": "vue"
+}
+
+```
+
 ### Svelte
 
 ```js
@@ -41,6 +51,15 @@ To author code using JSX & `.jsx` files in your `src/` directory, [connect Babel
 }
 ```
 
+**NOTE: Due to a bug, the "scripts" section must include at least one "build" script.** You can work around this issue by using a dummy build script, like this:
+
+```js
+"scripts": {
+  "build:dummy": "cat",
+  "plugin:svelte": "svelte"
+}
+
+```
 
 ### Babel
 
@@ -52,6 +71,16 @@ Babel will automatically read plugins & presets from your local project `babel.c
 "scripts": { 
   "plugin:js,jsx": "babel"
 }
+```
+
+**NOTE: Due to a bug, the "scripts" section must include at least one "build" script.** You can work around this issue by using a dummy build script, like this:
+
+```js
+"scripts": {
+  "build:dummy": "cat",
+  "plugin:js,jsx": "babel"
+}
+
 ```
 
 #### via @babel/cli
@@ -75,6 +104,15 @@ TypeScript will automatically read config from your local project `tsconfig.json
   "lintall:ts,tsx": "tsc --noEmit",
   "lintall:ts,tsx::watch": "$1 --watch"
 }
+```
+
+**NOTE: Due to a bug, the "scripts" section must include at least one "build" script.** You can work around this issue by using a dummy build script, like this:
+
+```js
+"scripts": {
+  "build:dummy": "cat",
+}
+
 ```
 
 Note that while TypeScript is a great type checker, we recommend using Babel to build TypeScript files to JavaScript. Babel supports much greater control over your build output.


### PR DESCRIPTION
As discussed here https://www.pika.dev/npm/snowpack/discuss/147#comment-6239

When your "scripts" section includes no "build" scripts, Snowpack refuses to build anything.

Adding this warning fixes the recipes. The warning should be removed when this bug is fixed.