### PR TITLE
Offer alternative port if specified port is busy

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -201,9 +201,7 @@ export async function command(commandOptions: CommandOptions) {
           chalk.yellow(
             `port ${chalk.bold(
               port,
-            )} is not available. Would you like to run the app on port ${chalk.bold(
-              availablePort,
-            )} instead? (Y/n) `,
+            )} is not available. Would you like to run the app on another port instead? (Y/n) `,
           ),
           (answer) => {
             resolve(!/^no?$/i.test(answer));
@@ -227,7 +225,7 @@ export async function command(commandOptions: CommandOptions) {
       process.exit(1);
     }
 
-    port = availablePort
+    port = await detectPort(availablePort);
   }
 
   // Set the proper install options, in case an install is needed.
@@ -812,6 +810,16 @@ export async function command(commandOptions: CommandOptions) {
 
     sendFile(req, res, wrappedResponse, responseFileExt);
   })
+    .on('error', (err: Error) => {
+      console.error(
+        chalk.red(
+          `  ✘ Failed to start server at port ${chalk.bold(port)}.`,
+        ),
+        err
+      );
+      server.close();
+      process.exit(1);
+    })
     .on('upgrade', (req: http.IncomingMessage, socket, head) => {
       config.proxy.forEach(([pathPrefix, proxyOptions]) => {
         const isWebSocket = proxyOptions.ws || proxyOptions.target?.toString().startsWith('ws');

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -181,7 +181,7 @@ export async function command(commandOptions: CommandOptions) {
   let serverStart = Date.now();
   const {cwd, config} = commandOptions;
   const {port: defaultPort, open, hmr: isHmr} = config.devOptions;
-  let port = defaultPort
+  let port = defaultPort;
 
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
@@ -193,15 +193,24 @@ export async function command(commandOptions: CommandOptions) {
   // Check whether the port is available
   const availablePort = await detectPort(port);
   if (port !== availablePort) {
-    let useNextPort: boolean = false
+    let useNextPort: boolean = false;
     if (process.stdout.isTTY) {
-      const rl = readline.createInterface({input: process.stdin, output: process.stdout})
+      const rl = readline.createInterface({input: process.stdin, output: process.stdout});
       useNextPort = await new Promise((resolve) => {
-        rl.question(chalk.yellow(`port ${chalk.bold(port)} is not available. Would you like to run the app on port ${chalk.bold(availablePort)} instead? (Y/n) `), (answer) => {
-          resolve(!/^no?$/i.test(answer))
-        })
-      })
-      rl.close()
+        rl.question(
+          chalk.yellow(
+            `port ${chalk.bold(
+              port,
+            )} is not available. Would you like to run the app on port ${chalk.bold(
+              availablePort,
+            )} instead? (Y/n) `,
+          ),
+          (answer) => {
+            resolve(!/^no?$/i.test(answer));
+          },
+        );
+      });
+      rl.close();
       serverStart = Date.now();
     }
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -180,7 +180,8 @@ let currentlyRunningCommand: any = null;
 export async function command(commandOptions: CommandOptions) {
   let serverStart = Date.now();
   const {cwd, config} = commandOptions;
-  const {port, open, hmr: isHmr} = config.devOptions;
+  const {port: defaultPort, open, hmr: isHmr} = config.devOptions;
+  let port = defaultPort
 
   const inMemoryBuildCache = new Map<string, Buffer>();
   const inMemoryResourceCache = new Map<string, string>();
@@ -201,6 +202,7 @@ export async function command(commandOptions: CommandOptions) {
         })
       })
       rl.close()
+      serverStart = Date.now();
     }
 
     if (!useNextPort) {
@@ -808,7 +810,7 @@ export async function command(commandOptions: CommandOptions) {
         }
       });
     })
-    .listen(availablePort);
+    .listen(port);
 
   const hmrEngine = new EsmHmrEngine({server});
 
@@ -889,7 +891,7 @@ export async function command(commandOptions: CommandOptions) {
 
   paint(messageBus, config.scripts, undefined, {
     protocol,
-    port: availablePort,
+    port,
     ips,
     startTimeMs: Date.now() - serverStart,
     addPackage: async (pkgName) => {
@@ -925,6 +927,6 @@ export async function command(commandOptions: CommandOptions) {
     },
   });
 
-  if (open !== 'none') await openInBrowser(protocol, availablePort, open);
+  if (open !== 'none') await openInBrowser(protocol, port, open);
   return new Promise(() => {});
 }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -226,6 +226,8 @@ export async function command(commandOptions: CommandOptions) {
       console.error();
       process.exit(1);
     }
+
+    port = availablePort
   }
 
   // Set the proper install options, in case an install is needed.

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -194,15 +194,13 @@ export async function command(commandOptions: CommandOptions) {
   if (port !== availablePort) {
     let useNextPort: boolean = false
     if (process.stdout.isTTY) {
-      
+      const rl = readline.createInterface({input: process.stdin, output: process.stdout})
       useNextPort = await new Promise((resolve) => {
-        const rl = readline.createInterface({input: process.stdin, output: process.stdout})
         rl.question(chalk.yellow(`port ${chalk.bold(port)} is not available. Would you like to run the app on port ${chalk.bold(availablePort)} instead? (Y/n) `), (answer) => {
-          console.log({answer})
-          rl.close()
           resolve(!/^no?$/i.test(answer))
         })
       })
+      rl.close()
     }
 
     if (!useNextPort) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -190,17 +190,18 @@ export async function command(commandOptions: CommandOptions) {
   const mountedDirectories: [string, string][] = [];
 
   // Check whether the port is available
-  let availablePort = await detectPort(port);
+  const availablePort = await detectPort(port);
   if (port !== availablePort) {
     let useNextPort: boolean = false
     if (process.stdout.isTTY) {
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-      });
-      rl.question(chalk.yellow(`port ${chalk.bold(port)} is not available. Would you like to run the app on port ${chalk.bold(availablePort)} instead? (Y/n)`), (answer) => {
-        useNextPort = !/n/i.test(answer)
-        rl.close()
+      
+      useNextPort = await new Promise((resolve) => {
+        const rl = readline.createInterface({input: process.stdin, output: process.stdout})
+        rl.question(chalk.yellow(`port ${chalk.bold(port)} is not available. Would you like to run the app on port ${chalk.bold(availablePort)} instead? (Y/n) `), (answer) => {
+          console.log({answer})
+          rl.close()
+          resolve(!/^no?$/i.test(answer))
+        })
       })
     }
 
@@ -809,7 +810,7 @@ export async function command(commandOptions: CommandOptions) {
         }
       });
     })
-    .listen(port);
+    .listen(availablePort);
 
   const hmrEngine = new EsmHmrEngine({server});
 

--- a/src/commands/paint.ts
+++ b/src/commands/paint.ts
@@ -56,9 +56,7 @@ export function paint(
     process.stdout.write(`${chalk.bold('Snowpack')}\n\n`);
     // Dashboard
     if (devMode) {
-      process.stdout.write(
-        `  ${chalk.bold.cyan(`${devMode.protocol}//localhost:${devMode.port}`)}`,
-      );
+      process.stdout.write(`  ${chalk.bold.cyan(`${devMode.protocol}//localhost:${devMode.port}`)}`);
       for (const ip of devMode.ips) {
         process.stdout.write(
           `${chalk.cyan(` > `)}${chalk.bold.cyan(`${devMode.protocol}//${ip}:${devMode.port}`)}`,

--- a/src/commands/paint.ts
+++ b/src/commands/paint.ts
@@ -56,7 +56,9 @@ export function paint(
     process.stdout.write(`${chalk.bold('Snowpack')}\n\n`);
     // Dashboard
     if (devMode) {
-      process.stdout.write(`  ${chalk.bold.cyan(`${devMode.protocol}//localhost:${devMode.port}`)}`);
+      process.stdout.write(
+        `  ${chalk.bold.cyan(`${devMode.protocol}//localhost:${devMode.port}`)}`,
+      );
       for (const ip of devMode.ips) {
         process.stdout.write(
           `${chalk.cyan(` > `)}${chalk.bold.cyan(`${devMode.protocol}//${ip}:${devMode.port}`)}`,


### PR DESCRIPTION
Resolves #386 

Testing on WSL turned out that `detect-port` isn't working properly. I filed an issue for them https://github.com/node-modules/detect-port/issues/39

@FredKSchott I wasn't sure if there was a reason to reuse the `readline` interface from paint. 