### PR TITLE
WIP: create snowpack configuration programmatically

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -509,7 +509,7 @@ function handleConfigError(msg: string) {
   process.exit(1);
 }
 
-function handleValidationErrors(filepath: string, errors: {toString: () => string}[]) {
+function handleValidationErrors(filepath: string | null, errors: {toString: () => string}[]) {
   console.error(chalk.red(`! ${filepath || 'Configuration error'}`));
   console.error(errors.map((err) => `    - ${err.toString()}`).join('\n'));
   console.error(`    See https://www.snowpack.dev/#configuration for more info.`);
@@ -638,6 +638,21 @@ function validateConfigAgainstV1(rawConfig: any, cliFlags: any) {
       '[Snowpack v1 -> v2] `installOptions.strict` is no longer supported.',
     );
   }
+}
+
+export function createConfiguration(config: SnowpackConfig) {
+  const validation = validate(config, configSchema, {
+    allowUnknownAttributes: false,
+    propertyName: CONFIG_NAME,
+  });
+
+  if (validation.errors && validation.errors.length > 0) {
+    handleValidationErrors(null, validation.errors);
+    process.exit(1);
+  }
+
+  const mergedConfig = merge<SnowpackConfig>([DEFAULT_CONFIG, config]);
+  return normalizeConfig(mergedConfig);
 }
 
 export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): SnowpackConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,7 @@ export type Proxy = [string, ProxyOptions];
 
 // interface this library uses internally
 export interface SnowpackConfig {
+  install: string[];
   extends?: string;
   exclude: string[];
   knownEntrypoints: string[];
@@ -640,7 +641,7 @@ function validateConfigAgainstV1(rawConfig: any, cliFlags: any) {
   }
 }
 
-export function createConfiguration(config: SnowpackConfig) {
+export function createConfiguration(config: Partial<SnowpackConfig>): SnowpackConfig {
   const validation = validate(config, configSchema, {
     allowUnknownAttributes: false,
     propertyName: CONFIG_NAME,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {addCommand, rmCommand} from './commands/add-rm';
 import {command as installCommand} from './commands/install';
-import {CLIFlags, loadAndValidateConfig} from './config.js';
+import {CLIFlags, loadAndValidateConfig, createConfiguration} from './config.js';
 import {readLockfile, clearCache} from './util.js';
 
 const cwd = process.cwd();
@@ -32,6 +32,8 @@ ${chalk.bold('Flags:')}
     `.trim(),
   );
 }
+
+export {createConfiguration};
 
 export async function cli(args: string[]) {
   // parse CLI flags


### PR DESCRIPTION
In this PR a `createConfiguration` function is exposed. It can be used to create configuration that can be then passed to `install` function.

The logic is essentially the same as existing `loadAndValidateConfig` function, only without loading.

Related to #312