### PR TITLE
update http/2 instructions

### DIFF
--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -250,14 +250,13 @@ npm start -- --secure
 
 #### Generating SSL Certificates
 
-You can automatically generate credentials for your project via either: 
+You can automatically generate credentials for your project via: 
 
-- [devcert (no install required)](https://github.com/davewasmer/devcert-cli): `npx devcert-cli generate localhost`
-- [mkcert (install required)](https://github.com/FiloSottile/mkcert): `mkcert -install && mkcert localhost`
+- [mkcert](https://github.com/FiloSottile/mkcert): `mkcert -install && mkcert -key-file snowpack.key -cert-file snowpack.crt localhost`
    
 #### HTTP2 
 
-Not sure what to write here...
+If you use snowpack's proxy settings to forward your API requests, you'll need to make sure the API server can handle HTTP/2 requests.
 
 ### Import Maps
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -431,17 +431,14 @@ export async function command(commandOptions: CommandOptions) {
         ),
       );
       console.log();
-      console.log('You can automatically generate credentials for your project via either:');
+      console.log('You can automatically generate credentials for your project via:');
       console.log();
       console.log(
-        `  - ${chalk.cyan('devcert')}: ${chalk.yellow('npx devcert-cli generate localhost')}`,
+        `  - ${chalk.cyan('mkcert')}: ${chalk.yellow(
+          'mkcert -install && mkcert -key-file snowpack.key -cert-file snowpack.crt',
+        )} localhost`,
       );
-      console.log('    https://github.com/davewasmer/devcert-cli (no install required)');
-      console.log();
-      console.log(
-        `  - ${chalk.cyan('mkcert')}: ${chalk.yellow('mkcert -install && mkcert localhost')}`,
-      );
-      console.log('    https://github.com/FiloSottile/mkcert (install required)');
+      console.log('    https://github.com/FiloSottile/mkcert');
       console.log();
       process.exit(1);
     }


### PR DESCRIPTION
I was not able to get devcert to work
fixed mkcert's command to generate snowpack.{crt,key}
Also put in a note about API server need to be able to handle HTTP/2 requests too.