### PR TITLE
less verbose hmr

### DIFF
--- a/assets/hmr.js
+++ b/assets/hmr.js
@@ -2,9 +2,14 @@
  * esm-hmr/runtime.ts
  * A client-side implementation of the ESM-HMR spec, for reference.
  */
-function debug(...args) {
-  console.log('[ESM-HMR]', ...args);
+let debug = () => {};
+
+if (localStorage.getItem('debug') === 'true') {
+  debug = (...args) => {
+    console.log('[ESM-HMR]', ...args);
+  };
 }
+
 function reload() {
   location.reload(true);
 }


### PR DESCRIPTION
Inspired by the debug lib, I added a check on the presence of a variable in localstorage to activate or deactivate the logs of the HMR.
I didn't want to pull "debug" as a dep though, as it seems overkill right now in regards to the small client side code required by snowpack.

It should solve with https://www.pika.dev/npm/snowpack/discuss/296
