### PR TITLE
Add first pass at Pipeline interface

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,166 @@
+/**
+ * 🏄‍♂️ Pipeline
+ */
+import path from 'path';
+import execa from 'execa';
+import npmRunPath from 'npm-run-path';
+import {
+  SnowpackFile,
+  SnowpackPipelineStep,
+  SnowpackPlugin,
+  SnowpackConfig,
+  SnowpackPipeline,
+} from './config';
+
+type ExtensionMap = {input: string; output?: string};
+
+/** Convert extension mappings, such as "js,ts" or "scss->css" */
+function parseExtString(ext: string): ExtensionMap[] {
+  const normalize = (s: string) => `.${s.replace(/^\./, '').trim()}`; // add initial "." if missing
+
+  // handle output extensions
+  const ARROW = '->';
+  const output = ext.split(ARROW)[1] || undefined; // the `|| undefined` is for TS
+  if (output?.includes(',')) {
+    throw new Error(`Only one output extension may be defined: ${ext}`); // throw error for things like tsx,jsx->ts,js
+  }
+
+  // separate inputs by comma & return
+  const inputs = ext.split(',').map(normalize);
+  return inputs.map((input) => ({input, output: output ? normalize(output) : undefined})); // if output exists, use it for all extensions; otherwise input === output
+}
+
+/** Rename extension */
+function renameExt(filename: string, replace: [string, string]): string {
+  const extRegEx = new RegExp(`${replace[0]}$`); // replace only the end of the filename
+  return filename.replace(extRegEx, replace[1]);
+}
+
+/** Create a new Snowpack Pipeline from a config. */
+export default class Pipeline {
+  config: SnowpackConfig;
+  isDev: boolean;
+
+  constructor({config, isDev}: {config: SnowpackConfig; isDev?: boolean}) {
+    this.config = config;
+    this.isDev = isDev || false;
+  }
+
+  /** Load a Snowpack plugin from a string or tuple */
+  loadPlugin(name: string, options: any = {}): SnowpackPlugin | undefined {
+    const config = this.config;
+
+    // internal proxy plugin (remove this when published to npm)
+    if (name === '@snowpack/plugin-proxy') {
+      return require('./plugin-proxy');
+    }
+
+    try {
+      const pluginLoc = require.resolve(name, {paths: [process.cwd()]});
+      return require(pluginLoc)(config, options);
+    } catch (err) {
+      return undefined;
+    }
+  }
+
+  /** Match a file with an existing pipeline */
+  public match(
+    filename: string,
+  ): {matched: string; replace?: [string, string]; pipeline: SnowpackPipelineStep[]} | undefined {
+    const pipeline = this.config.pipeline as SnowpackPipeline;
+
+    // note: don’t use path.extname() because that will convert things like *.proxy.js to .js
+    const allMatchers = Object.keys(pipeline);
+
+    for (let i = 0; i < allMatchers.length; i++) {
+      const matchedFiles = parseExtString(allMatchers[i]);
+      const firstMatch = matchedFiles.find(({input}) => filename.endsWith(input));
+
+      // short-circuit loop as soon as a match is found and don’t continue
+      if (firstMatch) {
+        const {input, output} = firstMatch;
+        return {
+          matched: input,
+          pipeline: pipeline[allMatchers[i]],
+          replace: output ? [input, output] : undefined,
+        };
+      }
+    }
+  }
+
+  /** Transform a file through plugins to generate a final result */
+  public async transform(input: SnowpackFile): Promise<SnowpackFile> {
+    const cwd = process.cwd();
+    const result = {...input}; // result to mutate
+
+    if (!input.filePath) {
+      throw new Error(`Couldn’t locate "${input.importPath}"`);
+    }
+
+    const match = this.match(input.filePath);
+
+    if (!match) {
+      return input; // no match; return as is
+    }
+
+    const {pipeline, replace} = match;
+
+    // for loop ensures we execute async transforms in order
+    for (let i = 0; i < pipeline.length; i++) {
+      const isLastStep = i === pipeline.length - 1;
+
+      // update extension
+      if (isLastStep && replace) {
+        result.filePath = renameExt(result.filePath, replace);
+        result.importPath = renameExt(result.importPath, replace);
+      }
+
+      const name = Array.isArray(pipeline[i]) ? pipeline[i][0] : (pipeline[i] as string);
+      const options = Array.isArray(pipeline[i]) ? pipeline[i][1] : {};
+
+      // Path A: try loading Snowpack plugin
+      const plugin = this.loadPlugin(name, options);
+      if (plugin) {
+        // 1. build()
+        if (plugin.build) {
+          const build = await plugin.build({
+            contents: result.code,
+            filePath: result.filePath,
+            isDev: this.isDev,
+          });
+          if (build) result.code = build.result;
+        }
+
+        // 2. transform()
+        if (plugin.transform) {
+          const build = await plugin.transform({
+            contents: result.code,
+            urlPath: result.importPath,
+            isDev: this.isDev,
+          });
+          if (build) result.code = build.result;
+        }
+      } else {
+        // Path B: Snowpack plugin failed; try running as CLI command
+        const {stdout, stderr} = await execa.command(name, {
+          env: {
+            ...npmRunPath.env(),
+            FILE: result.filePath,
+          },
+          input: result.code,
+          extendEnv: true,
+          shell: true,
+          cwd,
+        });
+
+        if (stderr) {
+          throw new Error(stderr);
+        }
+
+        if (stdout) result.code = stdout;
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/plugin-proxy.ts
+++ b/src/plugin-proxy.ts
@@ -1,0 +1,6 @@
+import {SnowpackPlugin} from './config';
+
+/** Internal Snowpack plugin to handle *.proxy.js files */
+const SnowpackProxyPlugin: SnowpackPlugin = {};
+
+export default SnowpackProxyPlugin;


### PR DESCRIPTION
## Change
This is the first step of an internal change for now (eventually to become an API change down the road) that will improve the plugin system, improve the way files are handled by Snowpack, and in the process provide some cleanup from the dev/build commands.

Currently, it’s not possible to run a file in Snowpack through multiple transform operations (useful in, say, Sass’ case where it’s desirable to run `sass` followed by `postcss`). Instead, we’d propose a new API (TBD) that takes the concept of **Pipelines**:

```
.jsx -> transform JS (Babel) -> minify -> .js
.react.svg -> run SVGO -> run svgr -> .svg.js
.scss -> transform Sass -> run PostCSS -> .css
```

This is an idea where every file has a series of transformations it steps through. Similar to webpack’s loaders, or even Gulp pipes. But the configuration will be simpler.

Put simply, this has always been the idea of Snowpack dev / build, so in a sense this change isn’t new. Pipelines are just an incremental step to make that concept more apparent in the codebase, as well as unlock more potential with Snowpack itself (again, like the ability to run multiple transformations in a defined order like Sass -> PostCSS or SVGO -> [svgr](https://github.com/gregberge/svgr)).

Here’s what a potential Pipeline config could look like:

```json
{
  "pipeline": {
    ".jsx,.js,.tsx,.ts": [
      "@snowpack/plugin-babel",
      "@snowpack/plugin-dotenv"
    ],
    ".module.scss->.module.css": [
      "sass --stdin",
      "postcss --config module.config.js"
    ],
    ".scss->.css": ["sass --stdin", "postcss -o $OUTPUT"],
    ".react.svg->.svg.js": ["svgo --input $FILE", "svgr"],
    ".svg": ["svgo --input $FILE"],
  }
}
```

In case this is Greek to you, I made a short [walkthrough video here](https://www.loom.com/share/4be6789547e346ad993ab49ccf702332)

### Notes

- This doesn’t actually change Snowpack’s internals (yet); it only provides the interface to
- We won’t make any breaking changes to Snowpack `2.x`; pipelines will probably end up being a new, optional config that improves `build:*` scripts and lives side-by-side until we make a major release in the future.