### PR TITLE
Run HMR WebSocket and HTTP server on same port / Call disposeCallback AFTER loading new modules

### DIFF
--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -19,7 +19,9 @@ function sendSocketMessage(msg) {
     _sendSocketMessage(msg);
   }
 }
-const socketURL = window.HMR_WEBSOCKET_URL || 'ws://localhost:12321/';
+const socketURL =
+  window.HMR_WEBSOCKET_URL ||
+  (location.protocol === 'http:' ? 'ws://' : 'wss://') + location.host + '/';
 const socket = new WebSocket(socketURL);
 socket.addEventListener('open', () => {
   SOCKET_MESSAGE_QUEUE.forEach(_sendSocketMessage);

--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -103,13 +103,13 @@ async function applyUpdate(id) {
   const disposeCallbacks = state.disposeCallbacks;
   state.disposeCallbacks = [];
   state.data = {};
-  disposeCallbacks.map((callback) => callback());
   const updateID = Date.now();
   for (const {deps, callback: acceptCallback} of acceptCallbacks) {
     const [module, ...depModules] = await Promise.all([
       import(id + `?mtime=${updateID}`),
       ...deps.map((d) => import(d + `?mtime=${updateID}`)),
     ]);
+    disposeCallbacks.map((callback) => callback());
     acceptCallback({module, deps: depModules});
   }
   return true;

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -120,7 +120,6 @@ export async function command(commandOptions: CommandOptions) {
 
   const {port, open} = config.devOptions;
 
-  const hmrEngine = new EsmHmrEngine();
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
   const filesBeingDeleted = new Set<string>();
@@ -325,7 +324,7 @@ export async function command(commandOptions: CommandOptions) {
     }
   }
 
-  http
+  const server = http
     .createServer(async (req, res) => {
       const reqUrl = req.url!;
       let reqPath = decodeURI(url.parse(reqUrl).pathname!);
@@ -664,6 +663,8 @@ export async function command(commandOptions: CommandOptions) {
       sendFile(req, res, wrappedResponse, responseFileExt);
     })
     .listen(port);
+
+  const hmrEngine = new EsmHmrEngine(server);
 
   // Live Reload + File System Watching
   let isLiveReloadPaused = false;


### PR DESCRIPTION
**Run HMR WebSocket and HTTP server on same port.** 
- It now becomes possible to use tools like ngrok to tunnel localhost online with the HMR still working. (This is the main reason for this PR)
- No more hardcoded `12321` port for WebSocket server.
- One less port used by snowpack.

**Call disposeCallback AFTER loading new modules**
I've changed the order when `disposeCallbacks` is called in the `hmr.js` file. This fixes a weird screen flash when the latency is more (like when tunneling localhost over ngrok) when changing CSS files. It's better to load new styles before removing old ones to prevent flashy screens (that happens because of no CSS on page)