### PR TITLE
ignore babel macro imports

### DIFF
--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -173,7 +173,9 @@ function parseCodeForInstallTargets(fileLoc: string, code: string): InstallTarge
   }
   const allImports: InstallTarget[] = imports
     .map((imp) => parseImportStatement(code, imp))
-    .filter(isTruthy);
+    .filter(isTruthy)
+    // Babel macros are not install targets!
+    .filter((imp) => !imp.specifier.endsWith('.macro'));
   return allImports;
 }
 

--- a/test/integration/include/dir/f.ts
+++ b/test/integration/include/dir/f.ts
@@ -18,5 +18,6 @@ function g() {
 class C {
   @f()
   @g()
+  // @ts-ignore
   method() {}
 }

--- a/test/integration/include/dir/g.ts
+++ b/test/integration/include/dir/g.ts
@@ -1,0 +1,4 @@
+// test 7: Ignore babel macros
+import 'twin.macro';
+// @ts-ignore
+import preval from 'preval.macro';


### PR DESCRIPTION
```
import 'twin.macro'
```

^ This will now be ignored by our import scanner since this isn't a real dependency (it's injected by Babel at build time). Learn more: https://github.com/kentcdodds/babel-plugin-macros

Fixes the issue brought up in this discussion: https://www.pika.dev/npm/snowpack/discuss/269

/cc @kingdaro