### PR TITLE
fix typo for sass note

### DIFF
--- a/docs/08-guides.md
+++ b/docs/08-guides.md
@@ -138,7 +138,7 @@ Follow the official [Tailwind CSS Docs](https://tailwindcss.com/docs/installatio
 
 [Check out the official Sass CLI documentation](https://sass-lang.com/documentation/cli/dart-sass) for a list of all available arguments. You can also use the [node-sass](https://www.npmjs.com/package/node-sass) CLI if you prefer to install Sass from npm.
 
-**Note:** Sass should be run as a "run:" script (see example above) to take advantage of the Sass CLI's partial handling. A ``"build:scss"` script would build each file individually as its served, but couldn't handle Sass partials via `@use` due to the fact that Sass bundles these into the importer file CSS.
+**Note:** Sass should be run as a "run:" script (see example above) to take advantage of the Sass CLI's partial handling. A `"build:scss"` script would build each file individually as its served, but couldn't handle Sass partials via `@use` due to the fact that Sass bundles these into the importer file CSS.
 
 To use Sass + PostCSS, check out [this guide](https://zellwk.com/blog/eleventy-snowpack-sass-postcss/).
 


### PR DESCRIPTION
The markup seems to be broken.

![](https://user-images.githubusercontent.com/11547305/83634232-22e4d900-a5dd-11ea-9906-df971e1b7234.png)