### PR TITLE
Add ejs output extension mapping

### DIFF
--- a/src/commands/src-file-extension-mapping.ts
+++ b/src/commands/src-file-extension-mapping.ts
@@ -6,4 +6,5 @@ export default {
   svelte: 'js',
   php: 'html',
   md: 'html',
+  ejs: 'html',
 };

--- a/src/commands/src-file-extension-mapping.ts
+++ b/src/commands/src-file-extension-mapping.ts
@@ -7,4 +7,5 @@ export default {
   php: 'html',
   md: 'html',
   ejs: 'html',
+  njk: 'html',
 };


### PR DESCRIPTION
This adds the mapping between `.ejs` -> `.html`.

Actually compiling ejs templates into html will require the following hacky build script:

```
{
  "scripts": {
    "build:ejs": "cat &> /dev/null && ejs $FILE"
  }
}
```

or a build plugin.


<details>
<summary>Why the hacky build script?</summary>
The ejs CLI expects the STDIN to stream template variable data in JSON format.
Because snowpack sends the source (template) file instead, the ejs CLI will crash trying to parse the template as JSON.

The hacky unix-only fix is to simply redirect all STDIN input into `/dev/null` and then execute the ejs CLI.
</details>
