### PR TITLE
Assorted fixes

### DIFF
--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -9,7 +9,7 @@
 
 Some packages are written with dependencies on Node.js built-in modules. This is a problem on the web, since Node.js built-in modules don't exist in the browser. For example, `import 'path'` will run just fine in Node.js but would fail in the browser.
 
-To solve this issue, you can either replace the offending package ([pika.dev](https://pika.dev/) is a great resource for web-friendly packages) or add Node.js polyfill support:
+**To solve this issue:** you can either replace the offending package ([pika.dev](https://pika.dev/) is a great resource for web-friendly packages) or add Node.js polyfill support:
 
 ```js
 // snowpack.config.js

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -160,7 +160,7 @@ function resolveWebDependency(dep: string): DependencyLoc {
       // Oh well, was worth a try
     }
   }
-  if (!depManifest) {
+  if (!depManifestLoc || !depManifest) {
     throw new ErrorWithHint(
       `Package "${dep}" not found. Have you installed it?`,
       depManifestLoc ? chalk.italic(depManifestLoc) : '',
@@ -199,7 +199,7 @@ function resolveWebDependency(dep: string): DependencyLoc {
   }
   return {
     type: 'JS',
-    loc: path.join(depManifestLoc || '', '..', foundEntrypoint),
+    loc: require.resolve(path.join(depManifestLoc || '', '..', foundEntrypoint)),
   };
 }
 
@@ -279,9 +279,6 @@ export async function install(
     try {
       const {type: targetType, loc: targetLoc} = resolveWebDependency(installSpecifier);
       if (targetType === 'JS') {
-        if (isSinglePackageMode && !checkIsEsModule(targetLoc)) {
-          autoDetectNamedExports.push(installSpecifier);
-        }
         installEntrypoints[targetName] = targetLoc;
         importMap.imports[installSpecifier] = `./${targetName}.js`;
         Object.entries(installAlias)

--- a/src/rollup-plugin-catch-unresolved.ts
+++ b/src/rollup-plugin-catch-unresolved.ts
@@ -19,7 +19,7 @@ export function rollupPluginCatchUnresolved(): Plugin {
       } else {
         this.warn({
           id: importer,
-          message: `"${id}" could not be resolved.`,
+          message: `"${id}" could not be resolved. (Is it installed?)`,
         });
       }
       return false;


### PR DESCRIPTION
Hope you don't mind that these are all together.

- Added: ` if (!depManifestLoc || !depManifest) {` 
  - More correct, and better for TypeScript usage
- Added: ` loc: require.resolve(...`
  - Turns out we were relying on Rollup to do this for us, and sometimes didn't pass full file paths (if `foundEntrypoint` was a partial like `index`, coming from from `"module": "index"` in a package.json).
- Removed: `autoDetectNamedExports()` auto-detection
  - This ended up being too hacky, and introduced a whole can of worms like #488 
  - Resolves #488 by removing
- Added: `(Is it installed?)` message
  - This came from a user reported issue, where Snowpack said "cannot resolve "some-package" and the user thought that it was a problem with Snowpack, and not the fact that the package was a peer dependency that hadn't been installed properly.