### PR TITLE
Cleanup unresolved import errors

### DIFF
--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -1,0 +1,26 @@
+## Troubleshooting
+
+### Node built-in could not be resolved
+
+```
+✖ /my-application/node_modules/dep/index.js
+  "http" (Node.js built-in) could not be resolved.
+```
+
+Some packages are written with dependencies on Node.js built-in modules. This is a problem on the web, since Node.js built-in modules don't exist in the browser. For example, `import 'path'` will run just fine in Node.js but would fail in the browser.
+
+To solve this issue, you can either replace the offending package ([pika.dev](https://pika.dev/) is a great resource for web-friendly packages) or add Node.js polyfill support:
+
+```js
+// snowpack.config.js
+// Plugin: https://github.com/ionic-team/rollup-plugin-node-polyfills
+module.exports = {
+  installOptions: {
+    rollup: {
+      plugins: [require("rollup-plugin-node-polyfills")()]
+    }
+  }
+};
+```
+
+

--- a/src/rollup-plugin-catch-unresolved.ts
+++ b/src/rollup-plugin-catch-unresolved.ts
@@ -11,37 +11,17 @@ export function rollupPluginCatchUnresolved(): Plugin {
   return {
     name: 'snowpack:rollup-plugin-catch-unresolved',
     resolveId(id, importer) {
-      if (!isNodeBuiltin(id)) {
-        console.error(
-          chalk.red(
-            chalk.bold(`! ${id}`) + ` is imported by '${importer}', but could not be resolved.`,
-          ),
-        );
-        return false;
+      if (isNodeBuiltin(id)) {
+        this.warn({
+          id: importer,
+          message: `"${id}" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved)`,
+        });
+      } else {
+        this.warn({
+          id: importer,
+          message: `"${id}" could not be resolved.`,
+        });
       }
-
-      console.error(
-        chalk.red(
-          chalk.bold(`! ${id}`) +
-            ` is a Node.js built-in module that does not exist in the browser.\n`,
-        ),
-      );
-      console.error(
-        `  1. Search pika.dev for a more web-friendly package alternative${
-          importer ? ` to ${chalk.bold(importer)}.` : '.'
-        }`,
-      );
-      console.error(
-        `  2. Or, add this rollup plugin to your installer to polyfill Node.js packages:\n\n` +
-          chalk.dim(
-            `      // snowpack.config.js\n` +
-              `      module.exports = {\n` +
-              `        installOptions: {\n` +
-              `          rollup: {plugins: [require("rollup-plugin-node-polyfills")()]}\n` +
-              `        }\n` +
-              `      };\n`,
-          ),
-      );
       return false;
     },
   };

--- a/test/integration/error-node-builtin-unresolved/expected-output.txt
+++ b/test/integration/error-node-builtin-unresolved/expected-output.txt
@@ -1,0 +1,8 @@
+- snowpack installing...
+⠼ snowpack installing... mock-test-package
+✖ node_modules/mock-test-package/entrypoint.js
+   "http" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved)
+✔ snowpack install complete with errors.
+
+  ⦿ web_modules/             size       gzip       brotli   
+    └─ mock-test-package.js    XXXX KB    XXXX KB    XXXX KB

--- a/test/integration/error-node-builtin-unresolved/node_modules/mock-test-package/entrypoint.js
+++ b/test/integration/error-node-builtin-unresolved/node_modules/mock-test-package/entrypoint.js
@@ -1,0 +1,3 @@
+export const FOO = 42;
+// ERROR: This shouldn't work without polyfill support
+import 'http';

--- a/test/integration/error-node-builtin-unresolved/node_modules/mock-test-package/package.json
+++ b/test/integration/error-node-builtin-unresolved/node_modules/mock-test-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-test-package",
+  "version": "1.2.3",
+  "module": "entrypoint.js"
+}

--- a/test/integration/error-node-builtin-unresolved/package.json
+++ b/test/integration/error-node-builtin-unresolved/package.json
@@ -1,0 +1,11 @@
+{
+    "scripts": {
+        "TEST": "node ../../../pkg/dist-node/index.bin.js"
+    },
+    "dependencies": {
+        "mock-test-package": "^1.2.3"
+    },
+    "snowpack": {
+        "install": ["mock-test-package"]
+    }
+}


### PR DESCRIPTION
- Cleanup the "unresolved import" error messages to be more concise.
- Add documentation to the docs site to start a "troubleshooting" section.
- Properly exit/fail when an unresolved import is encountered.
  - Bonus: `dev`/`build` will no longer clear output if this happens.
- Add a test.
 
## Currently
<img width="1426" alt="Screen Shot 2020-06-10 at 4 41 39 PM" src="https://user-images.githubusercontent.com/622227/84329319-4954c800-ab39-11ea-987f-605b5175c2e8.png">

## This PR

<img width="1175" alt="Screen Shot 2020-06-10 at 4 29 53 PM" src="https://user-images.githubusercontent.com/622227/84329216-0135a580-ab39-11ea-82f4-4c2d4c83cc3c.png">
