### PR TITLE
Fully managed dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3819,6 +3819,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -5131,6 +5136,31 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -10426,7 +10456,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       },
@@ -10435,7 +10464,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -10445,7 +10473,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -10454,7 +10481,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -10463,7 +10489,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -10471,8 +10496,7 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "esbuild": "^0.3.0",
     "etag": "^1.8.1",
     "execa": "^4.0.0",
+    "find-cache-dir": "^3.3.1",
     "glob": "^7.1.4",
     "got": "^11.1.4",
     "is-builtin-module": "^3.0.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,13 +3,19 @@ import path from 'path';
 import execa from 'execa';
 import open from 'open';
 import got, {CancelableRequest, Response} from 'got';
-import cachedir from 'cachedir';
+import globalCacheDir from 'cachedir';
+import projectCacheDir from 'find-cache-dir';
 import {SnowpackConfig} from './config';
 
 export const PIKA_CDN = `https://cdn.pika.dev`;
-export const CACHE_DIR = cachedir('snowpack');
-export const RESOURCE_CACHE = path.join(CACHE_DIR, 'pkg-cache-1.4');
-export const BUILD_CACHE = path.join(CACHE_DIR, 'build-cache-1.4');
+export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
+export const RESOURCE_CACHE = path.join(GLOBAL_CACHE_DIR, 'pkg-cache-1.4');
+export const BUILD_CACHE = path.join(GLOBAL_CACHE_DIR, 'build-cache-1.4');
+
+export const PROJECT_CACHE_DIR = projectCacheDir({name: 'snowpack'});
+export const DEV_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, 'dev');
+export const BUILD_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, 'build');
+
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 export interface ImportMap {
   imports: {[packageName: string]: string};


### PR DESCRIPTION
This is the final piece of transition from Snowpack v1 -> Snowpack v2: our dev & build workflows will manage your web_modules for you, internally, so that you never need to call `install` or see a `web_modules` directory if you don't want to.

This is done as both a UX improvement and a technical requirement to support more advanced dependency use-cases, specifically React Fast Refresh. 

```diff
- snowpack install --env NODE_ENV=development
snowpack dev

- snowpack install --env NODE_ENV=production
snowpack build
```

Our installer can only support one NODE_ENV value at a time, which caused ambiguity between dev & prod dependency behavior. We kicked this can down the road by just always installing the prod versions of your dependencies, but as a result some dev workflows weren't supported (React Refresh).

Now, we manage both sets of dependencies for you. Your dev dependencies are cached across sessions, so you still get that super-fast, <50ms start time after your first install. Your builds get the production dependencies. 

Whenever you add a new dependency, we'll rerun your install for you automatically so that there's no `prepare` scripts or additional `install` commands for you to manage.

/cc @jayphelps

<img width="943" alt="Screen Shot 2020-05-21 at 12 47 01 PM" src="https://user-images.githubusercontent.com/622227/82599732-a32d2800-9b61-11ea-8899-536ff474048f.png">
