### PR TITLE
Add plugins list to docs

### DIFF
--- a/docs/docs/07-plugins.md
+++ b/docs/docs/07-plugins.md
@@ -2,6 +2,8 @@
 
 For more powerful integrations, Snowpack supports custom **build plugins**.  A build plugin is more than just a bash script: it's loaded via Node.js to customize and extend your Snowpack dev environment & build process. 
 
+[👀 **See supported plugins**](https://github.com/pikapkg/create-snowpack-app#official-snowpack-plugins)
+
 ### Overview
 
 A build plugin offers one of several different hooks into your application:

--- a/docs/docs/07-plugins.md
+++ b/docs/docs/07-plugins.md
@@ -2,7 +2,24 @@
 
 For more powerful integrations, Snowpack supports custom **build plugins**.  A build plugin is more than just a bash script: it's loaded via Node.js to customize and extend your Snowpack dev environment & build process. 
 
-[👀 **See supported plugins**](https://github.com/pikapkg/create-snowpack-app#official-snowpack-plugins)
+### Supported plugins
+
+#### Official plugins
+- [@snowpack/plugin-babel](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-babel)
+- [@snowpack/plugin-dotenv](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-dotenv)
+- [@snowpack/plugin-parcel](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-parcel)
+- [@snowpack/plugin-react-refresh](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-react-refresh)
+- [@snowpack/plugin-svelte](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-svelte)
+- [@snowpack/plugin-vue](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-vue)
+- [@snowpack/plugin-webpack](https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-webpack)
+
+#### Featured third-party plugins
+
+- [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
+- [snowpack-plugin-import-map](https://github.com/zhoukekestar/snowpack-plugin-import-map)
+
+Don’t see your plugin in this list? [Add yours](https://github.com/pikapkg/snowpack/pulls)!
+
 
 ### Overview
 


### PR DESCRIPTION
## Change
At first I thought about simply linking the docs to the CSA repo, but that’s not really discoverable/searchable. So instead I added the plugin list to the docs so users can find this more easily. This PR duplicates info, but I think it gives the plugins more exposure. This is how it looks:

<img width="1345" alt="Screen Shot 2020-06-16 at 9 26 03 AM" src="https://user-images.githubusercontent.com/1369770/84794581-a924f600-afb3-11ea-8359-a3c00f7d1bb9.png">

### Other Notes
I was originally thinking about having plugin documentation live here, or on the advanced plugins page. But I think this approach instead—linking to the individual plugin—lets us keep documentation in the README of each plugin instead. So snowpack.dev is just a link list, and each thing manages its own docs. I think it’s a good compromise in making snowpack.dev more searchable, without having to manage documentation in too many places.