### PR TITLE
Fix CSS Svelte import

### DIFF
--- a/src/commands/import-resolver.ts
+++ b/src/commands/import-resolver.ts
@@ -31,7 +31,7 @@ function resolveSourceSpecifier(spec: string, stats: Stats | false, isBundled: b
   if (stats && stats.isDirectory()) {
     const trailingSlash = spec.endsWith('/') ? '' : '/';
     spec = spec + trailingSlash + 'index.js';
-  } else if (!stats && !spec.endsWith('.js')) {
+  } else if (!stats && !spec.endsWith('.js') && !spec.endsWith('.css')) {
     spec = spec + '.js';
   }
   const {baseExt} = getExt(spec);


### PR DESCRIPTION
Resolves: https://github.com/pikapkg/create-snowpack-app/issues/162

## Changes

In v2.6.0, we added new import resolution logic that would add a `.js` extension to any import that it couldn't find on disk. This was to support imports that had no JS file extension, but  it looks like thi broke Svelte support since the CSS file created by Svelte doesn't actually exist on disk.

Drew has confirmed that his larger plugin work will fix this in a much more robust way, so I'm fine making this little one-off fix to solve the immediate issue for Svelte.

## Testing

@drwpow are you adding Svelte & Vue tests to Snowpack as a part of your plugin work? If not, let's prioritize a separate PR to add.