### PR TITLE
Add support for devOptions.hmr

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -178,7 +178,7 @@ let currentlyRunningCommand: any = null;
 export async function command(commandOptions: CommandOptions) {
   let serverStart = Date.now();
   const {cwd, config} = commandOptions;
-  const {port, open} = config.devOptions;
+  const {port, open, hmr} = config.devOptions;
 
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
@@ -584,15 +584,15 @@ export async function command(commandOptions: CommandOptions) {
 
       async function wrapResponse(code: string, cssResource: string | undefined) {
         if (isRoute) {
-          code = wrapHtmlResponse(code, true);
+          code = wrapHtmlResponse(code, hmr);
         } else if (isProxyModule) {
           responseFileExt = '.js';
-          code = wrapEsmProxyResponse(reqPath, code, requestedFileExt, true);
+          code = wrapEsmProxyResponse(reqPath, code, requestedFileExt, hmr);
         } else if (isCssModule) {
           responseFileExt = '.js';
-          code = await wrapCssModuleResponse(reqPath, code, requestedFileExt, true);
+          code = await wrapCssModuleResponse(reqPath, code, requestedFileExt, hmr);
         } else if (responseFileExt === '.js') {
-          code = wrapImportMeta(code, {env: true, hmr: true});
+          code = wrapImportMeta(code, {env: true, hmr});
         }
         if (responseFileExt === '.js' && cssResource) {
           code = `import './${path.basename(reqPath).replace(/.js$/, '.css.proxy.js')}';\n` + code;

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ export interface SnowpackConfig {
     fallback: string;
     open: string;
     bundle: boolean | undefined;
+    hmr: boolean;
   };
   installOptions: {
     dest: string;
@@ -143,6 +144,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
     open: 'default',
     out: 'build',
     fallback: 'index.html',
+    hmr: true,
     bundle: undefined,
   },
 };
@@ -170,6 +172,7 @@ const configSchema = {
         fallback: {type: 'string'},
         bundle: {type: 'boolean'},
         open: {type: 'string'},
+        hmr: {type: 'boolean'},
       },
     },
     installOptions: {


### PR DESCRIPTION
This should enable users to control whether or not snowpack dev server should have `hmr` enabled.

This is PR1 for #377 .