### PR TITLE
Enable the dev server to proxy requests with methods other than GET

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -31,7 +31,7 @@ import etag from 'etag';
 import {EventEmitter} from 'events';
 import execa from 'execa';
 import {existsSync, promises as fs, readFileSync} from 'fs';
-import got from 'got';
+import got, { Method as RequestMethod } from 'got';
 import http from 'http';
 import mime from 'mime-types';
 import npmRunPath from 'npm-run-path';
@@ -371,8 +371,7 @@ export async function command(commandOptions: CommandOptions) {
           const newPath = reqPath.substr(workerConfig.args.toUrl.length);
           try {
             const response = await got(`${workerConfig.args.fromUrl}${newPath}`, {
-              // @ts-ignore - TS doesn't like method being a generic string
-              method: req.method,
+              method: req.method as RequestMethod,
               headers: req.headers,
               throwHttpErrors: false,
             });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -371,6 +371,8 @@ export async function command(commandOptions: CommandOptions) {
           const newPath = reqPath.substr(workerConfig.args.toUrl.length);
           try {
             const response = await got(`${workerConfig.args.fromUrl}${newPath}`, {
+              // @ts-ignore - TS doesn't like method being a generic string
+              method: req.method,
               headers: req.headers,
               throwHttpErrors: false,
             });


### PR DESCRIPTION
Currently all proxied requests are passed through as GET since no method is specified. This commit updates the proxied call to pass through the method that the initial request was made with.