### PR TITLE
Fixed proxy impl when translating --to url to proxified url

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -364,7 +364,7 @@ export async function command(commandOptions: CommandOptions) {
           continue;
         }
         if (reqPath.startsWith(workerConfig.args.toUrl)) {
-          const newPath = reqPath.substr(workerConfig.args.toUrl);
+          const newPath = reqPath.substr(workerConfig.args.toUrl.length);
           try {
             const response = await got(`${workerConfig.args.fromUrl}${newPath}`, {
               headers: req.headers,


### PR DESCRIPTION
Proxy url translation doesn't work since commit 541e5da35c65fdf55fec5ffd62a0379ae9b8d7d7 (`2.0.0-beta.22`) due to `.length` removed

See https://github.com/pikapkg/snowpack/commit/541e5da35c65fdf55fec5ffd62a0379ae9b8d7d7#diff-d577271f764f63004633a4aa7a30aa26R362