### PR TITLE
Run optimized dependency install after build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches: 
       - master
   pull_request:
-    branches: 
-      - master
 
 jobs:
   build:

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -60,6 +60,9 @@ export async function command(commandOptions: CommandOptions) {
 
   for (const workerConfig of config.scripts) {
     const {id, type, match} = workerConfig;
+    // web_modules dependencies are now installed directly into the build directory,
+    // instead of being copied like a traditional mount. This is required until we
+    // move the "web_modules" destination configuration out of the "scripts" config.
     if (id === 'mount:web_modules') {
       continue;
     }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -26,7 +26,7 @@ import {paint} from './paint';
 import srcFileExtensionMapping from './src-file-extension-mapping';
 
 async function installOptimizedDependencies(
-  allBuiltJsFiles: [string, string][],
+  allBuiltJsFiles: {outLoc: string, code: string}[],
   installDest: string,
   commandOptions: CommandOptions,
 ) {
@@ -39,7 +39,7 @@ async function installOptimizedDependencies(
     },
   });
   // 1. Scan imports from your final built JS files.
-  const installTargets = await getInstallTargets(installConfig, allBuiltJsFiles);
+  const installTargets = await getInstallTargets(installConfig, allBuiltJsFiles.map(({outLoc, code})=> [outLoc, code]));
   // 2. Install dependencies, based on the scan of your final build.
   const installResult = await installRunner(
     {...commandOptions, config: installConfig},
@@ -240,7 +240,7 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   const allBuiltFromFiles = new Set<string>();
-  const allBuiltJsFiles: [string, string, string][] = [];
+  const allBuiltJsFiles: {outLoc: string, code: string, fileLoc: string}[] = [];
   for (const workerConfig of relevantWorkers) {
     const {id, match, type} = workerConfig;
     if (type !== 'build' || match.length === 0) {
@@ -259,11 +259,11 @@ export async function command(commandOptions: CommandOptions) {
         if (!fileBuilder) {
           continue;
         }
-        let outPath = fileLoc.replace(dirDisk, dirDest);
+        let outLoc = fileLoc.replace(dirDisk, dirDest);
         const extToFind = path.extname(fileLoc).substr(1);
         const extToReplace = srcFileExtensionMapping[extToFind];
         if (extToReplace) {
-          outPath = outPath.replace(new RegExp(`${extToFind}$`), extToReplace!);
+          outLoc = outLoc.replace(new RegExp(`${extToFind}$`), extToReplace!);
         }
 
         const builtFile = await fileBuilder({
@@ -275,7 +275,7 @@ export async function command(commandOptions: CommandOptions) {
           continue;
         }
         let {result: code, resources} = builtFile;
-        const urlPath = outPath.substr(dirDest.length + 1);
+        const urlPath = outLoc.substr(dirDest.length + 1);
         for (const plugin of config.plugins) {
           if (plugin.transform) {
             code =
@@ -288,18 +288,18 @@ export async function command(commandOptions: CommandOptions) {
         }
 
         allBuiltFromFiles.add(fileLoc);
-        if (path.extname(outPath) === '.js') {
+        if (path.extname(outLoc) === '.js') {
           if (resources?.css) {
-            const cssOutPath = outPath.replace(/.js$/, '.css');
+            const cssOutPath = outLoc.replace(/.js$/, '.css');
             await fs.mkdir(path.dirname(cssOutPath), {recursive: true});
             await fs.writeFile(cssOutPath, resources.css);
             code = `import './${path.basename(cssOutPath)}';\n` + code;
           }
           code = wrapImportMeta({code, env: true, hmr: false, config});
-          allBuiltJsFiles.push([outPath, code, fileLoc]);
+          allBuiltJsFiles.push({outLoc, code, fileLoc});
         } else {
-          await fs.mkdir(path.dirname(outPath), {recursive: true});
-          await fs.writeFile(outPath, code);
+          await fs.mkdir(path.dirname(outLoc), {recursive: true});
+          await fs.writeFile(outLoc, code);
         }
       }
     }
@@ -311,7 +311,7 @@ export async function command(commandOptions: CommandOptions) {
   const webModulesPath = installWorker.args.toUrl;
   const installDest = path.join(buildDirectoryLoc, webModulesPath);
   const installResult = await installOptimizedDependencies(
-    (allBuiltJsFiles as any) as [string, string][],
+    allBuiltJsFiles,
     installDest,
     commandOptions,
   );
@@ -320,7 +320,7 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   const allProxiedFiles = new Set<string>();
-  for (const [outLoc, code, fileLoc] of allBuiltJsFiles) {
+  for (const {outLoc, code, fileLoc} of allBuiltJsFiles) {
     const resolveImportSpecifier = createImportResolver({
       fileLoc,
       webModulesPath,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import {Plugin as RollupPlugin} from 'rollup';
 import yargs from 'yargs-parser';
 import {esbuildPlugin} from './commands/esbuildPlugin';
-import {BUILD_DEPENDENCIES_DIR, DEV_DEPENDENCIES_DIR} from './util';
+import {DEV_DEPENDENCIES_DIR} from './util';
 
 const CONFIG_NAME = 'snowpack';
 const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/.types/**/*'];
@@ -315,9 +315,7 @@ function handleLegacyProxyScripts(config: any) {
 }
 
 type RawScripts = Record<string, string>;
-function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
-  const dependenciesLoc =
-    process.env.NODE_ENV === 'production' ? BUILD_DEPENDENCIES_DIR : DEV_DEPENDENCIES_DIR;
+export function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
   const processedScripts: BuildScript[] = [];
   if (Object.keys(scripts).filter((k) => k.startsWith('bundle:')).length > 1) {
     handleConfigError(`scripts can only contain 1 script of type "bundle:".`);
@@ -360,9 +358,9 @@ function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
       const dirUrl = to || `/${cmdArr[0]}`;
 
       // mount:web_modules is a special case script where the fromDisk
-      // arg is harcoded to match the internal dependency dir
+      // arg is hard-coded to match the internal dependency directory.
       if (scriptId === 'mount:web_modules') {
-        dirDisk = dependenciesLoc;
+        dirDisk = DEV_DEPENDENCIES_DIR;
       }
 
       newScriptConfig.args = {
@@ -394,7 +392,7 @@ function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
       match: ['web_modules'],
       cmd: `mount $WEB_MODULES --to /web_modules`,
       args: {
-        fromDisk: dependenciesLoc,
+        fromDisk: DEV_DEPENDENCIES_DIR,
         toUrl: '/web_modules',
       },
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -315,7 +315,7 @@ function handleLegacyProxyScripts(config: any) {
 }
 
 type RawScripts = Record<string, string>;
-export function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
+function normalizeScripts(cwd: string, scripts: RawScripts): BuildScript[] {
   const processedScripts: BuildScript[] = [];
   if (Object.keys(scripts).filter((k) => k.startsWith('bundle:')).length > 1) {
     handleConfigError(`scripts can only contain 1 script of type "bundle:".`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,6 @@ export const BUILD_CACHE = path.join(GLOBAL_CACHE_DIR, 'build-cache-1.4');
 
 export const PROJECT_CACHE_DIR = projectCacheDir({name: 'snowpack'});
 export const DEV_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, 'dev');
-export const BUILD_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, 'build');
 const LOCKFILE_HASH_FILE = '.hash';
 
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;


### PR DESCRIPTION
Resolves #475, based on #525 

This PR solves all of the tree-shaking issues we've seen since adding it back into Snowpack, mainly around `import {TSType}` and some of the more custom compile-to-JS languages like Svelte & Vue where the compiler adds imports that our current source code scanner never sees.

### This replaces our current build workflow:
1. Install dependencies into a temporary directory (tree-shaking based off the incomplete source code)
1. Copy temp dependencies directory into your build directory
1. Build your source files, resolve dependency imports, and write to disk

### With a new, more explicit workflow:
1. Built your source files (not yet resolving imports or saving to disk)
1. Pass these in-memory built files to our installer for tree-shaking analysis
1. Install dependencies directly into build, with tree-shaking based off of complete built source code
1. Now that we have installed dependencies, resolve your imports.
1. Save files to disk.

As a happy bonus, running install as a part of the build means that its output isn't immediately hidden by the first paint of dashboard. Install logs now show up in the Console portion of the dashboard. As a follow-up, we should make this its own section (`▼ Install Optimized Dependencies`).

Somewhat related: this feels like the final nail in the coffin for representing "where will we install web_modules?" inside of a "mount" script. Now that we have replaced our old "install-then-copy" with an "install directly into build dir", "mounting" this already-fake directory makes even less sense. I think it's time to treat "web_modules" as the special concept that it is, and give it its own "buildOptions.webModulesPath" configuration.


