### PR TITLE
Import scanner parse improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12642,6 +12642,11 @@
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^2.3.0",
+    "strip-comments": "^2.0.1",
     "tar": "^6.0.1",
     "validate-npm-package-name": "^3.0.0",
     "ws": "^7.3.0",

--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
-import nodePath from 'path';
+import {ImportSpecifier, init as initESModuleLexer, parse} from 'es-module-lexer';
 import fs from 'fs';
 import glob from 'glob';
-import esbuild from 'esbuild';
 import mime from 'mime-types';
+import nodePath from 'path';
+import stripComments from 'strip-comments';
 import validatePackageName from 'validate-npm-package-name';
-import {init as initESModuleLexer, parse, ImportSpecifier} from 'es-module-lexer';
-import {isTruthy} from './util';
 import {SnowpackConfig} from './config';
+import {isTruthy} from './util';
 
 const WEB_MODULES_TOKEN = 'web_modules/';
 const WEB_MODULES_TOKEN_LENGTH = WEB_MODULES_TOKEN.length;
@@ -15,6 +15,9 @@ const WEB_MODULES_TOKEN_LENGTH = WEB_MODULES_TOKEN.length;
 // [@\w] - Match a word-character or @ (valid package name)
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
+
+const ESM_IMPORT_REGEX = /import(?:["'\s]*([\w*${}\n\r\t, ]+)["'\s]from\s*)?["'\s]["'\s](.*?)["'\s].*;$/gm;
+const ESM_DYNAMIC_IMPORT_REGEX = /import\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const SPLIT_NAMED_IMPORTS_REGEX = /\bas\s+\w+|,/s;
 const DEFAULT_IMPORT_REGEX = /import\s+(\w)+(,\s\{[\w\s]*\})?\s+from/s;
@@ -131,8 +134,43 @@ function parseImportStatement(code: string, imp: ImportSpecifier): null | Instal
   };
 }
 
