### PR TITLE
Add option to generate source maps for project files

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -117,7 +117,7 @@ export async function command(commandOptions: CommandOptions) {
   console.log('NOTE: Still experimental, default behavior may change.');
   console.log('Starting up...\n');
 
-  const {port} = config.devOptions;
+  const {port, sourceMap} = config.devOptions;
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
   const filesBeingDeleted = new Set<string>();
@@ -158,7 +158,9 @@ export async function command(commandOptions: CommandOptions) {
   ): Promise<SnowpackPluginBuildResult> {
     if (!fileBuilder) {
       if (fileLoc.endsWith('.jsx') || fileLoc.endsWith('.tsx') || fileLoc.endsWith('.ts')) {
-        fileBuilder = await getEsbuildFileBuilder();
+        fileBuilder = await getEsbuildFileBuilder(
+          config.devOptions.sourceMap ? {sourceMap: 'inline'} : undefined,
+        );
       }
     }
     let builtFileResult: SnowpackPluginBuildResult;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,10 @@ type DeepPartial<T> = {
 
 export type EnvVarReplacements = Record<string, string | number | true>;
 
+export type SnowpackESBuildOptions = {
+  sourceMap: 'inline' | 'external';
+};
+
 export type SnowpackPluginBuildArgs = {
   contents: string;
   filePath: string;
@@ -31,6 +35,7 @@ export type SnowpackPluginTransformArgs = {
 };
 export type SnowpackPluginBuildResult = {
   result: string;
+  sourceMap?: string;
   resources?: {css?: string};
 };
 export type SnowpackPluginTransformResult = {
@@ -77,6 +82,7 @@ export interface SnowpackConfig {
     out: string;
     fallback: string;
     bundle: boolean | undefined;
+    sourceMap?: boolean;
   };
   installOptions: {
     dest: string;
@@ -147,6 +153,7 @@ const configSchema = {
         out: {type: 'string'},
         fallback: {type: 'string'},
         bundle: {type: 'boolean'},
+        sourceMap: {type: 'boolean'},
       },
     },
     installOptions: {


### PR DESCRIPTION
This PR introduces a new boolean "`sourceMap`" configuration option under `devOptions`. Unlike the `sourceMaps` option under `installOptions`, which controls source map generation for dependencies, this new option controls source map generation for **project files**, when the build pipeline is using the default [esbuild](https://github.com/evanw/esbuild). I was not able to find an existing way to enable project file source map generation without introducing my own build script to transform files using Babel.

Changes:
- Modified the `getEsbuildFileBuilder` function in `build-util.ts` to accept an `options` object parameter. Currently, the only property in this object is the optional `sourceMap`, whose value can be either "`inline`" or "`external`". This is passed through as the "`sourcemap`" option to the esbuild service's `transform` call, which tells esbuild to generate a source map for the file being tranformed.
- In `dev.ts`, modified the `buildFile` function to pass `{ sourceMap: 'inline' }` to `getEsbuildFileBuilder` so that the builder returned will return transformed files with inline source maps. This only occurs if the `sourceMap` option under `config.devOptions` is `true`.
- In `build.ts`, modified the `buildFile` function to pass `{ sourceMap: 'external' }` to `getEsbuildFileBuilder` so that the builder's return includes an additional `sourceMap` property with the external source map as a string. Also, the source map string is written to disk under `<file name.js>.map`, and the file itself is appended a source map URL reference comment before being written to disk itself. This also only occurs if the `sourceMap` option under `config.devOptions` is `true`.