### PR TITLE
fix css build matching

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -139,6 +139,7 @@ export async function command({cwd, config}: DevOptions) {
       env: npmRunPath.env(),
       extendEnv: true,
       shell: true,
+      cwd,
     });
     allWorkerPromises.push(workerPromise);
     workerPromise.catch((err) => {
@@ -281,6 +282,7 @@ export async function command({cwd, config}: DevOptions) {
             env: npmRunPath.env(),
             extendEnv: true,
             shell: true,
+            cwd,
             input: createReadStream(f),
           });
           if (stderr) {


### PR DESCRIPTION
Issues resolved:
- native file assets (js & css) weren't being properly sent to builders
- build scripts weren't being run with the correct `cwd`
- css proxy modules weren't being properly cached (wasn't noticed since builds were being skipped)