### PR TITLE
Hmr fixes

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -9,8 +9,7 @@ export function wrapEsmProxyResponse(url: string, code: string, ext: string, has
       hasHmr
         ? `
     import {apply} from '/web_modules/@snowpack/hmr.js';
-    console.log('apply', import.meta.url);
-    apply(import.meta.url, ({code}) => {
+    apply(window.location.origin + ${JSON.stringify(url)}, ({code}) => {
       styleEl.innerHtml = '';
       styleEl.appendChild(document.createTextNode(code));
     });


### PR DESCRIPTION
I tried the current CSS hot reload but it didn't work immediately for me...

Paths were not good on my machine (linux) with the `'raw'` chokidar event. This PR fixes this and resolution of CSS files mounted on `'.'`.

Then, `import.meta.url` registered to `apply` contained the `.proxy.js` suffix, but this mismatches with the URL receive in the change event, so it was reloading anyway.

With this, it works.

Also: remove disconnected clients to avoid a memory leak, now that we don't drop all of them after sending a "reload" command.