### PR TITLE
Make possible to import es6 modules without a semicolon in end

### DIFF
--- a/src/scan-imports.ts
+++ b/src/scan-imports.ts
@@ -16,7 +16,7 @@ const WEB_MODULES_TOKEN_LENGTH = WEB_MODULES_TOKEN.length;
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)
 const BARE_SPECIFIER_REGEX = /^[@\w](?!.*(:\/\/))/;
 
-const ESM_IMPORT_REGEX = /import(?:["'\s]*([\w*${}\n\r\t, ]+)["'\s]from\s*)?["'\s]["'\s](.*?)["'\s].*;$/gm;
+const ESM_IMPORT_REGEX = /import(?:["'\s]*([\w*${}\n\r\t, ]+)["'\s]from\s*)?["'\s]["'\s](.*?)["'\s].*(;?)$/gm;
 const ESM_DYNAMIC_IMPORT_REGEX = /import\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const SPLIT_NAMED_IMPORTS_REGEX = /\bas\s+\w+|,/s;


### PR DESCRIPTION
Hello guys !

I'm currently trying to use snowpack in my project. However, snowpack can't find my `import`s.
The problem here is that I'm currently using the shortened import syntax like the one below
```
import foo from 'bar'
``` 
and not the extended one (with a semicolon in the end)
```
import foo from 'bar';
```

This PR tries to fix this issue. However I'm not sure if it's the right solution. I'm open for help/comments. 

Thanks !