### PR TITLE
Fix Reload Issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export async function cli(args: string[]) {
   if (cliFlags.reload) {
     console.log(`${chalk.yellow('ℹ')} clearing CDN cache...`);
     await clearCache();
+    process.exit(0);
   }
 
   // Load the current package manifest


### PR DESCRIPTION
When using the --reload flag, there is an error 'Unknown CLI flag: "reload"'. When reviewing the source, I noticed that process.exit was missing from that cli flag.