### PR TITLE
Allow HMR to bubble up the tree

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -112,7 +112,11 @@ export async function command(commandOptions: CommandOptions) {
   console.log('Starting up...\n');
 
   const {port} = config.devOptions;
+<<<<<<< HEAD
   const hmrEngine = new EsmHmrEngine();
+=======
+  const tree = new Map<string, Set<string>>();
+>>>>>>> cosntruct a dependency tree
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
   const filesBeingDeleted = new Set<string>();
@@ -182,7 +186,19 @@ export async function command(commandOptions: CommandOptions) {
         if (spec.startsWith('http')) {
           return spec;
         }
+
         if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
+          if (!spec.includes('web_modules') && !spec.includes('node_modules') && !fileLoc.includes('web_modules') && !fileLoc.includes('node_modules')) {
+            const dependencies = tree.get(spec);
+            if (dependencies) {
+              tree.set(spec, dependencies.add(fileLoc));
+            } else {
+              tree.set(spec, new Set([fileLoc]))
+            }
+
+            console.log(tree);
+          }
+
           const ext = path.extname(spec).substr(1);
           if (!ext) {
             return spec + '.js';
@@ -194,6 +210,7 @@ export async function command(commandOptions: CommandOptions) {
           if (!spec.endsWith('.module.css') && (extToReplace || ext) !== 'js') {
             spec = spec + '.proxy.js';
           }
+
           return spec;
         }
         if (dependencyImportMap.imports[spec]) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -565,7 +565,7 @@ export async function command(commandOptions: CommandOptions) {
           const [, mtime] = reqUrl.split('?');
 
           // Transform when it's a buffer!
-          if (hotCachedResponse.toString) hotCachedResponse = hotCachedResponse.toString();
+          if (Buffer.isBuffer(hotCachedResponse)) hotCachedResponse = hotCachedResponse.toString();
 
           hotCachedResponse = await transformEsmImports(hotCachedResponse as string, (imp) => {
             const spec = path.posix.resolve(path.posix.dirname(reqPath), imp);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -687,7 +687,6 @@ export async function command(commandOptions: CommandOptions) {
       node.dependents.forEach(updateOrBubble);
     } else {
       // We've reached the top, trigger a full page refresh
-      // TODO: does this belong on the hmrEngine?
       hmrEngine.broadcastMessage('message', {type: 'reload'});
     }
   }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -113,10 +113,14 @@ export async function command(commandOptions: CommandOptions) {
 
   const {port} = config.devOptions;
 <<<<<<< HEAD
+<<<<<<< HEAD
   const hmrEngine = new EsmHmrEngine();
 =======
   const tree = new Map<string, Set<string>>();
 >>>>>>> cosntruct a dependency tree
+=======
+  const dependentsTree = new Map<string, Set<string>>();
+>>>>>>> cleanup
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
   const filesBeingDeleted = new Set<string>();
@@ -189,11 +193,11 @@ export async function command(commandOptions: CommandOptions) {
 
         if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
           if (!spec.includes('web_modules') && !spec.includes('node_modules') && !fileLoc.includes('web_modules') && !fileLoc.includes('node_modules')) {
-            const dependencies = tree.get(spec);
-            if (dependencies) {
-              tree.set(spec, dependencies.add(fileLoc));
+            const dependents = dependentsTree.get(spec);
+            if (dependents) {
+              dependentsTree.set(spec, dependents.add(fileLoc));
             } else {
-              tree.set(spec, new Set([fileLoc]))
+              dependentsTree.set(spec, new Set([fileLoc]))
             }
 
             console.log(tree);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -152,7 +152,7 @@ export async function command(commandOptions: CommandOptions) {
     if (!isModule(spec) && !isModule(fileUrl) && spec !== fileUrl) {
       let specResult = dependencyTree.get(spec);
       if (!specResult) {
-        specResult = { dependencies: new Set(), dependents: new Set() };
+        specResult = {dependencies: new Set(), dependents: new Set()};
         dependencyTree.set(spec, specResult);
       }
       specResult.dependents.add(fileUrl);
@@ -269,7 +269,7 @@ export async function command(commandOptions: CommandOptions) {
       if (!isModule(fileLoc)) {
         let result = dependencyTree.get(reqPath);
         if (!result) {
-          result = { dependencies: new Set(), dependents: new Set() };
+          result = {dependencies: new Set(), dependents: new Set()};
           dependencyTree.set(reqPath, result);
         }
 
@@ -285,13 +285,13 @@ export async function command(commandOptions: CommandOptions) {
         }
 
         if (existingDependencies.size > 0) {
-          existingDependencies.forEach(spec => {
+          existingDependencies.forEach((spec) => {
             (result as Dependency).dependencies.delete(spec);
             const specTree = dependencyTree.get(spec);
             if (specTree) {
               specTree.dependents.delete(reqPath);
             }
-          })
+          });
         }
 
         if (builtFileResult.result.includes('import.meta.hot')) {
@@ -562,7 +562,7 @@ export async function command(commandOptions: CommandOptions) {
       if (hotCachedResponse) {
         const isHot = reqUrl.includes('?mtime=');
         if (isHot) {
-          const [,mtime] = reqUrl.split('?');
+          const [, mtime] = reqUrl.split('?');
 
           // Transform when it's a buffer!
           if (hotCachedResponse.toString) hotCachedResponse = hotCachedResponse.toString();
@@ -572,7 +572,7 @@ export async function command(commandOptions: CommandOptions) {
             const result = dependencyTree.get(spec);
             if (result && result.needsUpdate) {
               result.needsUpdate = false;
-              return `${imp}?${mtime}`
+              return `${imp}?${mtime}`;
             }
             return imp;
           });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -112,15 +112,8 @@ export async function command(commandOptions: CommandOptions) {
   console.log('Starting up...\n');
 
   const {port} = config.devOptions;
-<<<<<<< HEAD
-<<<<<<< HEAD
   const hmrEngine = new EsmHmrEngine();
-=======
-  const tree = new Map<string, Set<string>>();
->>>>>>> cosntruct a dependency tree
-=======
   const dependentsTree = new Map<string, Set<string>>();
->>>>>>> cleanup
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
   const filesBeingDeleted = new Set<string>();
@@ -199,8 +192,6 @@ export async function command(commandOptions: CommandOptions) {
             } else {
               dependentsTree.set(spec, new Set([fileLoc]))
             }
-
-            console.log(tree);
           }
 
           const ext = path.extname(spec).substr(1);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -59,6 +59,7 @@ interface Dependency {
   dependents: Set<string>;
   dependencies: Set<string>;
   isHmrEnabled?: boolean;
+  needsUpdate?: boolean;
 }
 
 const HMR_DEV_CODE = readFileSync(path.join(__dirname, '../assets/hmr.js'));
@@ -664,6 +665,7 @@ export async function command(commandOptions: CommandOptions) {
     if (node && node.isHmrEnabled) {
       hmrEngine.broadcastMessage('message', {type: 'update', url});
     } else if (node && node.dependents.size > 0) {
+      node.needsUpdate = true;
       node.dependents.forEach(updateOrBubble);
     } else {
       // We've reached the top, trigger a full page refresh


### PR DESCRIPTION
This is an initial proof of concept that constructs the tree and sends down the dependents to the messagebus.

## Current structure

```
Map {
    './App.js' => {
      dependencies: Set {},
      dependents: Set { '/_dist_/index.js' },
      isHmrEnabled: true
    },
    '/_dist_/index.js' => {
      dependencies: Set { './App.js', './index.css.proxy.js' },
      dependents: Set {},
      isHmrEnabled: true
    },
    './index.css.proxy.js' => {
      dependencies: Set {},
      dependents: Set { '/_dist_/index.js' },
      isHmrEnabled: true
    },
    './App.css.proxy.js' => {
      dependencies: Set {},
      dependents: Set { '/_dist_/App.js' },
      isHmrEnabled: true
    },
    '/_dist_/App.js' => {
      dependencies: Set { './App.css.proxy.js', './useCounter.js' },
      dependents: Set {},
      isHmrEnabled: true
    },
    './useCounter.js' => {
      dependencies: Set {},
      dependents: Set { '/_dist_/App.js' },
      isHmrEnabled: true
    }
  }
```