### PR TITLE
Support import module from directory

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -1,19 +1,25 @@
+import Core from 'css-modules-loader-core';
+import type {EventEmitter} from 'events';
 import execa from 'execa';
 import path from 'path';
+import {statSync} from 'fs';
 import npmRunPath from 'npm-run-path';
-import type {EventEmitter} from 'events';
-import {
-  SnowpackConfig,
-  BuildScript,
-  SnowpackPluginBuildResult,
-  SnowpackPluginBuildArgs,
-} from '../config';
-import Core from 'css-modules-loader-core';
-import chalk from 'chalk';
+import {BuildScript, SnowpackPluginBuildArgs, SnowpackPluginBuildResult} from '../config';
 
 const IS_PREACT = /from\s+['"]preact['"]/;
 export function checkIsPreact(filePath: string, contents: string) {
   return filePath.endsWith('.jsx') && IS_PREACT.test(contents);
+}
+
+export function isDirectoryImport(fileLoc: string, spec: string): boolean {
+  const importedFileOnDisk = path.resolve(path.dirname(fileLoc), spec);
+  try {
+    const stat = statSync(importedFileOnDisk);
+    return stat.isDirectory();
+  } catch (err) {
+    // file doesn't exist, that's fine
+  }
+  return false;
 }
 
 export async function wrapJSModuleResponse(code: string, hasHmr = false) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -12,6 +12,7 @@ import {transformEsmImports} from '../rewrite-imports';
 import {BUILD_DEPENDENCIES_DIR, CommandOptions, ImportMap} from '../util';
 import {
   getFileBuilderForWorker,
+  isDirectoryImport,
   wrapCssModuleResponse,
   wrapEsmProxyResponse,
   wrapJSModuleResponse,
@@ -284,7 +285,11 @@ export async function command(commandOptions: CommandOptions) {
             if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
               const ext = path.extname(spec).substr(1);
               if (!ext) {
-                return spec + '.js';
+                if (isDirectoryImport(f, spec)) {
+                  return spec + '/index.js';
+                } else {
+                  return spec + '.js';
+                }
               }
               const extToReplace = srcFileExtensionMapping[ext];
               if (extToReplace) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -53,6 +53,7 @@ import {
 import {
   FileBuilder,
   getFileBuilderForWorker,
+  isDirectoryImport,
   wrapCssModuleResponse,
   wrapEsmProxyResponse,
   wrapHtmlResponse,
@@ -208,7 +209,11 @@ export async function command(commandOptions: CommandOptions) {
         if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
           const ext = path.extname(spec).substr(1);
           if (!ext) {
-            return spec + '.js';
+            if (isDirectoryImport(fileLoc, spec)) {
+              return spec + '/index.js';
+            } else {
+              return spec + '.js';
+            }
           }
           const extToReplace = srcFileExtensionMapping[ext];
           if (extToReplace) {


### PR DESCRIPTION
We've gotten enough user requests for this that I think it makes sense to support. We may still want to add a warning this is going out of fashion and won't be supported by Node (see discussion in https://www.pika.dev/npm/snowpack/discuss/260), but our goal right now is giving users an easy migration path from existing bundlers to Snowpack, and this falls within that goal.

```
// Input
import './routes';

// Output
import './routes/index.js';
```

Note that this currently won't be able to detect across mounted directories (ex: src/ importing from public/) but that's a rare case that I'm fine ignoring for now.

/cc @msaspence @lodi-g