### PR TITLE
fix(HTML_JS_REGEX): avoid transform commented inline script tag

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,7 @@ const LOCKFILE_HASH_FILE = '.hash';
 
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 // NOTE(fks): Must match empty script elements to work properly.
-export const HTML_JS_REGEX = /(<script.*?>)(.*?)<\/script>/gms;
+export const HTML_JS_REGEX = /(<script.*?type="?module"?.*?>)(.*?)<\/script>/gms;
 
 export interface ImportMap {
   imports: {[packageName: string]: string};

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,7 @@ const LOCKFILE_HASH_FILE = '.hash';
 
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 // NOTE(fks): Must match empty script elements to work properly.
-export const HTML_JS_REGEX = /(<script.*?>)(.*?)<\/script>/gms;
+export const HTML_JS_REGEX = /(?<!<!--.*?)(<script.*?type="?module"?.*?>)(.*?)<\/script>(?!.*?-->)/gms;
 
 export interface ImportMap {
   imports: {[packageName: string]: string};

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,7 @@ const LOCKFILE_HASH_FILE = '.hash';
 
 export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 // NOTE(fks): Must match empty script elements to work properly.
-export const HTML_JS_REGEX = /(?<!<!--.*?)(<script.*?type="?module"?.*?>)(.*?)<\/script>(?!.*?-->)/gms;
+export const HTML_JS_REGEX = /(<script.*?type="?module"?.*?>)(.*?)<\/script>/gms;
 
 export interface ImportMap {
   imports: {[packageName: string]: string};


### PR DESCRIPTION
## Changes
Original `HTML_JS_REGEX` will match commented inline script tag (example 1) and `type=script` script tag (example 2), then try to transform the inline code, which should not be transformed. Thus, change `HTML_JS_REGEX` to not match commented inline script tag (example 1) and `type=script` script tag (example 2)
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Before:
```
const HTML_JS_REGEX=/(<script.*?>)(.*?)<\/script>/gms
```
After:
```
const HTML_JS_REGEX = /(?<!<!--.*?)(<script.*?type="?module"?.*?>)(.*?)<\/script>(?!.*?-->)/gms;
```

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Test:
```
const HTML_JS_REGEX_AFTER = /(?<!<!--.*?)(<script.*?type="?module"?.*?>)(.*?)<\/script>(?!.*?-->)/gms;
const HTML_JS_REGEX_BEFORE=/(<script.*?>)(.*?)<\/script>/gms

// example 1
const html1=`<!-- <script type="module" src="http://example.com" crossorigin="anonymous">import 'hello'</script> -->`
// example 2
const html2=`<script type="script" src="http://example.com" crossorigin="anonymous"></script>`

const html3=`<script type="module" src="http://example.com" crossorigin="anonymous"></script>`


console.log(HTML_JS_REGEX_BEFORE.exec(html1))
HTML_JS_REGEX_BEFORE.lastIndex=0
console.log(HTML_JS_REGEX_BEFORE.exec(html2))
HTML_JS_REGEX_BEFORE.lastIndex=0
console.log(HTML_JS_REGEX_BEFORE.exec(html3))
console.log(HTML_JS_REGEX_AFTER.exec(html1))
HTML_JS_REGEX_AFTER.lastIndex=0
console.log(HTML_JS_REGEX_AFTER.exec(html2))
HTML_JS_REGEX_AFTER.lastIndex=0
console.log(HTML_JS_REGEX_AFTER.exec(html3))
```
Results:
```
[
  `<script type="module" src="http://example.com" crossorigin="anonymous">import 'hello'</script>`,
  '<script type="module" src="http://example.com" crossorigin="anonymous">',
  "import 'hello'",
  index: 5,
  input: `<!-- <script type="module" src="http://example.com" crossorigin="anonymous">import 'hello'</script> -->`,
  groups: undefined
]
[
  '<script type="script" src="http://example.com" crossorigin="anonymous"></script>',
  '<script type="script" src="http://example.com" crossorigin="anonymous">',
  '',
  index: 0,
  input: '<script type="script" src="http://example.com" crossorigin="anonymous"></script>',
  groups: undefined
]
[
  '<script type="module" src="http://example.com" crossorigin="anonymous"></script>',
  '<script type="module" src="http://example.com" crossorigin="anonymous">',
  '',
  index: 0,
  input: '<script type="module" src="http://example.com" crossorigin="anonymous"></script>',
  groups: undefined
]
null
null
[
  '<script type="module" src="http://example.com" crossorigin="anonymous"></script>',
  '<script type="module" src="http://example.com" crossorigin="anonymous">',
  '',
  index: 0,
  input: '<script type="module" src="http://example.com" crossorigin="anonymous"></script>',
  groups: undefined
]

```

