### PR TITLE
Add basic env variable support

### DIFF
--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -123,23 +123,6 @@ Note that this only works for directories that have been mounted via a `mount:*`
 ```
 
 
-### Dev HTTP Proxy
-
-```js
-// snowpack.config.json
-// Example: Proxy "/api/pokemon/ditto" -> "https://pokeapi.co/api/v2/pokemon/ditto"
-{
-  "proxy": {
-    "/api": "https://pokeapi.co/api/v2",
-  }
-}
-```
-
-Snowpack can proxy requests from the dev server to external URLs and APIs. Making API requests directly the dev server can help you mimic your production environment during development.
-
-See the [Proxy Options](#proxy-options) section for more information and full set of configuration options.
-
-
 ### JSX
 
 #### Compile to JavaScript
@@ -203,6 +186,59 @@ You can integrate TypeScript type checking with Snowpack via a [Build Script int
   }
 }
 ```
+
+### Environment Variables
+
+```js
+// `import.meta.env` - Read process.env variables in your web app
+fetch(`${import.meta.env.PUBLIC_API_URL}/users`).then(...)
+
+// Supports destructuring as well:
+const {PUBLIC_API_URL} = import.meta.env;
+fetch(`${PUBLIC_API_URL}/users`).then(...)
+
+// Instead of `import.meta.env.NODE_ENV` use `import.meta.env.MODE`
+if (import.meta.env.MODE === 'development') {
+  // ...
+```
+
+You can read environment variables directly in your web application via `import.meta.env`. If you've ever used `process.env` in Create React App or any Webpack application, this behaves exactly the same.
+
+Remember that these env variables are statically injected into your application for everyone at **build time**, and not runtime.
+
+For your safety, Snowpack only supports environment variables that begin with `PUBLIC_*`. We do this because everything in your web application is sent to the browser, and we don't want you to accidentally share sensitive keys/env variables with your public web application. Prefixing your frontend web env variables with `PUBLIC_` is a good reminder that they will be shared with the world.
+
+The one exception is `import.meta.env.MODE`, which is set to `development` during `snowpack dev` and `production` during `snowpack build`. This can be used instead of `process.env.NODE_ENV`. `import.meta.env.NODE_ENV` is also set for legacy reasons, but `import.meta.env.MODE` is recommended.
+
+#### `.env` File Support
+
+```js
+// snowpack.config.json
+{
+  "plugins": ["@snowpack/plugin-dotenv"]
+}
+```
+
+Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the plugin package README to learn more.
+
+
+
+### Dev Request Proxy
+
+```js
+// snowpack.config.json
+// Example: Proxy "/api/pokemon/ditto" -> "https://pokeapi.co/api/v2/pokemon/ditto"
+{
+  "proxy": {
+    "/api": "https://pokeapi.co/api/v2",
+  }
+}
+```
+
+Snowpack can proxy requests from the dev server to external URLs and APIs. Making API requests directly the dev server can help you mimic your production environment during development.
+
+See the [Proxy Options](#proxy-options) section for more information and full set of configuration options.
+
 
 ### Import Maps
 

--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -204,11 +204,11 @@ if (import.meta.env.MODE === 'development') {
 
 You can read environment variables directly in your web application via `import.meta.env`. If you've ever used `process.env` in Create React App or any Webpack application, this behaves exactly the same.
 
-Remember that these env variables are statically injected into your application for everyone at **build time**, and not runtime.
+For your safety, Snowpack only supports environment variables that begin with `PUBLIC_*`. We do this because everything in your web application is sent to the browser, and we don't want you to accidentally share sensitive keys/env variables with your public web application. Prefixing your frontend web env variables with `PUBLIC_` is a good reminder that they will be shared with the world. 
 
-For your safety, Snowpack only supports environment variables that begin with `PUBLIC_*`. We do this because everything in your web application is sent to the browser, and we don't want you to accidentally share sensitive keys/env variables with your public web application. Prefixing your frontend web env variables with `PUBLIC_` is a good reminder that they will be shared with the world.
+`import.meta.env.MODE` and `import.meta.env.NODE_ENV` are also both set to the current `process.env.NODE_ENV` value, so that you can change app behavior based on dev vs. build. The env value is set to `development` during `snowpack dev` and `production` during `snowpack build`. Use this in your application instead of `process.env.NODE_ENV`. 
 
-The one exception is `import.meta.env.MODE`, which is set to `development` during `snowpack dev` and `production` during `snowpack build`. This can be used instead of `process.env.NODE_ENV`. `import.meta.env.NODE_ENV` is also set for legacy reasons, but `import.meta.env.MODE` is recommended.
+**Remember:** that these env variables are statically injected into your application for everyone at **build time**, and not runtime.
 
 #### `.env` File Support
 
@@ -219,7 +219,7 @@ The one exception is `import.meta.env.MODE`, which is set to `development` durin
 }
 ```
 
-Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the plugin package README to learn more.
+Add the `@snowpack/plugin-dotenv` plugin to your dev environment to automatically load environment variables from your project `.env` files. Visit the [plugin README](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-dotenv) to learn more.
 
 
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -22,7 +22,8 @@ import {
   isDirectoryImport,
   wrapCssModuleResponse,
   wrapEsmProxyResponse,
-  wrapJSModuleResponse,
+  wrapImportMeta,
+  generateEnvModule,
 } from './build-util';
 import {stopEsbuild} from './esbuildPlugin';
 import {command as installCommand} from './install';
@@ -83,6 +84,7 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   const buildDirectoryLoc = isBundled ? path.join(cwd, `.build`) : config.devOptions.out;
+  const internalFilesBuildLoc = path.join(buildDirectoryLoc, '__snowpack__');
   const finalDirectoryLoc = config.devOptions.out;
 
   if (config.scripts.length <= 1) {
@@ -91,11 +93,12 @@ export async function command(commandOptions: CommandOptions) {
     return;
   }
 
-  rimraf.sync(finalDirectoryLoc);
-  mkdirp.sync(finalDirectoryLoc);
+  rimraf.sync(buildDirectoryLoc);
+  mkdirp.sync(buildDirectoryLoc);
+  mkdirp.sync(internalFilesBuildLoc);
   if (finalDirectoryLoc !== buildDirectoryLoc) {
-    rimraf.sync(buildDirectoryLoc);
-    mkdirp.sync(buildDirectoryLoc);
+    rimraf.sync(finalDirectoryLoc);
+    mkdirp.sync(finalDirectoryLoc);
   }
 
   console.log = (...args) => {
@@ -165,6 +168,9 @@ export async function command(commandOptions: CommandOptions) {
     });
     await workerPromise;
   }
+
+  // Write the `import.meta.env` contents file to disk
+  await fs.writeFile(path.join(internalFilesBuildLoc, 'env.js'), generateEnvModule('production'));
 
   const mountDirDetails: any[] = relevantWorkers
     .map((scriptConfig) => {
@@ -331,7 +337,7 @@ export async function command(commandOptions: CommandOptions) {
             });
             return `/web_modules/${spec}.js`;
           });
-          code = await wrapJSModuleResponse(code);
+          code = wrapImportMeta(code, {env: true, hmr: false});
         }
         await fs.mkdir(path.dirname(outPath), {recursive: true});
         await fs.writeFile(outPath, code);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -60,7 +60,8 @@ import {
   wrapCssModuleResponse,
   wrapEsmProxyResponse,
   wrapHtmlResponse,
-  wrapJSModuleResponse,
+  wrapImportMeta,
+  generateEnvModule,
 } from './build-util';
 import {command as installCommand} from './install';
 import {paint} from './paint';
@@ -386,8 +387,12 @@ export async function command(commandOptions: CommandOptions) {
         }
       });
 
-      if (reqPath === '/livereload/hmr.js') {
+      if (reqPath === '/__snowpack__/hmr.js') {
         sendFile(req, res, HMR_DEV_CODE, '.js');
+        return;
+      }
+      if (reqPath === '/__snowpack__/env.js') {
+        sendFile(req, res, generateEnvModule('development'));
         return;
       }
 
@@ -527,7 +532,7 @@ export async function command(commandOptions: CommandOptions) {
           responseFileExt = '.js';
           code = await wrapCssModuleResponse(reqPath, code, requestedFileExt, true);
         } else if (responseFileExt === '.js') {
-          code = await wrapJSModuleResponse(code, true);
+          code = wrapImportMeta(code, {env: true, hmr: true});
         }
         if (responseFileExt === '.js' && cssResource) {
           code = `import './${path.basename(reqPath).replace(/.js$/, '.css.proxy.js')}';\n` + code;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,12 @@ export async function cli(args: string[]) {
 
   const cmd = cliFlags['_'][2];
 
-  // Set this early - before config loading - so that plugins see it.
+  // Set this early -- before config loading -- so that plugins see it.
   if (cmd === 'build') {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+  }
+  if (cmd === 'dev') {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   }
 
   const commandOptions = {


### PR DESCRIPTION
This adds support for loading env variables off of `import.meta.env`:

- matches current behavior of webpack/CRA/etc. `process.env`
- `import.meta.env` is basically `process.env` but filtered by `PUBLIC_*`
- Adds an `import.meta.env.MODE` automatically: 'development' in dev & 'production' in build.

The idea is that `import.meta.env` this is the more web-friendly version of process.env + NODE_ENV, which was a Node.js pattern that was brought to the web because there was no other patterns to choose from. But, now that we have `import.meta`, we have a better place to put this env data :)

#### Example:

```js
console.log(import.meta.env);
// {MODE: 'development', PUBLIC_API_URL: 'http://api.example.com'}
```

```js
const {PUBLIC_API_URL} = import.meta.env;
fetch(`${PUBLIC_API_URL}/users`).then(...)
```

#### Todo:

- [x] Add documentation
- [x] Bikeshed/finalize the prefix that we filter by (Currently `PUBLIC_ *`. We need something that signifies that it will be publicly available in the website code so that users don't leak private data accidentally)
- [x] `env.MODE` instead of `env.NODE_ENV`. Thoughts?
- [x] Finalize how `.env` dotfiles files will be supported (I'd rather this be added via an opt-in plugin, but that would require `config` env support + a mechanism for plugins to modify config.)