### PR TITLE
Cleanup the shared import resolver logic between dev & build

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -280,7 +280,7 @@ export async function command(commandOptions: CommandOptions) {
           const resolveImportSpecifier = createImportResolver({
             fileLoc,
             dependencyImportMap,
-            isBuild: true,
+            isDev: false,
             isBundled,
             config,
           });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -336,7 +336,7 @@ export async function command(commandOptions: CommandOptions) {
       const resolveImportSpecifier = createImportResolver({
         fileLoc,
         dependencyImportMap,
-        isBuild: false,
+        isDev: true,
         isBundled: false,
         config,
       });

--- a/src/commands/import-resolver.ts
+++ b/src/commands/import-resolver.ts
@@ -9,7 +9,7 @@ const URL_HAS_PROTOCOL_REGEX = /^\w:\/\./;
 interface ImportResolverOptions {
   fileLoc: string;
   dependencyImportMap: any;
-  isBuild: boolean;
+  isDev: boolean;
   isBundled: boolean;
   config: SnowpackConfig;
 }
@@ -22,7 +22,7 @@ interface ImportResolverOptions {
 export function createImportResolver({
   fileLoc,
   dependencyImportMap,
-  isBuild,
+  isDev,
   isBundled,
   config,
 }: ImportResolverOptions) {
@@ -57,13 +57,13 @@ export function createImportResolver({
       return spec;
     }
     if (dependencyImportMap.imports[spec]) {
-      let resolvedImport = isBuild
-        ? path.posix.join(
+      let resolvedImport = isDev
+        ? path.posix.resolve(webModulesLoc, dependencyImportMap.imports[spec])
+        : path.posix.join(
             config.buildOptions.baseUrl,
             webModulesLoc,
             dependencyImportMap.imports[spec],
-          )
-        : path.posix.resolve(webModulesLoc, dependencyImportMap.imports[spec]);
+          );
       const extName = path.extname(resolvedImport);
       if (!isBundled && extName && extName !== '.js') {
         resolvedImport = resolvedImport + '.proxy.js';

--- a/src/commands/import-resolver.ts
+++ b/src/commands/import-resolver.ts
@@ -1,0 +1,73 @@
+import path from 'path';
+import {SnowpackConfig} from '../config';
+import {findMatchingMountScript} from '../util';
+import {isDirectoryImport} from './build-util';
+import srcFileExtensionMapping from './src-file-extension-mapping';
+
+interface ImportResolverOptions {
+  fileLoc: string;
+  dependencyImportMap: any;
+  isBuild: boolean;
+  isBundled: boolean;
+  config: SnowpackConfig;
+}
+
+/**
+ * Create a import resolver function, which converts any import relative to the given file at "fileLoc"
+ * to a proper URL. Returns false if no matching import was found, which usually indicates a package
+ * not found in the import map.
+ */
+export function createImportResolver({
+  fileLoc,
+  dependencyImportMap,
+  isBuild,
+  isBundled,
+  config,
+}: ImportResolverOptions) {
+  const webModulesScript = config.scripts.find((script) => script.id === 'mount:web_modules');
+  const webModulesLoc = webModulesScript ? webModulesScript.args.toUrl : '/web_modules';
+
+  return function importResolver(spec: string): string | false {
+    if (spec.startsWith('http')) {
+      return spec;
+    }
+    let mountScript = findMatchingMountScript(config.scripts, spec);
+    if (mountScript) {
+      let {fromDisk, toUrl} = mountScript.args;
+      spec = spec.replace(fromDisk, toUrl);
+    }
+    if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
+      const ext = path.extname(spec).substr(1);
+      if (!ext) {
+        if (isDirectoryImport(fileLoc, spec)) {
+          return spec + '/index.js';
+        } else {
+          return spec + '.js';
+        }
+      }
+      const extToReplace = srcFileExtensionMapping[ext];
+      if (extToReplace) {
+        spec = spec.replace(new RegExp(`${ext}$`), extToReplace);
+      }
+      if (!isBundled && (extToReplace || ext) !== 'js') {
+        spec = spec + '.proxy.js';
+      }
+      return spec;
+    }
+    if (dependencyImportMap.imports[spec]) {
+      let resolvedImport = isBuild
+        ? path.posix.join(
+            config.buildOptions.baseUrl,
+            webModulesLoc,
+            dependencyImportMap.imports[spec],
+          )
+        : path.posix.resolve(webModulesLoc, dependencyImportMap.imports[spec]);
+      const extName = path.extname(resolvedImport);
+      if (!isBundled && extName && extName !== '.js') {
+        resolvedImport = resolvedImport + '.proxy.js';
+      }
+      return resolvedImport;
+    }
+    return false;
+  };
+}

--- a/src/commands/import-resolver.ts
+++ b/src/commands/import-resolver.ts
@@ -4,6 +4,8 @@ import {findMatchingMountScript} from '../util';
 import {isDirectoryImport} from './build-util';
 import srcFileExtensionMapping from './src-file-extension-mapping';
 
+const URL_HAS_PROTOCOL_REGEX = /^\w:\/\./;
+
 interface ImportResolverOptions {
   fileLoc: string;
   dependencyImportMap: any;
@@ -28,7 +30,7 @@ export function createImportResolver({
   const webModulesLoc = webModulesScript ? webModulesScript.args.toUrl : '/web_modules';
 
   return function importResolver(spec: string): string | false {
-    if (spec.startsWith('http')) {
+    if (URL_HAS_PROTOCOL_REGEX.test(spec)) {
       return spec;
     }
     let mountScript = findMatchingMountScript(config.scripts, spec);


### PR DESCRIPTION
- Cleans up some ugly copy-paste code between dev & build import resolution.
- Cleans up some special treatment of css modules that turned out to be unnecessary.
- Tested on CSA React (with and without CSS modules) to confirm no bad changes to dev.
- Sets us up to now feel safer going forward and make changes to this logic, if needed.

