### PR TITLE
Allow plugins to extend the extension mapping

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -103,6 +103,22 @@ If you don't include this, the user will need to define the build script themsel
 defaultBuildScript: "build:vue", // hooks into the user’s build:vue script automatically unless they manually override this
 ```
 
+### extensionMap
+
+```ts
+extensionMap?: {[ext: string]: 'js'|'html'|'css'}
+```
+
+Additional extension mappings to use during module resolution. Allows this plugin to add additional extensions that translate to formats that snowpack will rewrite to appropriate import statements.
+
+#### Example
+
+```ts
+mapping: {
+  foo: 'js'
+} // Resolves *.foo files as javascript files
+```
+
 ### build()
 
 ```ts

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import {all as merge} from 'deepmerge';
 import {EventEmitter} from 'events';
 import execa from 'execa';
 import {promises as fs} from 'fs';
@@ -25,6 +26,12 @@ import srcFileExtensionMapping from './src-file-extension-mapping';
 
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config} = commandOptions;
+
+  const configSrcFileExtensionMapping = merge<{[ext: string]: string}>([
+    {},
+    srcFileExtensionMapping,
+    config.extensionMap || {},
+  ]);
 
   // Start with a fresh install of your dependencies, for production
   commandOptions.config.installOptions.env.NODE_ENV = process.env.NODE_ENV || 'production';
@@ -252,7 +259,7 @@ export async function command(commandOptions: CommandOptions) {
         }
         let outPath = f.replace(dirDisk, dirDest);
         const extToFind = path.extname(f).substr(1);
-        const extToReplace = srcFileExtensionMapping[extToFind];
+        const extToReplace = configSrcFileExtensionMapping[extToFind];
         if (extToReplace) {
           outPath = outPath.replace(new RegExp(`${extToFind}$`), extToReplace!);
         }
@@ -303,7 +310,7 @@ export async function command(commandOptions: CommandOptions) {
                   return spec + '.js';
                 }
               }
-              const extToReplace = srcFileExtensionMapping[ext];
+              const extToReplace = configSrcFileExtensionMapping[ext];
               if (extToReplace) {
                 spec = spec.replace(new RegExp(`${ext}$`), extToReplace);
               }

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,7 @@ export interface SnowpackConfig {
   exclude: string[];
   knownEntrypoints: string[];
   webDependencies?: {[packageName: string]: string};
+  extensionMap?: {[ext: string]: 'js' | 'html' | 'css'};
   scripts: BuildScript[];
   plugins: SnowpackPlugin[];
   devOptions: {
@@ -169,6 +170,10 @@ const configSchema = {
     install: {type: 'array', items: {type: 'string'}},
     exclude: {type: 'array', items: {type: 'string'}},
     plugins: {type: 'array'},
+    extensionMap: {
+      type: 'object',
+      additionalProperties: {type: 'string'},
+    },
     webDependencies: {
       type: ['object'],
       additionalProperties: {type: 'string'},
@@ -495,6 +500,13 @@ function normalizeConfig(config: SnowpackConfig): SnowpackConfig {
     allPlugins[configPluginPath] = configPlugin;
     if (configPlugin.knownEntrypoints) {
       config.knownEntrypoints.push(...configPlugin.knownEntrypoints);
+    }
+    if (configPlugin.extensionMap) {
+      config.extensionMap = merge<{[ext: string]: 'js' | 'html' | 'css'}>([
+        {},
+        config.extensionMap || {},
+        configPlugin.extensionMap,
+      ]);
     }
     if (
       configPlugin.defaultBuildScript &&


### PR DESCRIPTION
Adding support to allow plugins to extend the extension mapping. This allows plugins to add support for new types without needing to add them to the extension core. Use case: SASS

Despite the documentation warnings, some frameworks ([vuetify](https://vuetifyjs.com)) directly import `.sass` and `.scss` files in their javascript. While working on a `snowpack-plugin-sass` to address this, I ran into the issue of `.sass` files not importing correctly. Digging through the code led me to this change, which would allow my plugin to indicate that `.sass` files produce css, and should be handled accordingly.

As `.scss` is part of the built-in mapping, I've added `.sass` for completeness.

I've also updated the plugin documentation to document this. I took a stab at describing what the new `mapping` option does, but I'm not entirely sure what lexicon you'd like to use for this.

I would be happy to add tests for this, but I didn't see anywhere obvious that plugins are tested in the current codebase. Any suggestions on where is appropriate?

Let me know if there is anything I else I can do to help. While I'm new to this project, I very much agree with it's direction and mentality and plan to use it quite a bit going forward.