### PR TITLE
Only allow HTTP2 without proxies

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -840,23 +840,20 @@ export async function command(commandOptions: CommandOptions) {
     request: http2.Http2ServerRequest,
     response: http2.Http2ServerResponse,
   ) => void;
-  const createServer = async (requestHandler: http.RequestListener | Http2RequestListener) => {
+  const createServer = (requestHandler: http.RequestListener | Http2RequestListener) => {
     if (credentials && config.proxy.length === 0) {
-      const {createSecureServer} = http2;
-      return createSecureServer(
+      return http2.createSecureServer(
         {...credentials!, allowHTTP1: true},
         requestHandler as Http2RequestListener,
       );
     } else if (credentials) {
-      const {createServer} = https;
-      return createServer(credentials, requestHandler as http.RequestListener);
+      return https.createServer(credentials, requestHandler as http.RequestListener);
     }
 
-    const {createServer} = http;
-    return createServer(requestHandler as http.RequestListener);
+    return http.createServer(requestHandler as http.RequestListener);
   };
 
-  const server = await createServer(async (req, res) => {
+  const server = createServer(async (req, res) => {
     try {
       return await requestHandler(req, res);
     } catch (err) {
@@ -864,9 +861,7 @@ export async function command(commandOptions: CommandOptions) {
       console.error(err);
       return sendError(res, 500);
     }
-  });
-
-  server
+  })
     .on('error', (err: Error) => {
       console.error(colors.red(`  ✘ Failed to start server at port ${colors.bold(port)}.`), err);
       server.close();

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -31,9 +31,10 @@ import merge from 'deepmerge';
 import {EventEmitter} from 'events';
 import execa from 'execa';
 import {existsSync, promises as fs, readFileSync} from 'fs';
-import type http from 'http';
+import http from 'http';
+import https from 'https';
 import HttpProxy from 'http-proxy';
-import type http2 from 'http2';
+import http2 from 'http2';
 import * as colors from 'kleur/colors';
 import mime from 'mime-types';
 import npmRunPath from 'npm-run-path';
@@ -841,17 +842,17 @@ export async function command(commandOptions: CommandOptions) {
   ) => void;
   const createServer = async (requestHandler: http.RequestListener | Http2RequestListener) => {
     if (credentials && config.proxy.length === 0) {
-      const {createSecureServer} = await import('http2');
+      const {createSecureServer} = http2;
       return createSecureServer(
         {...credentials!, allowHTTP1: true},
         requestHandler as Http2RequestListener,
       );
     } else if (credentials) {
-      const {createServer} = await import('https');
+      const {createServer} = https;
       return createServer(credentials, requestHandler as http.RequestListener);
     }
 
-    const {createServer} = await import('http');
+    const {createServer} = http;
     return createServer(requestHandler as http.RequestListener);
   };
 


### PR DESCRIPTION
Fixes #516 

If `secure` flag and `proxy` config is passed, we will fallback to HTTPS since we can't currently proxy HTTP2 requests.

If `secure` flag and no `proxy` config is passed, we will continue to serve using HTTP2.

And fallback to using HTTP1.


I switched it to not load `http`, `https` and `http2` for every instance of the dev server running. Instead, I moved it to dynamically load the lib based on the above cases. I didn't notice any significant load time difference in a quick check. However, if you would prefer just load them all at the top, I have a stashed commit with those changes and can quickly push that. 