### PR TITLE
Fix HMR support for CSS modules

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -825,7 +825,7 @@ export async function command(commandOptions: CommandOptions) {
   async function onWatchEvent(fileLoc) {
     let updateUrl = getUrlFromFile(mountedDirectories, fileLoc);
     if (updateUrl) {
-      if (!updateUrl.endsWith('.js') && !updateUrl.endsWith('.module.css') ) {
+      if (!updateUrl.endsWith('.js') && !updateUrl.endsWith('.module.css')) {
         updateUrl += '.proxy.js';
       }
       if (isLiveReloadPaused) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -825,7 +825,7 @@ export async function command(commandOptions: CommandOptions) {
   async function onWatchEvent(fileLoc) {
     let updateUrl = getUrlFromFile(mountedDirectories, fileLoc);
     if (updateUrl) {
-      if (!updateUrl.endsWith('.js')) {
+      if (!updateUrl.endsWith('.js') && !updateUrl.endsWith('.module.css') ) {
         updateUrl += '.proxy.js';
       }
       if (isLiveReloadPaused) {


### PR DESCRIPTION
According to [dev.ts#297](https://github.com/pikapkg/snowpack/blob/62a00e857aec3101e359dfebf00c3d25ce9fbc83/src/commands/dev.ts#L297), `'.proxy.js'` shouldn't get appended to CSS module files. With this fix in place, HMR is working for CSS modules.