### PR TITLE
Improve advanced plugin docs

### DIFF
--- a/docs/.eleventy/layouts/extend.njk
+++ b/docs/.eleventy/layouts/extend.njk
@@ -15,6 +15,47 @@ layout: layouts/base.njk
 .toc, .grid-toc-buttons, .grid-extra-space video {
   filter: hue-rotate(45deg);
 }
+.font-heading {
+  font-family: "Overpass", sans-serif;
+}
+.tc-blue { color: #267dd6; }
+.tc-green { color: #24bd65; }
+.tc-magenta { color: #b224d0; }
+.tc-text { color: #24292e; }
+.ol {
+  counter-reset: ol;
+  list-style: none;
+  padding: 0;
+}
+.ol li {
+  margin: 1em 0;
+  counter-increment: ol;
+  position: relative;
+  padding-left: 0.75rem;
+}
+.ol .ol-title {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  font-family: "Overpass", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.0625em;
+}
+.ol li::before {
+  top: -0.125em;
+  right: 100%;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  font-size: 14px;
+  font-family: "Overpass", sans-serif;
+  font-weight: 700;
+  width: 1.625em;
+  height: 1.625em;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  content: counter(ol);
+}
 </style>
 
 <div class="grid-body-header">

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,7 +2,6 @@
 layout: layouts/extend.njk
 ---
 
-
 #### Who is this page for?
 
 - Anyone writing a custom plugin for Snowpack.
@@ -10,13 +9,32 @@ layout: layouts/extend.njk
 - Anyone adding framework-specific auto-HMR.
 - Anyone using Snowpack programatically (ex: `snowpack.install()`).
 
-Looking for help using Snowpack in your project?  
+Looking for help using Snowpack in your project?
 👉 **[Check out our main docs.](/)**
+
+## Overview
+
+Snowpack runs through 3 stages internally: _build_, _transform_, and _bundle_. Snowpack plugins hook into **one** of these stages:
+
+<ol class="ol">
+  <li class="tc-green">
+    <h4 class="ol-title">Build</h4>
+    <div class="tc-text">The main action Snowpack uses. This handles most operations, such as transforming JSX to JS, or converting Sass to CSS. Every build plugin should map to an existing <a href="/#build-scripts">build script</a>.</div>
+  </li>
+  <li class="tc-blue">
+    <h4 class="ol-title">Transform</h4>
+    <div class="tc-text">This stage happens after the <strong>build</strong> step, and can be used for additional transformations if needed. This has more context since it comes later, such as which URL the module was requested at.</div>
+  </li>
+  <li class="tc-magenta">
+    <h4 class="ol-title">Bundle</h4>
+    <div class="tc-text">Optional stage that only happens when using a bundler plugin such as <a href="https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-webpack" target="_blank" rel="noopener nofollow">@snowpack/plugin-webpack</a> or <a href="https://github.com/pikapkg/create-snowpack-app/tree/master/packages/plugin-parcel" target="_blank" rel="noopener nofollow">@snowpack/plugin-parcel</a>. This passes all of Snowpack’s built files to a final bundler. <em>Note: only 1 bundler plugin can receive the final files.</em></div>
+  </li>
+</ol>
+
 
 ## Plugin API
 
 A Snowpack plugin is a JavaScript module that exports a function. That function takes Snowpack config & plugin options as it's function arguments and must return a valid Snowpack Plugin object.
-
 
 ### Example
 
@@ -31,7 +49,7 @@ module.exports = function createPlugin(snowpackConfig, pluginOptions) {
   return {
     knownEntrypoints: ['@prefresh/core'],
     /**
-     * transform() - Transform web assets (JS, CSS, or HTML). Useful for 
+     * transform() - Transform web assets (JS, CSS, or HTML). Useful for
      * post-processing or adding functionality into your web app.
      */
     async transform({ contents, urlPath, isDev }) {
@@ -57,15 +75,21 @@ module.exports = function createPlugin(snowpackConfig, pluginOptions) {
 
 ### knownEntrypoints
 
-```
+```ts
 knownEntrypoints?: string[]
 ```
 
-Additional web_modules to install in the project that may not otherwise be picked up by the install command. Similar to the "install" config value. If your plugin itself injects package imports, then put them here. 
+Additional web_modules to install in the project that may not otherwise be picked up by the install command. Similar to the "install" config value. If your plugin relies on dependencies the user may not import directly (or a necessary part of a dependency gets tree-shaken by Snowpack because the user didn’t import it), list those dependencies here.
+
+#### Example
+
+```ts
+knownEntrypoints: ["svelte/internal"], // ensures svelte/internal exists in web_modules at the end
+```
 
 ### defaultBuildScript
 
-```
+```ts
 defaultBuildScript?: string
 ```
 
@@ -73,10 +97,15 @@ The build script that will be used for this plugin, if none is provided by the u
 
 If you don't include this, the user will need to define the build script themselves for the plugin to do anything.
 
+#### Example
+
+```ts
+defaultBuildScript: "build:vue", // hooks into the user’s build:vue script automatically unless they manually override this
+```
 
 ### build()
 
-```
+```ts
 build?: async ({
   filePath: string,
   contents: string,
@@ -91,13 +120,13 @@ Build any file from source. Files can be built from any source file type, but mu
 
 The build function is run on all files that match the file extensions in the build script (or `defaultBuildScript` if none is provided by the user). The build function must return a result, or an error will be thrown. You can validate the `filePath` ahead of time if you know that you can only handle a certain set of file extensions.
 
-Note that production optimizations like minification, dead code elimination, and legacy browser transpilation are all handled automatically by Snowpack and are not a concern for plugin authors. A plugin's output should always be modern code. 
+Note that production optimizations like minification, dead code elimination, and legacy browser transpilation are all handled automatically by Snowpack and are not a concern for plugin authors. A plugin's output should always be modern code.
 
-Use `resources` if your build outputs multiple files from your one source file. For example, Svelte & Vue files output both JavaScript and CSS. Return the JS output as `result` and the CSS output as `resources.css`. Snowpack will make sure that they're handled together in your final build.  
+Use `resources` if your build outputs multiple files from your one source file. For example, Svelte & Vue files output both JavaScript and CSS. Return the JS output as `result` and the CSS output as `resources.css`. Snowpack will make sure that they're handled together in your final build.
 
 ### transform()
 
-```
+```ts
 transform?: async ({
   urlPath: string,
   contents: string,
@@ -107,16 +136,15 @@ transform?: async ({
 
 Transform an already-loaded file before it is sent to the browser. This is called for every file in your build, so be sure to test the `urlPath` extension to filter your transform by a certain file type. Return `false` to skip transforming this file.
 
-Note that production optimizations like minification, dead code elimination, and legacy browser transpilation are all handled automatically by Snowpack and are not a concern for plugin authors. A plugin's output should always be modern code. 
+Note that production optimizations like minification, dead code elimination, and legacy browser transpilation are all handled automatically by Snowpack and are not a concern for plugin authors. A plugin's output should always be modern code.
 
 #### Use Cases
 
-- Adding framework-specific HMR code, if a matching import is found. 
-
+- Adding framework-specific HMR code, if a matching import is found.
 
 ### bundle()
 
-```  
+```ts
 bundle?(args: {
   srcDirectory: string;
   destDirectory: string;
@@ -130,6 +158,18 @@ Bundle the web application for production.
 
 👉 **[Back to the main docs.](/)**
 
+## TypeScript types
+
+Building your Snowpack plugin with TypeScript? You can typecheck your plugin by importing the following type:
+
+```ts
+import { SnowpackPlugin } from 'snowpack/dist-types/config';
+
+export default function mySnowpackPlugin() {
+  const plugin: SnowpackPlugin = { /* … */ };
+  return plugin;
+}
+```
 
 ## JavaScript API
 


### PR DESCRIPTION
## Change
Adds a summary of all the build stages at the beginning.

<img width="1329" alt="Screen Shot 2020-06-17 at 9 21 43 AM" src="https://user-images.githubusercontent.com/1369770/84917303-60853f80-b07c-11ea-9be2-b0f1d26c8635.png">

At least for me, when I’m browsing the plugin docs, by the time I make it down to the `build()` and friends API, I feel like I’ve lost context. I feel that I don’t know how all these stages relate to one another.

The biggest improvement here is just the ordering, which to me clarifies the relationship and hints at when to use each.

Although I originally envisioned something like a [lifecycle flow diagram](https://stenciljs.com/docs/component-lifecycle), I think an ordered list communicates the idea better because it is a 3-step, linear process for now. If Snowpack ever had more events and/or a more complicated flow, I think we could add a cool graphic in the future.