### PR TITLE
Support CJS -> ESM dependency imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ ${chalk.bold('Flags:')}
 
 export async function cli(args: string[]) {
   // parse CLI flags
-  const cliFlags = yargs(args, {array: ['env', 'exclude', 'externalPackage']}) as CLIFlags;
+  const cliFlags = yargs(args, {array: ['install', 'env', 'exclude', 'externalPackage']}) as CLIFlags;
   if (cliFlags.help) {
     printHelp();
     process.exit(0);

--- a/test/integration/config-alias/package.json
+++ b/test/integration/config-alias/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Handle deep imports to package entrypoints",
   "scripts": {
-    "TEST": "node ../../../pkg/dist-node/index.bin.js --external-package lit-html"
+    "TEST": "node ../../../pkg/dist-node/index.bin.js"
   },
   "snowpack": {
     "installOptions": {


### PR DESCRIPTION
This PR adds limited support for CJS -> ESM imports inside of your dependency graph. Note that this currently only runs if `--external-package` is provided, so most users will never use it. It also relies on a fork of the official Rollup CJS plugin existing. If the fork does not exist, it is a no-op.

This is a short-term workaround until the Rollup plugin officially supports this specific usecase. See this discussion for progress: https://github.com/rollup/plugins/pull/414#issuecomment-643063427