### PR TITLE
Strip the pathPrefix from basic proxy requests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -412,10 +412,14 @@ function normalizeProxies(proxies: RawProxies): Proxy[] {
     return [
       pathPrefix,
       {
-        on: {},
+        on: {
+          proxyReq: (proxyReq, req) => {
+            proxyReq.path = req.url.replace(pathPrefix, '')
+          }
+        },
         target: options,
-        ignorePath: true,
         changeOrigin: true,
+        secure: false
       },
     ];
   });


### PR DESCRIPTION
Addresses issues that were brought up in #393 

- Adds `secure: false` back in
- Drops `ignorePath: true` which strips the entire path of the request. Replaced it with a default `proxyReq` event listener that just strips the `pathPrefix` off the path.


```
proxy: {
  "/storybook": "http://localhost:3000"
}
```

This will result in the URL going from `http://localhost:8080/storybook/static/js/bundle.js` -> `http://localhost:3000/static/js/bundle.js` which, I believe, was the intention of that config entry.

For the advanced configs, I'm going to leave it as whatever you configure is what you get.

@FredKSchott 
/cc @fcamblor 