### PR TITLE
Fix: index file not loading

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -423,7 +423,7 @@ export async function command(commandOptions: CommandOptions) {
             return [await attemptLoadFile(requestedFile), null];
           }
 
-          if (requestedFileExt) {
+          if (requestedFileExt !== '.html') {
             for (const workerConfig of config.scripts) {
               const {type, match} = workerConfig;
               if (type !== 'build') {


### PR DESCRIPTION
Index file is not loading when we access URL like `https://localhost:8080/`