### PR TITLE
Add better external matching support

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -98,6 +98,10 @@ function formatInstallResults(): string {
     .join(', ');
 }
 
+function isImportOfPackage(importUrl: string, packageName: string) {
+  return packageName === importUrl || importUrl.startsWith(packageName + '/');
+}
+
 /**
  * Formats the snowpack dependency name from a "webDependencies" input value:
  * 2. Remove any ".js"/".mjs" extension (will be added automatically by Rollup)
@@ -271,7 +275,10 @@ export async function install(
   }
   const allInstallSpecifiers = new Set(
     installTargets
-      .filter((dep) => !externalPackages.includes(dep.specifier))
+      .filter(
+        (dep) =>
+          !externalPackages.some((packageName) => isImportOfPackage(dep.specifier, packageName)),
+      )
       .map((dep) => dep.specifier)
       .map((specifier) => installAlias[specifier] || specifier)
       .sort(),
@@ -349,7 +356,7 @@ export async function install(
   let isCircularImportFound = false;
   const inputOptions: InputOptions = {
     input: installEntrypoints,
-    external: externalPackages,
+    external: (id) => externalPackages.some((packageName) => isImportOfPackage(id, packageName)),
     treeshake: {moduleSideEffects: 'no-external'},
     plugins: [
       rollupPluginReplace(getRollupReplaceKeys(env)),

--- a/test/integration/config-external/expected-install/import-map.json
+++ b/test/integration/config-external/expected-install/import-map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "mock-test-package-a": "./mock-test-package-a.js"
+  }
+}

--- a/test/integration/config-external/expected-install/mock-test-package-a.js
+++ b/test/integration/config-external/expected-install/mock-test-package-a.js
@@ -1,0 +1,4 @@
+import { foo } from 'mock-test-package-b';
+import { foo as foo$1 } from 'mock-test-package-b/entrypoint';
+
+console.log(foo, foo$1);

--- a/test/integration/config-external/expected-output.txt
+++ b/test/integration/config-external/expected-output.txt
@@ -1,0 +1,3 @@
+✔ snowpack install complete.
+  ⦿ web_modules/               size       gzip       brotli
+    └─ mock-test-package-a.js    XXXX KB    XXXX KB    XXXX KB

--- a/test/integration/config-external/mock-test-package/entrypoint.js
+++ b/test/integration/config-external/mock-test-package/entrypoint.js
@@ -1,0 +1,4 @@
+module.exports = {
+    export1: 'foo',
+    export2: 'bar',
+};

--- a/test/integration/config-external/mock-test-package/package.json
+++ b/test/integration/config-external/mock-test-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-test-package",
+  "version": "1.2.3",
+  "main":  "entrypoint.js"
+}

--- a/test/integration/config-external/node_modules/mock-test-package-a/entrypoint.js
+++ b/test/integration/config-external/node_modules/mock-test-package-a/entrypoint.js
@@ -1,0 +1,3 @@
+import {foo} from 'mock-test-package-b';
+import {foo as foo_} from 'mock-test-package-b/entrypoint';
+console.log(foo, foo_);

--- a/test/integration/config-external/node_modules/mock-test-package-a/package.json
+++ b/test/integration/config-external/node_modules/mock-test-package-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-test-package-a",
+  "version": "1.2.3",
+  "module":  "entrypoint.js"
+}

--- a/test/integration/config-external/node_modules/mock-test-package-b/entrypoint.js
+++ b/test/integration/config-external/node_modules/mock-test-package-b/entrypoint.js
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/test/integration/config-external/node_modules/mock-test-package-b/package.json
+++ b/test/integration/config-external/node_modules/mock-test-package-b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-test-package-b",
+  "version": "1.2.3",
+  "module":  "entrypoint.js"
+}

--- a/test/integration/config-external/package.json
+++ b/test/integration/config-external/package.json
@@ -1,0 +1,16 @@
+{
+  "description": "Handle external packages",
+  "scripts": {
+    "TEST": "node ../../../pkg/dist-node/index.bin.js"
+  },
+  "snowpack": {
+    "installOptions": {
+      "externalPackage": ["mock-test-package-b"]
+    },
+    "install": ["mock-test-package-a"]
+  },
+  "dependencies": {
+    "mock-test-package-a": "^1.0.0",
+    "mock-test-package-b": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Similar to #450, externals only match the exact string instead of the package. Since we pass this in via `--external-package`, this doesn't really make much sense for our usecase. 

```
import 'foo'; // Matched
import 'foo/bar'; // Not Matched
```

This PR moves to the function form of Rollup `externals` so that we can match by package name, and makes sure that our own matching logic does the same.