### PR TITLE
Add ETag to file responses

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -101,6 +101,7 @@ const sendFile = (
   res.writeHead(200, {
     'Content-Type': mime.contentType(ext) || 'application/octet-stream',
     'Access-Control-Allow-Origin': '*',
+    'ETag': etag(body)
   });
   res.write(body, getEncodingType(ext));
   res.end();


### PR DESCRIPTION
Part 1 of #404 

This adds an `ETag` header for each file we send from the server.

The only thing I'm not sure on is if we should specify the Weak option or not.