### PR TITLE
Standardize Basic Plugin API

### DIFF
--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -1,9 +1,8 @@
-const hotStates = {};
+const REGISTERED_MODULES = {};
 
-class HotState {
+class HotModuleState {
   constructor(id) {
     this.id = id;
-    this.data = {};
     this.disposeCallbacks = [];
   }
   lock() {
@@ -13,55 +12,47 @@ class HotState {
     this.disposeCallbacks.push(cb);
   }
   accept(cb = true) {
-    if (this.isLocked) {
-      return;
+    if (!this.isLocked) {
+      this.acceptCallback = cb;
     }
-    this.acceptCallback = cb;
   }
-  // beforeUpdate(cb) {
-  //   globalState.beforeUpdateCallbacks[this.id] = cb;
-  // }
-  // afterUpdate(cb) {
-  //   globalState.afterUpdateCallbacks[this.id] = cb;
-  // }
 }
 
-export const createHotContext = (fullUrl) => {
+function debug(...args) {
+  console.log('[snowpack:hmr]', ...args);
+}
+
+export function createHotContext(fullUrl) {
   const id = new URL(fullUrl).pathname;
-  const existing = hotStates[id];
+  const existing = REGISTERED_MODULES[id];
   if (existing) {
     existing.lock();
     return existing;
   }
-  const state = new HotState(id);
-  hotStates[id] = state;
+  const state = new HotModuleState(id);
+  REGISTERED_MODULES[id] = state;
   return state;
-};
+}
 
-const serial = (f) => {
-  let promise;
-  return (...args) => (promise = promise ? promise.then(() => f(...args)) : f(...args));
-};
-
-const applyUpdate = serial(async (fullUrl) => {
+async function applyUpdate(id) {
   let state = null;
-  const cssModuleState = hotStates[fullUrl];
-  if (cssModuleState && fullUrl.endsWith('.module.css')) {
-    // const response = await import(fullUrl + `?mtime=${Date.now()}`);
+  const cssModuleState = REGISTERED_MODULES[id];
+  if (cssModuleState && id.endsWith('.module.css')) {
+    // const response = await import(id + `?mtime=${Date.now()}`);
     // cssModuleState({module: response});
     state = cssModuleState;
   }
-  const proxyModuleListener = hotStates[fullUrl + '.proxy.js'];
+  const proxyModuleListener = REGISTERED_MODULES[id + '.proxy.js'];
   if (!state && proxyModuleListener) {
     state = proxyModuleListener;
-    // const response = await fetch(fullUrl);
+    // const response = await fetch(id);
     // const code = await response.text();
     // proxyModuleListener({code});
   }
 
-  const moduleListener = hotStates[fullUrl];
-  if (!state && moduleListener && fullUrl.endsWith('.js')) {
-    // const response = await import(fullUrl + `?mtime=${Date.now()}`);
+  const moduleListener = REGISTERED_MODULES[id];
+  if (!state && moduleListener && id.endsWith('.js')) {
+    // const response = await import(id + `?mtime=${Date.now()}`);
     // moduleListener({module: response});
     state = moduleListener;
   }
@@ -71,13 +62,12 @@ const applyUpdate = serial(async (fullUrl) => {
   }
 
   const acceptCallback = state.acceptCallback;
+  const disposeCallbacks = state.disposeCallbacks;
+  state.disposeCallbacks = [];
   // const disposeCallback = state.disposeCallback;
   // delete globalState.afterUpdateCallbacks[fileId];
   // delete globalState.beforeUpdateCallbacks[fileId];
   // delete state.acceptCallback;
-
-  await Promise.all(state.disposeCallbacks.map((cb) => cb(state.data)));
-  state.disposeCallbacks = [];
 
   if (!acceptCallback) {
     return false;
@@ -85,30 +75,31 @@ const applyUpdate = serial(async (fullUrl) => {
   if (acceptCallback === true) {
     return true;
   }
-  if (fullUrl.endsWith('.js') || fullUrl.endsWith('.module.css')) {
-    const response = await import(fullUrl + `?mtime=${Date.now()}`);
+  if (id.endsWith('.js') || id.endsWith('.module.css')) {
+    const response = await import(id + `?mtime=${Date.now()}`);
     await acceptCallback({module: response});
   } else {
-    const response = await import(fullUrl + '.proxy.js' + `?mtime=${Date.now()}`);
+    const response = await import(id + '.proxy.js' + `?mtime=${Date.now()}`);
     await acceptCallback({module: response});
   }
+  await Promise.all(disposeCallbacks.map((cb) => cb()));
   return true;
-});
+}
 
 const source = new EventSource('/livereload');
 const reload = () => location.reload(true);
 source.onerror = () => (source.onopen = reload);
 source.onmessage = async (e) => {
   const data = JSON.parse(e.data);
-  console.log(e.data);
+  debug('message', e.data);
   if (!data.url) {
     reload();
     return;
   }
-  const fullUrl = data.url.split('?')[0];
-  console.log(fullUrl, hotStates);
+  const id = data.url.split('?')[0];
+  debug(id, Object.keys(REGISTERED_MODULES));
 
-  applyUpdate(fullUrl)
+  applyUpdate(id)
     .then((ok) => {
       if (!ok) reload();
     })
@@ -118,4 +109,4 @@ source.onmessage = async (e) => {
     });
 };
 
-console.log('[snowpack] listening for file changes');
+debug('listening for file changes...');

--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -1,3 +1,83 @@
+const hotStates = {};
+
+const globalState = {
+  beforeUpdateCallbacks: {},
+  afterUpdateCallbacks: {},
+};
+
+class HotState {
+  constructor(id) {
+    this.id = id;
+    this.data = {}
+  }
+
+  dispose(cb) {
+    this.disposeCallback = cb;
+  }
+
+  accept(cb = true) {
+    this.acceptCallback = cb;
+  }
+
+  beforeUpdate(cb) {
+    globalState.beforeUpdateCallbacks[this.id] = cb;
+  }
+
+  afterUpdate(cb) {
+    globalState.afterUpdateCallbacks[this.id] = cb;
+  }
+}
+
+const getHotState = id => {
+  const existing = hotStates[id];
+  if (existing) {
+    return existing;
+  }
+  const state = new HotState(id);
+  hotStates[id] = state;
+  return state;
+};
+
+export const createHotContext = getHotState;
+
+const serial = f => {
+  let promise
+  return (...args) => (promise = promise ? promise.then(() => f(...args)) : f(...args))
+}
+
+const applyUpdate = serial(async (event, id) => {
+  if (event === 'add') {
+    await import(id + `.proxy.js?mtime=${Date.now()}`);
+    return true
+  }
+
+  const state = getHotState(id);
+  const acceptCallback = state.acceptCallback;
+  const disposeCallback = state.disposeCallback;
+
+  delete globalState.afterUpdateCallbacks[id];
+  delete globalState.beforeUpdateCallbacks[id];
+  delete state.acceptCallback;
+  delete state.disposeCallback;
+
+  if (typeof disposeCallback === 'function') {
+    await disposeCallback(state.data);
+  }
+
+  if (event === 'change') {
+    if (!acceptCallback) return false;
+
+    await import(id + `.proxy.js?mtime=${Date.now()}`);
+
+    if (typeof acceptCallback === 'function') {
+      await acceptCallback();
+    }
+  }
+
+  return true;
+})
+
+
 const listeners = {};
 export function apply(url, callback) {
   const fullUrl = new URL(url).pathname;
@@ -5,8 +85,11 @@ export function apply(url, callback) {
 }
 
 const source = new EventSource('/livereload');
+
 const reload = () => location.reload(true);
+
 source.onerror = () => (source.onopen = reload);
+
 source.onmessage = async (e) => {
   const data = JSON.parse(e.data);
   console.log(e.data);

--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -92,7 +92,7 @@ source.onerror = () => (source.onopen = reload);
 source.onmessage = async (e) => {
   const data = JSON.parse(e.data);
   debug('message', e.data);
-  if (!data.url) {
+  if (data.reload || !data.url) {
     reload();
     return;
   }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -11,7 +11,12 @@ import rimraf from 'rimraf';
 import {DevScript} from '../config';
 import {transformEsmImports} from '../rewrite-imports';
 import {CommandOptions, ImportMap} from '../util';
-import {getFileBuilderForWorker, wrapCssModuleResponse, wrapEsmProxyResponse} from './build-util';
+import {
+  getFileBuilderForWorker,
+  wrapCssModuleResponse,
+  wrapEsmProxyResponse,
+  wrapJSModuleResponse,
+} from './build-util';
 import {paint} from './paint';
 import srcFileExtensionMapping from './src-file-extension-mapping';
 const {copy} = require('fs-extra');
@@ -341,6 +346,7 @@ export async function command(commandOptions: CommandOptions) {
             });
             return `/web_modules/${spec}.js`;
           });
+          code = await wrapJSModuleResponse(code);
         }
         await fs.mkdir(path.dirname(outPath), {recursive: true});
         await fs.writeFile(outPath, code);
@@ -358,7 +364,6 @@ export async function command(commandOptions: CommandOptions) {
     const proxyFileLoc = proxiedFileLoc.replace('.module.css', '.css.module.js');
     await fs.writeFile(proxyFileLoc, proxyCode, {encoding: 'utf8'});
   }
-
   for (const proxiedFileLoc of allProxiedFiles) {
     const proxiedCode = await fs.readFile(proxiedFileLoc, {encoding: 'utf8'});
     const proxiedExt = path.extname(proxiedFileLoc);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -65,6 +65,11 @@ async function getEsbuildFileBuilder() {
   };
 }
 
+const hmrEnabledExtensions = {
+  css: true,
+  svelte: true,
+}
+
 function getEncodingType(ext: string): 'utf8' | 'binary' {
   if (ext === '.js' || ext === '.css' || ext === '.html') {
     return 'utf8';

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -73,7 +73,7 @@ async function getEsbuildFileBuilder() {
 const hmrEnabledExtensions = {
   css: true,
   svelte: true,
-}
+};
 
 function getEncodingType(ext: string): 'utf8' | 'binary' {
   if (ext === '.js' || ext === '.css' || ext === '.html') {
@@ -360,7 +360,7 @@ export async function command(commandOptions: CommandOptions) {
         return;
       }
 
-      if (reqPath === '/web_modules/@snowpack/hmr.js') {
+      if (reqPath === '/livereload/hmr.js') {
         sendFile(req, res, HMR_DEV_CODE, '.js');
         return;
       }
@@ -485,9 +485,7 @@ export async function command(commandOptions: CommandOptions) {
       let hotCachedResponse: string | Buffer | undefined = inMemoryBuildCache.get(fileLoc);
       if (hotCachedResponse) {
         if (isRoute) {
-          hotCachedResponse =
-            hotCachedResponse.toString() +
-            `<script type="module" src="/web_modules/@snowpack/hmr.js"></script>`;
+          hotCachedResponse = hotCachedResponse.toString();
         }
         if (isProxyModule) {
           responseFileExt = '.js';
@@ -506,7 +504,7 @@ export async function command(commandOptions: CommandOptions) {
             true,
           );
         } else if (responseFileExt === '.js') {
-          hotCachedResponse = await wrapJSModuleResponse(hotCachedResponse.toString());
+          hotCachedResponse = await wrapJSModuleResponse(hotCachedResponse.toString(), true);
         }
         sendFile(req, res, hotCachedResponse, responseFileExt);
         return;
@@ -535,9 +533,7 @@ export async function command(commandOptions: CommandOptions) {
           inMemoryBuildCache.set(fileLoc, coldCachedResponse);
           let serverResponse: Buffer | string = coldCachedResponse;
           if (isRoute) {
-            serverResponse =
-              serverResponse.toString() +
-              `<script type="module" src="/web_modules/@snowpack/hmr.js"></script>`;
+            serverResponse = serverResponse.toString();
           }
           if (isProxyModule) {
             responseFileExt = '.js';
@@ -556,7 +552,7 @@ export async function command(commandOptions: CommandOptions) {
               true,
             );
           } else if (responseFileExt === '.js') {
-            serverResponse = await wrapJSModuleResponse(coldCachedResponse.toString());
+            serverResponse = await wrapJSModuleResponse(coldCachedResponse.toString(), true);
           }
           // Trust... but verify.
           sendFile(req, res, serverResponse, responseFileExt);
@@ -580,7 +576,7 @@ export async function command(commandOptions: CommandOptions) {
               );
             }
             if (checkFinalBuildAnyway && responseFileExt === '.js') {
-              serverResponse = await wrapJSModuleResponse(checkFinalBuildAnyway);
+              serverResponse = await wrapJSModuleResponse(checkFinalBuildAnyway, true);
             }
           } catch (err) {
             // safe to ignore, it will be surfaced later anyway
@@ -617,7 +613,7 @@ export async function command(commandOptions: CommandOptions) {
         {metadata: {originalFileHash}},
       );
       if (isRoute) {
-        finalBuild += `<script type="module" src="/web_modules/@snowpack/hmr.js"></script>`;
+        // finalBuild += `<script type="module" src="/web_modules/@snowpack/hmr.js"></script>`;
       }
       if (isProxyModule) {
         responseFileExt = '.js';
@@ -626,7 +622,7 @@ export async function command(commandOptions: CommandOptions) {
         responseFileExt = '.js';
         finalBuild = await wrapCssModuleResponse(reqPath, finalBuild, requestedFileExt, true);
       } else if (responseFileExt === '.js') {
-        finalBuild = await wrapJSModuleResponse(finalBuild);
+        finalBuild = await wrapJSModuleResponse(finalBuild, true);
       }
       sendFile(req, res, finalBuild, responseFileExt);
     })

--- a/src/commands/paint.ts
+++ b/src/commands/paint.ts
@@ -3,7 +3,7 @@ import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import util from 'util';
 import readline from 'readline';
-import {DevScript} from '../config';
+import {BuildScript} from '../config';
 import {addCommand} from './add-rm';
 
 function getStateString(workerState: any, isWatch: boolean) {
@@ -28,7 +28,7 @@ const WORKER_BASE_STATE = {done: false, error: null, output: ''};
 
 export function paint(
   bus: EventEmitter,
-  registeredWorkers: DevScript[],
+  registeredWorkers: BuildScript[],
   buildMode: {dest: string} | undefined,
   devMode:
     | {

--- a/src/commands/parcel-bundle-plugin.ts
+++ b/src/commands/parcel-bundle-plugin.ts
@@ -1,0 +1,66 @@
+import execa from 'execa';
+import {promises as fs} from 'fs';
+import npmRunPath from 'npm-run-path';
+import path from 'path';
+import rimraf from 'rimraf';
+const {copy} = require('fs-extra');
+const cwd = process.cwd();
+
+export function parcelBundlePlugin(config, args) {
+  return {
+    async bundle({srcDirectory, destDirectory, log, jsFilePaths}) {
+      // Prepare the new build directory by copying over all static assets
+      // This is important since sometimes Parcel doesn't pick these up.
+      await copy(srcDirectory, destDirectory, {
+        filter: (srcLoc) => {
+          return !jsFilePaths.has(srcLoc);
+        },
+      });
+      const tempBuildManifest = JSON.parse(
+        await fs.readFile(path.join(cwd, 'package.json'), {encoding: 'utf-8'}),
+      );
+      delete tempBuildManifest.name;
+      delete tempBuildManifest.babel;
+      tempBuildManifest.devDependencies = tempBuildManifest.devDependencies || {};
+      tempBuildManifest.devDependencies['@babel/core'] =
+        tempBuildManifest.devDependencies['@babel/core'] || '^7.9.0';
+      tempBuildManifest.browserslist =
+        tempBuildManifest.browserslist || '>0.75%, not ie 11, not UCAndroid >0, not OperaMini all';
+      await fs.writeFile(
+        path.join(srcDirectory, 'package.json'),
+        JSON.stringify(tempBuildManifest, null, 2),
+      );
+      await fs.writeFile(
+        path.join(srcDirectory, '.babelrc'),
+        `{"plugins": [[${JSON.stringify(require.resolve('@babel/plugin-syntax-import-meta'))}]]}`, // JSON.stringify is needed because on windows, \ in paths need to be escaped
+      );
+      const fallbackFile = await fs.readFile(path.join(srcDirectory, config.devOptions.fallback), {
+        encoding: 'utf-8',
+      });
+      await fs.writeFile(
+        path.join(srcDirectory, config.devOptions.fallback),
+        fallbackFile.replace(/type\=\"module\"/g, ''),
+      );
+      // Remove PostCSS config since it's no longer needed. Parcel does its own optimization.
+      rimraf.sync(path.join(srcDirectory, 'postcss.config.js'));
+      rimraf.sync(path.join(srcDirectory, '.postcssrc'));
+      rimraf.sync(path.join(srcDirectory, '.postcssrc.js'));
+
+      const parcelOptions = ['build', config.devOptions.fallback, '--out-dir', destDirectory];
+
+      if (config.homepage) {
+        parcelOptions.push('--public-url', config.homepage);
+      }
+
+      const bundleAppPromise = execa('parcel', parcelOptions, {
+        cwd: srcDirectory,
+        env: npmRunPath.env(),
+        extendEnv: true,
+      });
+      bundleAppPromise.stdout?.on('data', (b) => log(b.toString()));
+      bundleAppPromise.stderr?.on('data', (b) => log(b.toString()));
+
+      return bundleAppPromise;
+    },
+  };
+}


### PR DESCRIPTION
/cc @JoviDeCroock, @developit 

This adds an official (documented and semver-compliant for v2.0.0) 3rd-party plugin system for Snowpack. This PR builds on #331 to specifically allow for auto-HMR plugins via Preact's [prefresh](https://github.com/JoviDeCroock/prefresh), React's Fast Reload, and more.

## API

Official documentation is still todo (and this PR definitely still needs some cleanup before merging) but the basic interface is:

```ts
interface SnowpackPlugin {
  // knownEntrypoints - additional web_modules to install in the project
  knownEntrypoints?: string[],
  // defaultBuildScript - a build script to configure for the user automatically
  defaultBuildScript?: string,
  // build() - Build any source file to web-ready JS, CSS, or HTML
  build?: ({
    filePath: string,
    contents: string,
    isDev: boolean,
  }) => Promise<{
    result: string; 
    resouces?: {css?: string}
  }>
  // transform() - Transform JS, CSS, or HTML
  transform?: ({
    urlPath: string,
    contents: string,
    isDev: boolean,
  }) => Promise<{
    result: string
  }>
}

module.exports = (config: SnowpackConfig, args: any) => SnowpackPlugin;
// or: export default (config: SnowpackConfig, args: any) => SnowpackPlugin;
```

```js
/* snowpack.config.json */
{
  "plugins": ["@snowpack/plugin-svelte"]
  // or:  [ ["@snowpack/plugin-svelte", {...args}] ]
  // or:  ["./some/local-path.js"]
}
```


## Example: @prefresh/snowpack

@JoviDeCroock here's a basic Prefresh plugin I built to test the transform method. Feel free to borrow & modify to build an official plugin in your repo:

```js
module.exports = function plugin(config, pluginOptions) {
  return {
    knownEntrypoints: ['@prefresh/core'],
    async transform({ contents, urlPath, isDev }) {
      if (!isDev) {
        return;
      }
      if (!urlPath.endsWith('.js')) {
        return;
      }
      return {
        result: `
          import '@prefresh/core';
          import * as $OriginalModule$ from ${JSON.stringify(urlPath)};
          let $CurrentModule$ = $OriginalModule$;
          ${contents}

          if (import.meta.hot) {
            import.meta.hot.accept(({module}) => {
              for (let i in module) {
                self.__PREFRESH__.replaceComponent($CurrentModule$[i], module[i]);
              }
              $CurrentModule$ = module;
            });
          }`,
      };
    },
  };
};

```

