### PR TITLE
Open browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,11 +2661,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -5224,17 +5219,6 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      }
-    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -5412,7 +5396,8 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -6213,8 +6198,7 @@
     "is-docker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
-      "dev": true
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
     },
     "is-expression": {
       "version": "3.0.0",
@@ -7782,15 +7766,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "jsonfile": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^1.0.0"
       }
     },
     "jsonschema": {
@@ -9884,7 +9859,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
       "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
-      "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -9894,7 +9868,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-          "dev": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -13181,11 +13154,6 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
-    },
-    "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "jsonschema": "^1.2.5",
     "mime-types": "^2.1.26",
     "mkdirp": "^1.0.3",
+    "open": "^7.0.4",
     "ora": "^4.0.4",
     "p-queue": "^6.2.1",
     "resolve-from": "^5.0.0",

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -699,6 +699,6 @@ export async function command(commandOptions: CommandOptions) {
     },
   });
 
-  if (open) await openInBrowser(port);
+  if (open !== 'none') await openInBrowser(port, open);
   return new Promise(() => {});
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,7 +86,7 @@ export interface SnowpackConfig {
     port: number;
     out: string;
     fallback: string;
-    open: boolean;
+    open: string;
     bundle: boolean | undefined;
   };
   installOptions: {
@@ -131,7 +131,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
   },
   devOptions: {
     port: 8080,
-    open: true,
+    open: 'default',
     out: 'build',
     fallback: 'index.html',
     bundle: undefined,
@@ -160,7 +160,7 @@ const configSchema = {
         out: {type: 'string'},
         fallback: {type: 'string'},
         bundle: {type: 'boolean'},
-        open: {type: 'boolean'},
+        open: {type: 'string'},
       },
     },
     installOptions: {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import execa from 'execa';
 import open from 'open';
-import got, { CancelableRequest, Response } from 'got';
+import got, {CancelableRequest, Response} from 'got';
 import cachedir from 'cachedir';
-import { SnowpackConfig } from './config';
+import {SnowpackConfig} from './config';
 
 export const PIKA_CDN = `https://cdn.pika.dev`;
 export const CACHE_DIR = cachedir('snowpack');
@@ -12,7 +12,7 @@ export const RESOURCE_CACHE = path.join(CACHE_DIR, 'pkg-cache-1.4');
 export const BUILD_CACHE = path.join(CACHE_DIR, 'build-cache-1.4');
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 export interface ImportMap {
-  imports: { [packageName: string]: string };
+  imports: {[packageName: string]: string};
 }
 
 export interface CommandOptions {
@@ -36,11 +36,11 @@ export async function readLockfile(cwd: string): Promise<ImportMap | null> {
 }
 
 export async function writeLockfile(loc: string, importMap: ImportMap): Promise<void> {
-  const sortedImportMap: ImportMap = { imports: {} };
+  const sortedImportMap: ImportMap = {imports: {}};
   for (const key of Object.keys(importMap.imports).sort()) {
     sortedImportMap.imports[key] = importMap.imports[key];
   }
-  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), { encoding: 'utf8' });
+  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), {encoding: 'utf8'});
 }
 
 export function fetchCDNResource(
@@ -53,7 +53,7 @@ export function fetchCDNResource(
   // @ts-ignore - TS doesn't like responseType being unknown amount three options
   return got(resourceUrl, {
     responseType: responseType,
-    headers: { 'user-agent': `snowpack/v1.4 (https://snowpack.dev)` },
+    headers: {'user-agent': `snowpack/v1.4 (https://snowpack.dev)`},
     throwHttpErrors: false,
   });
 }
@@ -76,7 +76,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
   // include a package.json. If we detect that to be the reason for failure,
   // move on to our custom implementation.
   try {
-    const depManifest = require.resolve(`${dep}/package.json`, { paths: [cwd] });
+    const depManifest = require.resolve(`${dep}/package.json`, {paths: [cwd]});
     return [depManifest, require(depManifest)];
   } catch (err) {
     // if its an export map issue, move on to our manual resolver.
@@ -92,7 +92,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
   // established & move out of experimental mode.
   let result = [null, null] as [string | null, any | null];
   try {
-    const fullPath = require.resolve(dep, { paths: [cwd] });
+    const fullPath = require.resolve(dep, {paths: [cwd]});
     // Strip everything after the package name to get the package root path
     // NOTE: This find-replace is very gross, replace with something like upath.
     const searchPath = `${path.sep}node_modules${path.sep}${dep.replace('/', path.sep)}`;
@@ -101,7 +101,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
       const manifestPath =
         fullPath.substring(0, indexOfSearch + searchPath.length + 1) + 'package.json';
       result[0] = manifestPath;
-      const manifestStr = fs.readFileSync(manifestPath, { encoding: 'utf8' });
+      const manifestStr = fs.readFileSync(manifestPath, {encoding: 'utf8'});
       result[1] = JSON.parse(manifestStr);
     }
   } catch (err) {
@@ -115,7 +115,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
  * If Rollup erred parsing a particular file, show suggestions based on its
  * file extension (note: lowercase is fine).
  */
-export const MISSING_PLUGIN_SUGGESTIONS: { [ext: string]: string } = {
+export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.svelte':
     'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
   '.vue':
@@ -124,27 +124,27 @@ export const MISSING_PLUGIN_SUGGESTIONS: { [ext: string]: string } = {
 
 const appNames = {
   win32: {
-    brave: "brave",
-    chrome: "chrome"
+    brave: 'brave',
+    chrome: 'chrome',
   },
   darwin: {
-    brave: "Brave Browser",
-    chrome: "Google Chrome"
+    brave: 'Brave Browser',
+    chrome: 'Google Chrome',
   },
   linux: {
-    brave: "brave",
-    chrome: "google-chrome"
-  }
-}
+    brave: 'brave',
+    chrome: 'google-chrome',
+  },
+};
 
 export async function openInBrowser(port: number, browser: string) {
   const url = `http://localhost:${port}`;
   browser = /chrome/i.test(browser)
-    ? appNames[process.platform]["chrome"]
+    ? appNames[process.platform]['chrome']
     : /brave/i.test(browser)
-      ? appNames[process.platform]["brave"]
-      : browser;
-  if (process.platform === 'darwin' && /chrome|default/.test(browser)) {
+    ? appNames[process.platform]['brave']
+    : browser;
+  if (process.platform === 'darwin' && /chrome|default/i.test(browser)) {
     // If we're on macOS, and we haven't requested a specific browser,
     // we can try opening Chrome with AppleScript. This lets us reuse an
     // existing tab when possible instead of creating a new one.
@@ -163,6 +163,6 @@ export async function openInBrowser(port: number, browser: string) {
       open(url);
     }
   } else {
-    browser === 'default' ? open(url) : open(url, { app: browser });
+    browser === 'default' ? open(url) : open(url, {app: browser});
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import execa from 'execa';
 import open from 'open';
-import got, {CancelableRequest, Response} from 'got';
+import got, { CancelableRequest, Response } from 'got';
 import cachedir from 'cachedir';
-import {SnowpackConfig} from './config';
+import { SnowpackConfig } from './config';
 
 export const PIKA_CDN = `https://cdn.pika.dev`;
 export const CACHE_DIR = cachedir('snowpack');
@@ -12,7 +12,7 @@ export const RESOURCE_CACHE = path.join(CACHE_DIR, 'pkg-cache-1.4');
 export const BUILD_CACHE = path.join(CACHE_DIR, 'build-cache-1.4');
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 export interface ImportMap {
-  imports: {[packageName: string]: string};
+  imports: { [packageName: string]: string };
 }
 
 export interface CommandOptions {
@@ -36,11 +36,11 @@ export async function readLockfile(cwd: string): Promise<ImportMap | null> {
 }
 
 export async function writeLockfile(loc: string, importMap: ImportMap): Promise<void> {
-  const sortedImportMap: ImportMap = {imports: {}};
+  const sortedImportMap: ImportMap = { imports: {} };
   for (const key of Object.keys(importMap.imports).sort()) {
     sortedImportMap.imports[key] = importMap.imports[key];
   }
-  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), {encoding: 'utf8'});
+  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), { encoding: 'utf8' });
 }
 
 export function fetchCDNResource(
@@ -53,7 +53,7 @@ export function fetchCDNResource(
   // @ts-ignore - TS doesn't like responseType being unknown amount three options
   return got(resourceUrl, {
     responseType: responseType,
-    headers: {'user-agent': `snowpack/v1.4 (https://snowpack.dev)`},
+    headers: { 'user-agent': `snowpack/v1.4 (https://snowpack.dev)` },
     throwHttpErrors: false,
   });
 }
@@ -76,7 +76,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
   // include a package.json. If we detect that to be the reason for failure,
   // move on to our custom implementation.
   try {
-    const depManifest = require.resolve(`${dep}/package.json`, {paths: [cwd]});
+    const depManifest = require.resolve(`${dep}/package.json`, { paths: [cwd] });
     return [depManifest, require(depManifest)];
   } catch (err) {
     // if its an export map issue, move on to our manual resolver.
@@ -92,7 +92,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
   // established & move out of experimental mode.
   let result = [null, null] as [string | null, any | null];
   try {
-    const fullPath = require.resolve(dep, {paths: [cwd]});
+    const fullPath = require.resolve(dep, { paths: [cwd] });
     // Strip everything after the package name to get the package root path
     // NOTE: This find-replace is very gross, replace with something like upath.
     const searchPath = `${path.sep}node_modules${path.sep}${dep.replace('/', path.sep)}`;
@@ -101,7 +101,7 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
       const manifestPath =
         fullPath.substring(0, indexOfSearch + searchPath.length + 1) + 'package.json';
       result[0] = manifestPath;
-      const manifestStr = fs.readFileSync(manifestPath, {encoding: 'utf8'});
+      const manifestStr = fs.readFileSync(manifestPath, { encoding: 'utf8' });
       result[1] = JSON.parse(manifestStr);
     }
   } catch (err) {
@@ -115,30 +115,35 @@ export function resolveDependencyManifest(dep: string, cwd: string) {
  * If Rollup erred parsing a particular file, show suggestions based on its
  * file extension (note: lowercase is fine).
  */
-export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
+export const MISSING_PLUGIN_SUGGESTIONS: { [ext: string]: string } = {
   '.svelte':
     'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
   '.vue':
     'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
 };
-function getChromeName() {
-  switch (process.platform) {
-    case 'darwin':
-      return 'google chrome';
-    case 'win32':
-      return 'chrome';
-    default:
-      return 'google-chrome';
+
+const appNames = {
+  win32: {
+    brave: "brave",
+    chrome: "chrome"
+  },
+  darwin: {
+    brave: "Brave Browser",
+    chrome: "Google Chrome"
+  },
+  linux: {
+    brave: "brave",
+    chrome: "google-chrome"
   }
 }
 
 export async function openInBrowser(port: number, browser: string) {
   const url = `http://localhost:${port}`;
   browser = /chrome/i.test(browser)
-    ? getChromeName()
+    ? appNames[process.platform]["chrome"]
     : /brave/i.test(browser)
-    ? 'Brave Browser'
-    : browser;
+      ? appNames[process.platform]["brave"]
+      : browser;
   if (process.platform === 'darwin' && /chrome|default/.test(browser)) {
     // If we're on macOS, and we haven't requested a specific browser,
     // we can try opening Chrome with AppleScript. This lets us reuse an
@@ -158,6 +163,6 @@ export async function openInBrowser(port: number, browser: string) {
       open(url);
     }
   } else {
-    browser === 'default' ? open(url) : open(url, {app: browser});
+    browser === 'default' ? open(url) : open(url, { app: browser });
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import execa from 'execa';
+import open from 'open';
 import got, {CancelableRequest, Response} from 'got';
 import cachedir from 'cachedir';
 import {SnowpackConfig} from './config';
@@ -120,14 +121,27 @@ export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
   '.vue':
     'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
 };
+function getChromeName() {
+  switch (process.platform) {
+    case 'darwin':
+      return 'google chrome';
+    case 'win32':
+      return 'chrome';
+    default:
+      return 'google-chrome';
+  }
+}
 
-export async function openInBrowser(port) {
+export async function openInBrowser(port: number, browser: string) {
   const url = `http://localhost:${port}`;
-  const args = [url];
-  let openCmd = 'xdg-open';
-  if (process.platform === 'darwin') {
-    // If we're on OS X, we can try opening
-    // Chrome with AppleScript. This lets us reuse an
+  browser = /chrome/i.test(browser)
+    ? getChromeName()
+    : /brave/i.test(browser)
+    ? 'Brave Browser'
+    : browser;
+  if (process.platform === 'darwin' && /chrome|default/.test(browser)) {
+    // If we're on macOS, and we haven't requested a specific browser,
+    // we can try opening Chrome with AppleScript. This lets us reuse an
     // existing tab when possible instead of creating a new one.
     try {
       await execa.command('ps cax | grep "Google Chrome"', {
@@ -140,15 +154,10 @@ export async function openInBrowser(port) {
       });
       return true;
     } catch (err) {
-      // If OSX auto-reuse doesn't work, just open normally.
-      openCmd = 'open';
+      // If macOS auto-reuse doesn't work, just open normally, using default browser.
+      open(url);
     }
+  } else {
+    browser === 'default' ? open(url) : open(url, {app: browser});
   }
-  if (process.platform === 'win32') {
-    openCmd = 'start';
-    args.unshift('');
-  }
-  execa(openCmd, args).catch(() => {
-    // couldn't open automatically, safe to ignore
-  });
 }


### PR DESCRIPTION
I have added a new feature behind the open flag to allow for the browser to be specified. This PR also fixes an issue that occurred when using snowpack from within Cmder, a popular console emulator for Windows.

Open default will open the default browser. This is also the default setting used if --open is excluded from the cli.

--open default

To open the dev server with any installed browser, just add the name of the browser.
e.g.
--open chrome
--open firefox
--open brave

To prevent the browser from being launched, specify none. That matches the browser setting for CRA.

--open none

The utils.ts file has an appNames object that maps Chrome and Brave to the respective browser names for the platform being used. I don't have Linux installed to test, but I'm using the names that are recommended in an issue on the Open library's repo.

The issue on Open's repo that I'm referring to is regarding automatically doing that mapping within the library in the future, so at some point this mapping object will no longer be needed.

https://github.com/sindresorhus/open/issues/177

