### PR TITLE
Fix HMR on secure server

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -448,7 +448,8 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   const createServer = credentials
-    ? (requestHandler) => http2.createSecureServer(credentials!, requestHandler)
+    ? (requestHandler) =>
+        http2.createSecureServer({...credentials!, allowHTTP1: true}, requestHandler)
     : (requestHandler) => http.createServer(requestHandler);
 
   const server = createServer(async (req, res) => {


### PR DESCRIPTION
Fixes #457 

Sorry about that!

NodeJS doesn't handle Websockets over HTTP2 so you have to allow the fallback to HTTP1.1. This is the current workaround.