### PR TITLE
Make build bundling optional again

### DIFF
--- a/docs/05-configuration.md
+++ b/docs/05-configuration.md
@@ -37,7 +37,7 @@ CLI flags will be merged with (and take priority over) your config file values. 
   ],
   "homepage": "/your-project",
   "installOptions": { /* ... */ },
-  "buildOptions": { /* ..... */ }
+  "devOptions": { /* ..... */ }
 }
 ```
 
@@ -58,7 +58,7 @@ CLI flags will be merged with (and take priority over) your config file values. 
   - Set build scripts to transform your source files. See the section below for more info.
 - **`installOptions.*`**
   - Configure how npm packages are installed. See the section below for all options.
-- **`buildOptions.*`**
+- **`devOptions.*`**
   - Configure your dev server and build workflows. See the section below for all options.
 
 #### Install Options
@@ -81,12 +81,16 @@ CLI flags will be merged with (and take priority over) your config file values. 
   - **`rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve#usage) for more documentation.
   - **`rollup.namedExports`** - If needed, you can explicitly define named exports for any dependency. You should only use this if you're getting `"'X' is not exported by Y"` errors without it. See [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs#usage) for more documentation.
 
-#### Build Options
+#### Dev Options
 
 - **`port`** | `number` | Default: `3000`
   - The port number to run the dev server on.
 - **`out`** | `string` | Default: `"build"`
   - The local directory that we output your final build to.
+- **`bundle`** | `boolean`
+  - Create an optimized, bundled build for production. 
+  - You must have [Parcel](https://parceljs.org/) as a dev dependency in your project.
+  - If undefined, this option will be enabled if the `parcel` package is found.
 - **`fallback`** | `string` | Default: `"index.html"`
   - When using the Single-Page Application (SPA) pattern, this is the HTML "shell" file that gets served for every (non-resource) user route. Make sure that you configure your production servers to serve this as well.
 

--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -1,0 +1,23 @@
+export function wrapEsmProxyResponse(url: string, code: string, ext: string, hasHmr = false) {
+  if (ext === '.css') {
+    return `
+    const styleEl = document.createElement("style");
+    styleEl.type = 'text/css';
+    styleEl.appendChild(document.createTextNode(${JSON.stringify(code)}));
+    document.head.appendChild(styleEl);
+    ${
+      hasHmr
+        ? `
+    import {apply} from '/web_modules/@snowpack/hmr.js';
+    console.log('apply', import.meta.url);
+    apply(import.meta.url, ({code}) => {
+      styleEl.innerHtml = '';
+      styleEl.appendChild(document.createTextNode(code));
+    });
+    `
+        : ''
+    }
+  `;
+  }
+  return `export default ${JSON.stringify(url)};`;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import {all as merge} from 'deepmerge';
 import chalk from 'chalk';
 
 const CONFIG_NAME = 'snowpack';
-const ALWAYS_EXCLUDE = ['node_modules/**/*', '.*'];
+const ALWAYS_EXCLUDE = ['node_modules/**/*', '.*', '.types/**/*'];
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
@@ -34,6 +34,7 @@ export interface SnowpackConfig {
     port: number;
     out: string;
     fallback: string;
+    bundle: boolean | undefined;
   };
   installOptions: {
     dest: string;
@@ -77,6 +78,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
     port: 8080,
     out: 'build',
     fallback: 'index.html',
+    bundle: undefined,
   },
 };
 
@@ -133,6 +135,7 @@ const configSchema = {
         port: {type: 'number'},
         out: {type: 'string'},
         fallback: {type: 'string'},
+        bundle: {type: 'boolean'},
       },
     },
     scripts: {
@@ -282,11 +285,6 @@ function validateConfigAgainstV1(rawConfig: any, cliFlags: any) {
     );
   }
   // Removed!
-  if (rawConfig.devOptions?.bundle || cliFlags.bundle) {
-    handleDeprecatedConfigError(
-      '[Snowpack v1 -> v2] `devOptions.bundle` is now the default build behavior. This config is safe to remove.',
-    );
-  }
   if (rawConfig.devOptions?.dist) {
     handleDeprecatedConfigError(
       '[Snowpack v1 -> v2] `devOptions.dist` is no longer required. This config is safe to remove.',


### PR DESCRIPTION
Resolves https://github.com/pikapkg/create-snowpack-app/issues/39

<img width="718" alt="Screen Shot 2020-05-09 at 10 20 51 PM" src="https://user-images.githubusercontent.com/622227/81491426-5da85b00-9243-11ea-9c02-d9cdfa914be0.png">

Bundling used to be optional, and then it became required, and now it is optional again! This lets us shrink the footprint of default CSA apps, and also lets us keep experimenting with unbundled deployments.