### PR TITLE
Utilize ETags

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -98,12 +98,19 @@ const sendFile = (
   body: string | Buffer,
   ext = '.html',
 ) => {
-  res.writeHead(200, {
+  const ETag = etag(body)
+  const headers = {
     'Content-Type': mime.contentType(ext) || 'application/octet-stream',
     'Access-Control-Allow-Origin': '*',
-    ETag: etag(body),
-  });
-  res.write(body, getEncodingType(ext));
+    ETag
+  }
+
+  if (req.headers["if-none-match"] === ETag) {
+    res.writeHead(304, headers)
+  } else {
+    res.writeHead(200, headers);
+    res.write(body, getEncodingType(ext));
+  }
   res.end();
 };
 


### PR DESCRIPTION
Part 2 of #404 

This builds on #410 by returning a 304 response for an ETag that matches the `if-none-match` header.

Here was the result of serving the cached file, modifying, and performing 2 refreshes.

![image](https://user-images.githubusercontent.com/855184/83516965-ae575080-a49d-11ea-81da-8302c22e5df2.png)

This greatly reduces the amount of data transferred when all files are cached. It can impact the load times as well when working in larger apps. These next results are from the react-typescript scaffold.

Previously:
![image](https://user-images.githubusercontent.com/855184/83517422-78ff3280-a49e-11ea-9e65-42747aa41b3c.png)

Utilizing ETags:
![image](https://user-images.githubusercontent.com/855184/83517468-8b796c00-a49e-11ea-87c9-e2dddfed402c.png)

I'm unsure if all headers are necessary for the 304 response. From what I could tell, the ETag is but the rest I'm not sure about.

@FredKSchott 