### PR TITLE
Fix for opening browser in Windows.

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -587,7 +587,10 @@ function openInBrowser(port) {
   if (process.platform === 'darwin') openCmd = 'open';
   if (process.platform === 'win32') openCmd = 'start';
 
-  execa(openCmd, [url]).catch(() => {
+  let args = [url];
+  if (process.platform === 'win32') args = ['', ...args];  
+ 
+  execa(openCmd, args).catch(() => {
     // couldn't open automatically, safe to ignore
   });
 }


### PR DESCRIPTION
Running snowpack dev in my Windows system does not open the browser. Instead it treats the url as the Title of the new console window where the command is run. This fix prepends an empty parameter when the environment is Windows so that this one gets treated like the Title of the window and the second one as the actual url that needs to be open.

Fixes #326 

Sorry, didn't have time to write a test so please review carefully.
