### PR TITLE
Fix hmr proxy

### DIFF
--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -22,7 +22,7 @@ function sendSocketMessage(msg) {
 const socketURL =
   window.HMR_WEBSOCKET_URL ||
   (location.protocol === 'http:' ? 'ws://' : 'wss://') + location.host + '/';
-const socket = new WebSocket(socketURL);
+const socket = new WebSocket(socketURL, 'snowpack-hmr');
 socket.addEventListener('open', () => {
   SOCKET_MESSAGE_QUEUE.forEach(_sendSocketMessage);
   SOCKET_MESSAGE_QUEUE = [];

--- a/src/hmr-server-engine.ts
+++ b/src/hmr-server-engine.ts
@@ -19,9 +19,12 @@ export class EsmHmrEngine {
       : new WebSocket.Server({port: 12321});
     if (options.server) {
       options.server.on('upgrade', (req, socket, head) => {
-        wss.handleUpgrade(req, socket, head, (client) => {
-          wss.emit('connection', client, req);
-        });
+        let isHmrRequest = req.headers['sec-websocket-protocol'] === 'snowpack-hmr';
+        if (isHmrRequest) {
+          wss.handleUpgrade(req, socket, head, (client) => {
+            wss.emit('connection', client, req);
+          });          
+        }
       });
     }
     wss.on('connection', (client) => {


### PR DESCRIPTION
Hi,

This commit fixes #414 by filtering the websockets upgrade requests that the hmr module will handle. Only the upgrade requests originating from the hmr.js will be processed. Uses custom header `Sec-WebSocket-Protocol : snowpack-hmr` to do the filtering.
