### PR TITLE
add proxy support

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -380,6 +380,8 @@ export async function command(commandOptions: CommandOptions) {
           proxy.web(req, res, { 
             target: `${workerConfig.args.fromUrl}${newPath}`,
             ignorePath: true,
+            secure: false,
+            changeOrigin: true
           });
           return;
         }


### PR DESCRIPTION
- ran prettier
- proxy: remove secure option to enable ssl
- add changeOrigin true to make proxy work
- making http-proxy import conditionnal depending on if a 'proxy' workerConfig exists or not
- Add support for websockets in proxy build script
- fixes #371
