### PR TITLE
Fix warning message bug

### DIFF
--- a/docs/docs/09-troubleshooting.md
+++ b/docs/docs/09-troubleshooting.md
@@ -23,4 +23,34 @@ module.exports = {
 };
 ```
 
+### No such file or directory
 
+If you encounter a warning message such as this:
+
+```
+ENOENT: no such file or directory, open …/node_modules/csstype/index.js
+```
+
+That may be due to the fact that there was nothing Snowpack could bundle. In the case of `csstype`, it only emits a TypeScript definition (`.d.ts`) file, so Snowpack can’t bundle it!
+
+There are 2 ways to solve this:
+
+##### Option 1: importing `type`
+
+```ts
+import type { something } from 'csstype';
+```
+
+Using the `import type` keyword is friendlier in most cases. Sometimes Snowpack can correctly determine when you’re importing TypeScript types, but sometimes it has trouble—mostly it depends on how each package is configured (and no 2 packages are alike!). Using `import type` helps.
+
+##### Option 2: manual `install`
+
+If Snowpack still is having trouble with certain packages, you can manually set `install` in `snowpack.config.js` like so:
+
+```json
+{
+  "install": ["package-one", "package-two", "package-three"]
+}
+```
+
+This isn’t ideal because now you have to maintain this list, and omit the packages that are giving you trouble. However, sometimes this is the quickest way to fix the issue.

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -384,8 +384,12 @@ export async function install(
         warning.plugin === 'snowpack:rollup-plugin-catch-unresolved'
       ) {
         // Display posix-style on all environments, mainly to help with CI :)
-        const fileName = warning.id!.replace(cwd + path.sep, '').replace(/\\/g, '/');
-        logError(`${fileName}\n   ${warning.message}`);
+        if (warning.id) {
+          const fileName = warning.id.replace(cwd + path.sep, '').replace(/\\/g, '/');
+          logError(`${fileName}\n   ${warning.message}`);
+        } else {
+          logError(`${warning.message}. See https://www.snowpack.dev/#troubleshooting`);
+        }
         return;
       }
       warn(warning);


### PR DESCRIPTION
This was a bug in the warning message display, raised here: https://www.pika.dev/npm/snowpack/discuss/373

The problem was the assertion that `warning.id!` would always be there. Sometimes, it don’t be.