### PR TITLE
fix bugs related to path seperators on windows

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -196,6 +196,7 @@ export async function command({cwd, config}: DevOptions) {
       const allBuildNeededFiles: string[] = [];
       await Promise.all(
         allFiles.map((f) => {
+          f = path.resolve(f); // this is necessary since glob.sync() returns paths with / on windows.  path.resolve() will switch them to the native path separator.
           if (allBuildExtensions.includes(path.extname(f).substr(1))) {
             allBuildNeededFiles.push(f);
             return;
@@ -352,7 +353,7 @@ export async function command({cwd, config}: DevOptions) {
     );
     await fs.writeFile(
       path.join(buildDirectoryLoc, '.babelrc'),
-      `{"plugins": [["${require.resolve('@babel/plugin-syntax-import-meta')}"]]}`,
+      `{"plugins": [[${JSON.stringify(require.resolve('@babel/plugin-syntax-import-meta'))}]]}`, // JSON.stringify is needed because on windows, \ in paths need to be escaped
     );
   }
   await prepareBuildDirectoryForParcel();


### PR DESCRIPTION
This fixes several places in the build.ts where there was a mismatch between paths with / separators and \ separators. 

This was related to issue pikapkg/create-snowpack-app#3, or at least my post in that issue.  I did confirm that the svelte template also works with these changes, but I also was not able to reproduce the exact same error message that was originally reported.

Note, I did not systematically search for other places in the codebase that might be mixing APIs that use/return unix-style paths and APIs that use/return windows-style paths.