### PR TITLE
Guarentee webdeps must be unique

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -396,6 +396,18 @@ export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): Snowpa
     ],
     {arrayMerge: overwriteMerge},
   );
+  for (const webDependencyName of Object.keys(mergedConfig.webDependencies || {})) {
+    if (pkgManifest.dependencies && pkgManifest.dependencies[webDependencyName]) {
+      handleConfigError(
+        `"${webDependencyName}" is included in "webDependencies". Please remove it from your package.json "dependencies" config.`,
+      );
+    }
+    if (pkgManifest.devDependencies && pkgManifest.devDependencies[webDependencyName]) {
+      handleConfigError(
+        `"${webDependencyName}" is included in "webDependencies". Please remove it from your package.json "devDependencies" config.`,
+      );
+    }
+  }
 
   // if CLI flags present, apply those as overrides
   return normalizeConfig(mergedConfig);


### PR DESCRIPTION
We've seen a lot of confusion over this question, so codifying it into the config validation. We should also improve our docs to make this explicit as well.