-function getInstallTargetsForFile(code: string): InstallTarget[] {
-  const [imports] = parse(code) || [];
+function cleanCodeForParsing(code: string): string {
+  code = stripComments(code);
+  const allMatches: string[] = [];
+  let match;
+  while ((match = ESM_IMPORT_REGEX.exec(code))) {
+    allMatches.push(match);
+  }
+  while ((match = ESM_DYNAMIC_IMPORT_REGEX.exec(code))) {
+    allMatches.push(match);
+  }
+  return allMatches.map(([full]) => full).join('\n');
+}
+
+function parseCodeForInstallTargets(fileLoc: string, code: string): InstallTarget[] {
+  let imports: ImportSpecifier[];
+  // Attempt #1: Parse the file as JavaScript. JSX and some decorator
+  // syntax will break this.
+  try {
+    if (fileLoc.endsWith('.jsx') || fileLoc.endsWith('.tsx')) {
+      // We know ahead of time that this will almost certainly fail.
+      // Just jump right to the secondary attempt.
+      throw new Error('JSX must be cleaned before parsing');
+    }
+    [imports] = parse(code) || [];
+  } catch (err) {
+    // Attempt #2: Parse only the import statements themselves.
+    // This lets us guarentee we aren't sending any broken syntax to our parser,
+    // but at the expense of possible false +/- caused by our regex extractor.
+    try {
+      code = cleanCodeForParsing(code);
+      [imports] = parse(code) || [];
+    } catch (err) {
+      // Another error! No hope left, just abort.
+      console.error(chalk.red(`! ${fileLoc}`));
+      throw err;
+    }
+  }
   const allImports: InstallTarget[] = imports
     .map((imp) => parseImportStatement(code, imp))
     .filter(isTruthy);
@@ -180,7 +218,6 @@ export async function scanImports(
   }
 
   // Scan every matched JS file for web dependency imports
-  const esbuildService = await esbuild.startService();
   const loadedFiles = await Promise.all(
     includeFiles.map(async (filePath) => {
       const ext = nodePath.extname(filePath);
@@ -193,16 +230,8 @@ export async function scanImports(
         return null;
       }
       // Our import scanner can handle normal JS & even TypeScript without a problem.
-      if (ext === '.js' || ext === '.mjs' || ext === '.ts') {
-        return fs.promises.readFile(filePath, 'utf-8');
-      }
-      // JSX breaks our import scanner, so we need to transform it before sending it to our scanner.
-      if (ext === '.jsx' || ext === '.tsx') {
-        const code = await fs.promises.readFile(filePath, 'utf-8');
-        const {js} = await esbuildService.transform(code, {
-          loader: ext.substr(1) as 'js' | 'ts' | 'tsx',
-        });
-        return js;
+      if (ext === '.js' || ext === '.mjs' || ext === '.ts' || ext === '.jsx' || ext === '.tsx') {
+        return [filePath, await fs.promises.readFile(filePath, 'utf-8')];
       }
       if (ext === '.vue' || ext === '.svelte') {
         const result = await fs.promises.readFile(filePath, 'utf-8');
@@ -213,7 +242,7 @@ export async function scanImports(
         while ((match = HTML_JS_REGEX.exec(result))) {
           allMatches.push(match);
         }
-        return allMatches.map(([full, code]) => code).join('\n');
+        return [filePath, allMatches.map(([full, code]) => code).join('\n')];
       }
       // If we don't recognize the file type, it could be source. Warn just in case.
       if (!mime.lookup(nodePath.extname(filePath))) {
@@ -224,10 +253,9 @@ export async function scanImports(
       return null;
     }),
   );
-  esbuildService.stop();
-  return (loadedFiles as string[])
-    .filter((code) => !!code)
-    .map((code) => getInstallTargetsForFile(code))
+  return loadedFiles
+    .filter(isTruthy)
+    .map(([fileLoc, code]) => parseCodeForInstallTargets(fileLoc, code))
     .reduce((flat, item) => flat.concat(item), [])
     .sort((impA, impB) => impA.specifier.localeCompare(impB.specifier));
 }

--- a/test/integration/include/dir/f.ts
+++ b/test/integration/include/dir/f.ts
@@ -1,0 +1,22 @@
+// test 6: TypeScript decorators
+import {test} from 'package-01';
+
+function f() {
+  console.log('f(): evaluated');
+  return function (target, propertyKey: string, descriptor: PropertyDescriptor) {
+    console.log('f(): called');
+  };
+}
+
+function g() {
+  console.log('g(): evaluated');
+  return function (target, propertyKey: string, descriptor: PropertyDescriptor) {
+    console.log('g(): called');
+  };
+}
+
+class C {
+  @f()
+  @g()
+  method() {}
+}

--- a/test/integration/include/expected-install/import-map.json
+++ b/test/integration/include/expected-install/import-map.json
@@ -2,6 +2,7 @@
   "imports": {
     "array-flatten": "./array-flatten.js",
     "http-vue-loader/src/httpVueLoader.js": "./http-vue-loader/src/httpVueLoader.js",
+    "package-01": "./package-01.js",
     "vue-router": "./vue-router.js",
     "vue/dist/vue.esm.browser.js": "./vue/dist/vue.esm.browser.js"
   }

--- a/test/integration/include/expected-install/package-01.js
+++ b/test/integration/include/expected-install/package-01.js
@@ -1,0 +1,3 @@
+function test() {}
+
+export { test };

--- a/test/integration/include/node_modules/package-01/README.md
+++ b/test/integration/include/node_modules/package-01/README.md
@@ -1,0 +1,43 @@
+# Array Flatten
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][downloads-image]][downloads-url]
+[![Build status][travis-image]][travis-url]
+[![Test coverage][coveralls-image]][coveralls-url]
+[![Bundle size][bundlephobia-image]][bundlephobia-url]
+
+> Flatten nested arrays.
+
+## Installation
+
+```
+npm install array-flatten --save
+```
+
+## Usage
+
+```js
+import { flatten } from "array-flatten";
+
+flatten([1, [2, [3, [4, [5], 6], 7], 8], 9]);
+//=> [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+(function() {
+  flatten(arguments); //=> [1, 2, 3]
+})(1, [2, 3]);
+```
+
+## License
+
+MIT
+
+[npm-image]: https://img.shields.io/npm/v/array-flatten.svg?style=flat
+[npm-url]: https://npmjs.org/package/array-flatten
+[downloads-image]: https://img.shields.io/npm/dm/array-flatten.svg?style=flat
+[downloads-url]: https://npmjs.org/package/array-flatten
+[travis-image]: https://img.shields.io/travis/blakeembrey/array-flatten.svg?style=flat
+[travis-url]: https://travis-ci.org/blakeembrey/array-flatten
+[coveralls-image]: https://img.shields.io/coveralls/blakeembrey/array-flatten.svg?style=flat
+[coveralls-url]: https://coveralls.io/r/blakeembrey/array-flatten?branch=master
+[bundlephobia-image]: https://img.shields.io/bundlephobia/minzip/array-flatten.svg
+[bundlephobia-url]: https://bundlephobia.com/result?p=array-flatten

--- a/test/integration/include/node_modules/package-01/index.js
+++ b/test/integration/include/node_modules/package-01/index.js
@@ -1,0 +1,1 @@
+export function test() {}

--- a/test/integration/include/node_modules/package-01/package.json
+++ b/test/integration/include/node_modules/package-01/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-01",
+  "module": "index.js"
+}


### PR DESCRIPTION
- Better error logging now shows the file name when a Parse Error happens
- Replaced esbuild in our import scanner with a pure regex import extractor.
  - no longer limited by esbuild's limitations: https://github.com/evanw/esbuild#javascript-syntax-support
  -  mainly, we now support TypeScript decorators
- Add a test for decorators

Resolves #370, Resolves #369