### PR TITLE
Swap ansi-escapes for a working cross-platform clear

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       }
@@ -13135,7 +13136,8 @@
     "type-fest": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@rollup/plugin-replace": "^2.1.0",
     "@types/http-proxy": "^1.17.4",
     "@types/tar": "^4.0.3",
-    "ansi-escapes": "^4.3.1",
     "cacache": "^15.0.0",
     "cachedir": "^2.3.0",
     "chalk": "^4.0.0",

--- a/src/commands/paint.ts
+++ b/src/commands/paint.ts
@@ -1,4 +1,3 @@
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import {EventEmitter} from 'events';
 import readline from 'readline';
@@ -52,7 +51,7 @@ export function paint(
   }
 
   function repaint() {
-    process.stdout.write(ansiEscapes.clearTerminal);
+    process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
     process.stdout.write(`${chalk.bold('Snowpack')}\n\n`);
     // Dashboard
     if (devMode) {


### PR DESCRIPTION
This swaps out `ansi-escapes` which we utilized `clearTerminal`, for a working windows command. 

The main difference is just a slight difference in the `ESC` sequence. This swaps, `\u001B[` to `\x1B[`. This is how Jest and CRA both handle their clearTerminal command.


@FredKSchott feel free to close if you want