### PR TITLE
Refactor Plugin API

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,25 +1,24 @@
 import merge from 'deepmerge';
 import {EventEmitter} from 'events';
-import execa from 'execa';
 import {promises as fs} from 'fs';
 import glob from 'glob';
 import * as colors from 'kleur/colors';
 import mkdirp from 'mkdirp';
-import npmRunPath from 'npm-run-path';
 import path from 'path';
 import rimraf from 'rimraf';
-import {BuildScript, SnowpackBuildMap} from '../config';
+import {SnowpackBuildMap} from '../config';
+import {stopEsbuild} from '../plugins/plugin-esbuild';
 import {transformFileImports} from '../rewrite-imports';
 import {printStats} from '../stats-formatter';
-import {CommandOptions, getExt} from '../util';
+import {CommandOptions, getEncodingType, getExt, replaceExt} from '../util';
 import {
+  buildFile,
   generateEnvModule,
-  getFileBuilderForWorker,
   wrapCssModuleResponse,
   wrapEsmProxyResponse,
+  wrapHtmlResponse,
   wrapImportMeta,
 } from './build-util';
-import {stopEsbuild} from './esbuildPlugin';
 import {createImportResolver} from './import-resolver';
 import {getInstallTargets, run as installRunner} from './install';
 import {paint} from './paint';
@@ -59,49 +58,14 @@ async function installOptimizedDependencies(
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config} = commandOptions;
   const messageBus = new EventEmitter();
-  const relevantWorkers: BuildScript[] = [];
-  const allBuildExtensions: string[] = [];
 
-  for (const workerConfig of config.scripts) {
-    const {id, type, match} = workerConfig;
-    // web_modules dependencies are now installed directly into the build directory,
-    // instead of being copied like a traditional mount. This is required until we
-    // move the "web_modules" destination configuration out of the "scripts" config.
-    if (id === 'mount:web_modules') {
-      continue;
-    }
-    if (type === 'build' || type === 'run' || type === 'mount' || type === 'bundle') {
-      relevantWorkers.push(workerConfig);
-    }
-    if (type === 'build') {
-      allBuildExtensions.push(...match);
-    }
-  }
-
-  let bundleWorker = config.scripts.find((s) => s.type === 'bundle');
-  let installWorker = config.scripts.find((s) => s.id === 'mount:web_modules')!;
   const isBundledHardcoded = config.devOptions.bundle !== undefined;
-  const isBundled = isBundledHardcoded ? !!config.devOptions.bundle : !!bundleWorker;
-  if (!bundleWorker) {
-    bundleWorker = {
-      id: 'bundle:*',
-      type: 'bundle',
-      match: ['*'],
-      cmd: '',
-      watch: undefined,
-    };
-    relevantWorkers.push(bundleWorker);
-  }
-
+  const bundlerPlugin = config._bundler;
+  const isBundled = isBundledHardcoded ? !!config.devOptions.bundle : !!bundlerPlugin;
+  const bundlerDashboardId = bundlerPlugin ? bundlerPlugin.name : 'bundle';
   const buildDirectoryLoc = isBundled ? path.join(cwd, `.build`) : config.devOptions.out;
   const internalFilesBuildLoc = path.join(buildDirectoryLoc, config.buildOptions.metaDir);
   const finalDirectoryLoc = config.devOptions.out;
-
-  if (config.scripts.length <= 1) {
-    console.error(colors.red(`No build scripts found, so nothing to build.`));
-    console.error(`See https://www.snowpack.dev/#build-scripts for help getting started.`);
-    return;
-  }
 
   rimraf.sync(buildDirectoryLoc);
   mkdirp.sync(buildDirectoryLoc);
@@ -124,207 +88,118 @@ export async function command(commandOptions: CommandOptions) {
   if (!relDest.startsWith(`..${path.sep}`)) {
     relDest = `.${path.sep}` + relDest;
   }
-  paint(messageBus, relevantWorkers, {dest: relDest}, undefined);
+  paint(
+    messageBus,
+    config.plugins.map((p) => p.name),
+    {dest: relDest},
+    undefined,
+  );
 
   if (!isBundled) {
     messageBus.emit('WORKER_UPDATE', {
-      id: bundleWorker.id,
+      id: bundlerDashboardId,
       state: ['SKIP', 'dim'],
     });
   }
 
-  for (const workerConfig of relevantWorkers) {
-    const {id, type} = workerConfig;
-    if (type !== 'run') {
-      continue;
+  for (const runPlugin of config.plugins) {
+    if (runPlugin.run) {
+      messageBus.emit('WORKER_START', {id: runPlugin.name});
+      runPlugin
+        .run({
+          isDev: false,
+          log: (msg, data) => {
+            messageBus.emit(msg, {...data, id: runPlugin.name});
+          },
+        })
+        .then(() => {
+          messageBus.emit('WORKER_COMPLETE', {id: runPlugin.name, error: null});
+        })
+        .catch((err) => {
+          messageBus.emit('WORKER_COMPLETE', {id: runPlugin.name, error: err});
+        });
     }
-    messageBus.emit('WORKER_UPDATE', {id, state: ['RUNNING', 'yellow']});
-    const workerPromise = execa.command(workerConfig.cmd, {
-      env: npmRunPath.env(),
-      extendEnv: true,
-      shell: true,
-      cwd,
-    });
-    workerPromise.catch((err) => {
-      messageBus.emit('WORKER_MSG', {id, level: 'error', msg: err.toString()});
-      messageBus.emit('WORKER_COMPLETE', {id, error: err});
-    });
-    workerPromise.then(() => {
-      messageBus.emit('WORKER_COMPLETE', {id, error: null});
-    });
-    const {stdout, stderr} = workerPromise;
-    stdout?.on('data', (b) => {
-      let stdOutput = b.toString();
-      if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
-        messageBus.emit('WORKER_RESET', {id});
-        stdOutput = stdOutput.replace(/\x1Bc/, '').replace(/\u001bc/, '');
-      }
-      if (id.endsWith(':tsc')) {
-        if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
-          messageBus.emit('WORKER_UPDATE', {id, state: ['RUNNING', 'yellow']});
-        }
-        if (/Watching for file changes./gm.test(stdOutput)) {
-          messageBus.emit('WORKER_UPDATE', {id, state: 'WATCHING'});
-        }
-        const errorMatch = stdOutput.match(/Found (\d+) error/);
-        if (errorMatch && errorMatch[1] !== '0') {
-          messageBus.emit('WORKER_UPDATE', {id, state: ['ERROR', 'red']});
-        }
-      }
-      messageBus.emit('WORKER_MSG', {id, level: 'log', msg: stdOutput});
-    });
-    stderr?.on('data', (b) => {
-      messageBus.emit('WORKER_MSG', {id, level: 'error', msg: b.toString()});
-    });
-    await workerPromise;
   }
 
   // Write the `import.meta.env` contents file to disk
   await fs.writeFile(path.join(internalFilesBuildLoc, 'env.js'), generateEnvModule('production'));
 
-  const mountDirDetails: any[] = relevantWorkers
-    .map((scriptConfig) => {
-      const {id, type, args} = scriptConfig;
-      if (id === 'mount:web_modules') {
-        return false;
-      }
-      if (type !== 'mount') {
-        return false;
-      }
-      const dirDisk = path.resolve(cwd, args.fromDisk);
-      const dirDest = path.resolve(buildDirectoryLoc, args.toUrl.replace(/^\//, ''));
-      return [id, dirDisk, dirDest];
-    })
-    .filter(Boolean);
-
   const includeFileSets: [string, string, string[]][] = [];
-  for (const [id, dirDisk, dirDest] of mountDirDetails) {
-    messageBus.emit('WORKER_UPDATE', {id, state: ['RUNNING', 'yellow']});
-    let allFiles;
-    try {
-      allFiles = glob.sync(`**/*`, {
-        ignore: config.exclude,
-        cwd: dirDisk,
-        absolute: true,
-        nodir: true,
-        dot: true,
-      });
-      const allBuildNeededFiles: string[] = [];
-      await Promise.all(
-        allFiles.map(async (f) => {
-          f = path.resolve(f); // this is necessary since glob.sync() returns paths with / on windows.  path.resolve() will switch them to the native path separator.
-          const {baseExt} = getExt(f);
-          if (
-            allBuildExtensions.includes(baseExt) ||
-            baseExt === '.jsx' ||
-            baseExt === '.tsx' ||
-            baseExt === '.ts' ||
-            baseExt === '.js'
-          ) {
-            allBuildNeededFiles.push(f);
-            return;
-          }
-          const outPath = f.replace(dirDisk, dirDest);
-          mkdirp.sync(path.dirname(outPath));
-
-          // replace %PUBLIC_URL% in HTML files
-          if (baseExt === '.html') {
-            let code = await fs.readFile(f, 'utf8');
-            code = code.replace(/%PUBLIC_URL%\/?/g, config.buildOptions.baseUrl);
-            return fs.writeFile(outPath, code, 'utf8');
-          }
-          return fs.copyFile(f, outPath);
-        }),
-      );
-      includeFileSets.push([dirDisk, dirDest, allBuildNeededFiles]);
-      messageBus.emit('WORKER_COMPLETE', {id});
-    } catch (err) {
-      messageBus.emit('WORKER_MSG', {id, level: 'error', msg: err.toString()});
-      messageBus.emit('WORKER_COMPLETE', {id, error: err});
-    }
+  for (const [fromDisk, toUrl] of Object.entries(config._mountedDirs)) {
+    const dirDisk = path.resolve(cwd, fromDisk);
+    const dirDest = path.resolve(buildDirectoryLoc, toUrl.replace(/^\//, ''));
+    const allFiles = glob.sync(`**/*`, {
+      ignore: config.exclude,
+      cwd: dirDisk,
+      absolute: true,
+      nodir: true,
+      dot: true,
+    });
+    const allBuildNeededFiles: string[] = [];
+    await Promise.all(
+      allFiles.map(async (f) => {
+        f = path.resolve(f); // this is necessary since glob.sync() returns paths with / on windows.  path.resolve() will switch them to the native path separator.
+        allBuildNeededFiles.push(f);
+      }),
+    );
+    includeFileSets.push([dirDisk, dirDest, allBuildNeededFiles]);
   }
 
   const allBuiltFromFiles = new Set<string>();
   const allFilesToResolveImports: SnowpackBuildMap = {};
-  for (const workerConfig of relevantWorkers) {
-    const {id, match, type} = workerConfig;
-    if (type !== 'build' || match.length === 0) {
-      continue;
-    }
 
-    messageBus.emit('WORKER_UPDATE', {id, state: ['RUNNING', 'yellow']});
-    for (const [dirDisk, dirDest, allFiles] of includeFileSets) {
-      for (const locOnDisk of allFiles) {
-        const inputExt = getExt(locOnDisk);
-        if (!match.includes(inputExt.baseExt) && !match.includes(inputExt.expandedExt)) {
-          continue;
-        }
-        const fileContents = await fs.readFile(locOnDisk, {encoding: 'utf8'});
-        let fileBuilder = getFileBuilderForWorker(cwd, workerConfig, messageBus);
-        if (!fileBuilder) {
-          continue;
-        }
-        let outLoc = locOnDisk.replace(dirDisk, dirDest);
-        const extToReplace = srcFileExtensionMapping[inputExt.baseExt];
-        if (extToReplace) {
-          outLoc = outLoc.replace(new RegExp(`\\${inputExt.baseExt}$`), extToReplace!);
-        }
-
-        const builtFile = await fileBuilder({
-          contents: fileContents,
-          filePath: locOnDisk,
-          isDev: false,
-        });
-        if (!builtFile) {
-          continue;
-        }
-        let {result: code, resources} = builtFile;
-        const urlPath = outLoc.substr(dirDest.length + 1);
-        for (const plugin of config.plugins) {
-          if (plugin.transform) {
-            code =
-              (await plugin.transform({contents: fileContents, urlPath, isDev: false}))?.result ||
-              code;
+  for (const [dirDisk, dirDest, allFiles] of includeFileSets) {
+    for (const locOnDisk of allFiles) {
+      const {baseExt: fileExt} = getExt(locOnDisk);
+      let outLoc = locOnDisk.replace(dirDisk, dirDest);
+      let builtLocOnDisk = locOnDisk;
+      const extToReplace = srcFileExtensionMapping[fileExt];
+      if (extToReplace) {
+        outLoc = replaceExt(outLoc, extToReplace);
+        builtLocOnDisk = replaceExt(builtLocOnDisk, extToReplace);
+      }
+      const fileContents = await fs.readFile(locOnDisk, getEncodingType(extToReplace || fileExt));
+      const builtFileOutput = await buildFile(locOnDisk, fileContents, {
+        buildPipeline: config.plugins,
+        messageBus,
+        isDev: false,
+      });
+      allBuiltFromFiles.add(locOnDisk);
+      const {baseExt, expandedExt} = getExt(outLoc);
+      let contents = builtFileOutput[builtLocOnDisk]?.contents;
+      if (!contents) {
+        continue;
+      }
+      const cssBuildPath = builtLocOnDisk.replace(/.js$/, '.css');
+      const cssOutPath = outLoc.replace(/.js$/, '.css');
+      mkdirp.sync(path.dirname(outLoc));
+      switch (baseExt) {
+        case '.js': {
+          if (builtFileOutput[cssBuildPath]) {
+            await fs.mkdir(path.dirname(cssOutPath), {recursive: true});
+            await fs.writeFile(cssOutPath, builtFileOutput[cssBuildPath].contents, 'utf8');
+            contents = `import './${path.basename(cssOutPath)}';\n` + contents;
           }
+          contents = wrapImportMeta({code: contents, env: true, hmr: false, config});
+          allFilesToResolveImports[outLoc] = {baseExt, expandedExt, contents, locOnDisk};
+          break;
         }
-        if (!code) {
-          continue;
-        }
-
-        allBuiltFromFiles.add(locOnDisk);
-
-        const {baseExt, expandedExt} = getExt(outLoc);
-        switch (baseExt) {
-          case '.js': {
-            if (resources?.css) {
-              const cssOutPath = outLoc.replace(/.js$/, '.css');
-              await fs.mkdir(path.dirname(cssOutPath), {recursive: true});
-              await fs.writeFile(cssOutPath, resources.css);
-              code = `import './${path.basename(cssOutPath)}';\n` + code;
-            }
-            code = wrapImportMeta({code, env: true, hmr: false, config});
-            allFilesToResolveImports[outLoc] = {baseExt, expandedExt, code, locOnDisk};
-            break;
-          }
-          case '.html': {
-            allFilesToResolveImports[outLoc] = {baseExt, expandedExt, code, locOnDisk};
-            break;
-          }
-          default: {
-            await fs.mkdir(path.dirname(outLoc), {recursive: true});
-            await fs.writeFile(outLoc, code);
-            break;
-          }
+        case '.html': {
+          contents = wrapHtmlResponse({
+            code: contents,
+            hasHmr: false,
+            buildOptions: config.buildOptions,
+          });
+          allFilesToResolveImports[outLoc] = {baseExt, expandedExt, contents, locOnDisk};
+          break;
         }
       }
+      await fs.writeFile(outLoc, contents, getEncodingType(baseExt));
     }
-    messageBus.emit('WORKER_COMPLETE', {id, error: null});
   }
-
   stopEsbuild();
 
-  const webModulesPath = installWorker.args.toUrl;
-  const installDest = path.join(buildDirectoryLoc, webModulesPath);
+  const installDest = path.join(buildDirectoryLoc, config._webModulesPath);
   const installResult = await installOptimizedDependencies(
     allFilesToResolveImports,
     installDest,
@@ -338,7 +213,7 @@ export async function command(commandOptions: CommandOptions) {
   for (const [outLoc, file] of Object.entries(allFilesToResolveImports)) {
     const resolveImportSpecifier = createImportResolver({
       fileLoc: file.locOnDisk!, // we’re confident these are reading from disk because we just read them
-      webModulesPath,
+      webModulesPath: config._webModulesPath,
       dependencyImportMap: installResult.importMap,
       isDev: false,
       isBundled,
@@ -366,9 +241,9 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   for (const proxiedFileLoc of allProxiedFiles) {
-    const proxiedCode = await fs.readFile(proxiedFileLoc, {encoding: 'utf8'});
     const proxiedExt = path.extname(proxiedFileLoc);
-    const proxiedUrl = proxiedFileLoc.substr(buildDirectoryLoc.length).replace(/\\/g, '/'); // replace backslashes on Windows
+    const proxiedCode = await fs.readFile(proxiedFileLoc, getEncodingType(proxiedExt));
+    const proxiedUrl = proxiedFileLoc.substr(buildDirectoryLoc.length).replace(/\\/g, '/');
     const proxyCode = proxiedFileLoc.endsWith('.module.css')
       ? await wrapCssModuleResponse({
           url: proxiedUrl,
@@ -383,18 +258,18 @@ export async function command(commandOptions: CommandOptions) {
           config,
         });
     const proxyFileLoc = proxiedFileLoc + '.proxy.js';
-    await fs.writeFile(proxyFileLoc, proxyCode, {encoding: 'utf8'});
+    await fs.writeFile(proxyFileLoc, proxyCode, getEncodingType('.js'));
   }
 
   if (!isBundled) {
-    messageBus.emit('WORKER_COMPLETE', {id: bundleWorker.id, error: null});
+    messageBus.emit('WORKER_COMPLETE', {id: bundlerDashboardId, error: null});
     messageBus.emit('WORKER_UPDATE', {
-      id: bundleWorker.id,
+      id: bundlerDashboardId,
       state: ['SKIP', isBundledHardcoded ? 'dim' : 'yellow'],
     });
     if (!isBundledHardcoded) {
       messageBus.emit('WORKER_MSG', {
-        id: bundleWorker.id,
+        id: bundlerDashboardId,
         level: 'log',
         msg:
           `"plugins": ["@snowpack/plugin-webpack"]\n\n` +
@@ -402,25 +277,30 @@ export async function command(commandOptions: CommandOptions) {
           colors.dim(`Set "devOptions.bundle" configuration to false to remove this message.`),
       });
     }
+  } else if (!bundlerPlugin) {
+    messageBus.emit('WORKER_COMPLETE', {
+      id: bundlerDashboardId,
+      error: new Error('No bundler plugin connected.'),
+    });
   } else {
     try {
-      messageBus.emit('WORKER_UPDATE', {id: bundleWorker.id, state: ['RUNNING', 'yellow']});
-      await bundleWorker?.plugin!.bundle!({
+      messageBus.emit('WORKER_UPDATE', {id: bundlerDashboardId, state: ['RUNNING', 'yellow']});
+      await bundlerPlugin.bundle!({
         srcDirectory: buildDirectoryLoc,
         destDirectory: finalDirectoryLoc,
         jsFilePaths: allBuiltFromFiles,
         log: (msg) => {
-          messageBus.emit('WORKER_MSG', {id: bundleWorker!.id, level: 'log', msg});
+          messageBus.emit('WORKER_MSG', {id: bundlerDashboardId, level: 'log', msg});
         },
       });
-      messageBus.emit('WORKER_COMPLETE', {id: bundleWorker.id, error: null});
+      messageBus.emit('WORKER_COMPLETE', {id: bundlerDashboardId, error: null});
     } catch (err) {
       messageBus.emit('WORKER_MSG', {
-        id: bundleWorker.id,
+        id: bundlerDashboardId,
         level: 'error',
         msg: err.toString(),
       });
-      messageBus.emit('WORKER_COMPLETE', {id: bundleWorker.id, error: err});
+      messageBus.emit('WORKER_COMPLETE', {id: bundlerDashboardId, error: err});
     }
   }
 

--- a/src/commands/paint.ts
+++ b/src/commands/paint.ts
@@ -1,9 +1,9 @@
 import detectPort from 'detect-port';
 import {EventEmitter} from 'events';
 import * as colors from 'kleur/colors';
+import path from 'path';
 import readline from 'readline';
 import util from 'util';
-import {BuildScript} from '../config';
 import {isYarn} from '../util';
 const cwd = process.cwd();
 
@@ -65,11 +65,17 @@ function getStateString(workerState: any, isWatch: boolean): [colors.Colorize, s
   return [colors.dim, 'READY'];
 }
 
-const WORKER_BASE_STATE = {done: false, error: null, output: ''};
+interface WorkerState {
+  done: boolean;
+  state: null | [string, string];
+  error: null | Error;
+  output: string;
+}
+const WORKER_BASE_STATE: WorkerState = {done: false, error: null, state: null, output: ''};
 
 export function paint(
   bus: EventEmitter,
-  registeredWorkers: BuildScript[],
+  scripts: string[],
   buildMode: {dest: string} | undefined,
   devMode:
     | {
@@ -86,10 +92,17 @@ export function paint(
   let isInstalling = false;
   let hasBeenCleared = false;
   let missingWebModule: null | {id: string; spec: string; pkgName: string} = null;
-  const allWorkerStates: any = {};
+  const allWorkerStates: Record<string, WorkerState> = {};
+  const allFileBuilds = new Set<string>();
 
-  for (const config of registeredWorkers) {
-    allWorkerStates[config.id] = {...WORKER_BASE_STATE, config};
+  for (const script of scripts) {
+    allWorkerStates[script] = {...WORKER_BASE_STATE};
+  }
+
+  function setupWorker(id: string) {
+    if (!allWorkerStates[id]) {
+      allWorkerStates[id] = {...WORKER_BASE_STATE};
+    }
   }
 
   function repaint() {
@@ -98,11 +111,12 @@ export function paint(
     // Dashboard
     if (devMode) {
       const isServerStarted = startTimeMs > 0 && port > 0 && protocol;
+
       if (isServerStarted) {
         process.stdout.write(`  ${colors.bold(colors.cyan(`${protocol}//localhost:${port}`))}`);
         for (const ip of ips) {
           process.stdout.write(
-            `${colors.cyan(` > `)}${colors.bold(colors.cyan(`${protocol}//${ip}:${port}`))}`,
+            `${colors.cyan(` • `)}${colors.bold(colors.cyan(`${protocol}//${ip}:${port}`))}`,
           );
         }
         process.stdout.write('\n');
@@ -111,6 +125,9 @@ export function paint(
             startTimeMs < 1000 ? `  Server started in ${startTimeMs}ms.` : `  Server started.`, // Not to hide slow startup times, but likely there were extraneous factors (prompts, etc.) where the speed isn’t accurate
           ),
         );
+        if (allFileBuilds.size > 0) {
+          process.stdout.write(colors.dim(` Building...`));
+        }
         process.stdout.write('\n\n');
       } else {
         process.stdout.write(colors.dim(`  Server starting…`) + '\n\n');
@@ -121,22 +138,22 @@ export function paint(
       process.stdout.write(colors.dim(` Building your application...\n\n`));
     }
 
-    for (const config of registeredWorkers) {
-      if (devMode && config.type === 'bundle') {
+    let didPrintDashboard = false;
+    for (const [script, workerState] of Object.entries(allWorkerStates)) {
+      if (!workerState.state) {
         continue;
       }
-      const workerState = allWorkerStates[config.id];
-      const dotLength = 24 - config.id.length;
+      const dotLength = 34 - script.length;
       const dots = colors.dim(''.padEnd(dotLength, '.'));
       const [fmt, stateString] = getStateString(workerState, !!devMode);
-      const spacer = ' '; //.padEnd(8 - stateString.length);
-      let cmdMsg = `${config.plugin && config.cmd[0] !== '(' ? '(plugin) ' : ''}${config.cmd}`;
-      if (cmdMsg.length > 52) {
-        cmdMsg = cmdMsg.substr(0, 52) + '...';
-      }
-      const cmdStr = stateString === 'FAIL' ? colors.red(cmdMsg) : colors.dim(cmdMsg);
-      process.stdout.write(`  ${config.id}${dots}[${fmt(stateString)}]${spacer}${cmdStr}\n`);
+      process.stdout.write(`  ${script}${dots}[${fmt(stateString)}]\n`);
+      didPrintDashboard = true;
     }
+
+    if (didPrintDashboard) {
+      process.stdout.write('\n');
+    }
+
     process.stdout.write('\n');
     if (isInstalling) {
       process.stdout.write(`${colors.underline(colors.bold('▼ snowpack install'))}\n\n`);
@@ -166,11 +183,10 @@ export function paint(
       }
       return;
     }
-    for (const config of registeredWorkers) {
-      const workerState = allWorkerStates[config.id];
-      if (workerState && workerState.output) {
+    for (const [script, workerState] of Object.entries(allWorkerStates)) {
+      if (workerState.output) {
         const colorsFn = Array.isArray(workerState.error) ? colors.red : colors.reset;
-        process.stdout.write(`${colorsFn(colors.underline(colors.bold('▼ ' + config.id)))}\n\n`);
+        process.stdout.write(`${colorsFn(colors.underline(colors.bold('▼ ' + script)))}\n\n`);
         process.stdout.write(
           workerState.output
             ? '  ' + workerState.output.trim().replace(/\n/gm, '\n  ')
@@ -192,14 +208,12 @@ export function paint(
       );
       process.stdout.write('\n\n');
     }
-    const overallStatus: any = Object.values(allWorkerStates).reduce(
-      (result: any, {done, error}: any) => {
-        return {
-          done: result.done && done,
-          error: result.error || error,
-        };
-      },
-    );
+    const overallStatus = Object.values(allWorkerStates).reduce((result, {done, error}) => {
+      return {
+        done: result.done && done,
+        error: result.error || error,
+      } as any;
+    });
     if (overallStatus.error) {
       process.stdout.write(`${colors.underline(colors.red(colors.bold('▼ Result')))}\n\n`);
       process.stdout.write('  ⚠️  Finished, with errors.');
@@ -212,24 +226,39 @@ export function paint(
     }
   }
 
+  bus.on('BUILD_FILE', ({id, isBuilding}) => {
+    if (isBuilding) {
+      allFileBuilds.add(path.relative(cwd, id));
+    } else {
+      allFileBuilds.delete(path.relative(cwd, id));
+    }
+    repaint();
+  });
+  bus.on('WORKER_START', ({id, state}) => {
+    setupWorker(id);
+    allWorkerStates[id].state = state || ['RUNNING', 'yellow'];
+    repaint();
+  });
   bus.on('WORKER_MSG', ({id, msg}) => {
+    setupWorker(id);
     allWorkerStates[id].output += msg;
     repaint();
   });
   bus.on('WORKER_UPDATE', ({id, state}) => {
     if (typeof state !== undefined) {
+      setupWorker(id);
       allWorkerStates[id].state = state;
     }
     repaint();
   });
   bus.on('WORKER_COMPLETE', ({id, error}) => {
-    allWorkerStates[id].state = null;
+    allWorkerStates[id].state = ['DONE', 'green'];
     allWorkerStates[id].done = true;
     allWorkerStates[id].error = allWorkerStates[id].error || error;
     repaint();
   });
   bus.on('WORKER_RESET', ({id}) => {
-    allWorkerStates[id] = {...WORKER_BASE_STATE, config: allWorkerStates[id].config};
+    allWorkerStates[id] = {...WORKER_BASE_STATE};
     repaint();
   });
   bus.on('CONSOLE', ({level, args}) => {
@@ -249,11 +278,11 @@ export function paint(
       hasBeenCleared = true;
     }
     // Reset all per-file build scripts
-    for (const config of registeredWorkers) {
-      if (config.type === 'build') {
-        allWorkerStates[config.id] = {
+    for (const script of scripts) {
+      if (script.startsWith('build')) {
+        setupWorker(script);
+        allWorkerStates[script] = {
           ...WORKER_BASE_STATE,
-          config: allWorkerStates[config.id].config,
         };
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
-import path from 'path';
 import * as colors from 'kleur/colors';
+import path from 'path';
 import yargs from 'yargs-parser';
+import {addCommand, rmCommand} from './commands/add-rm';
 import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
-import {addCommand, rmCommand} from './commands/add-rm';
 import {command as installCommand} from './commands/install';
 import {CLIFlags, loadAndValidateConfig} from './config.js';
-import {readLockfile, clearCache} from './util.js';
+import {clearCache, readLockfile} from './util.js';
 
-export {createConfiguration} from './config.js';
 export {install as unstable_installCommand} from './commands/install';
+export {createConfiguration} from './config.js';
 
 const cwd = process.cwd();
 

--- a/src/plugins/plugin-build-script.ts
+++ b/src/plugins/plugin-build-script.ts
@@ -1,0 +1,42 @@
+import execa from 'execa';
+import npmRunPath from 'npm-run-path';
+const cwd = process.cwd();
+
+export function buildScriptPlugin({
+  input,
+  output,
+  cmd,
+}: {
+  input: string[];
+  output: string[];
+  cmd: string;
+}) {
+  if (output.length !== 1) {
+    throw new Error('Requires one output.');
+  }
+  return {
+    name: `build:${cmd.split(' ')[0]}`,
+    input: input,
+    output: output,
+    async build({contents, filePath, log}) {
+      const cmdWithFile = cmd.replace('$FILE', filePath);
+      try {
+        const {stdout, stderr} = await execa.command(cmdWithFile, {
+          env: npmRunPath.env(),
+          extendEnv: true,
+          shell: true,
+          input: contents,
+          cwd,
+        });
+        if (stderr) {
+          log('WORKER_MSG', {level: 'warn', msg: stderr});
+        }
+        return {[output[0]]: stdout};
+      } catch (err) {
+        log('WORKER_MSG', {level: 'error', msg: err.stderr});
+        log('WORKER_UPDATE', {state: ['ERROR', 'red']});
+        return null;
+      }
+    },
+  };
+}

--- a/src/plugins/plugin-esbuild.ts
+++ b/src/plugins/plugin-esbuild.ts
@@ -1,13 +1,19 @@
 import {Service, startService} from 'esbuild';
 import * as colors from 'kleur/colors';
 import path from 'path';
-import {SnowpackPluginBuildResult} from '../config';
-import {checkIsPreact} from './build-util';
 
 let esbuildService: Service | null = null;
 
-export function esbuildPlugin() {
+const IS_PREACT = /from\s+['"]preact['"]/;
+export function checkIsPreact(filePath: string, contents: string) {
+  return filePath.endsWith('.jsx') && IS_PREACT.test(contents);
+}
+
+export function esbuildPlugin({input}: {input: string[]}) {
   return {
+    name: '@snowpack/plugin-esbuild',
+    input,
+    output: ['.js'],
     async build({contents, filePath}) {
       esbuildService = esbuildService || (await startService());
       const isPreact = checkIsPreact(filePath, contents);
@@ -20,7 +26,7 @@ export function esbuildPlugin() {
         console.error(colors.bold('! ') + filePath);
         console.error('  ' + warning.text);
       }
-      return {result: js || ''} as SnowpackPluginBuildResult;
+      return {'.js': js || ''};
     },
   };
 }

--- a/src/plugins/plugin-run-script.ts
+++ b/src/plugins/plugin-run-script.ts
@@ -1,0 +1,49 @@
+import execa from 'execa';
+import npmRunPath from 'npm-run-path';
+const cwd = process.cwd();
+
+export function runScriptPlugin({cmd, watch: _watchCmd}: {cmd: string; watch?: string}) {
+  const cmdProgram = cmd.split(' ')[0];
+  const watchCmd = _watchCmd && _watchCmd.replace('$1', cmd);
+
+  return {
+    name: `run:${cmdProgram}`,
+    input: [],
+    output: [],
+    async run({isDev, log}) {
+      const workerPromise = execa.command(isDev ? watchCmd || cmd : cmd, {
+        env: npmRunPath.env(),
+        extendEnv: true,
+        shell: true,
+        cwd,
+      });
+      const {stdout, stderr} = workerPromise;
+      stdout?.on('data', (b) => {
+        let stdOutput = b.toString();
+        if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
+          log('WORKER_RESET', {});
+          log('WORKER_UPDATE', {state: ['RUNNING', 'yellow']});
+          stdOutput = stdOutput.replace(/\x1Bc/, '').replace(/\u001bc/, '');
+        }
+        if (cmdProgram === 'tsc') {
+          if (/Watching for file changes./gm.test(stdOutput)) {
+            log('WORKER_UPDATE', {state: ['RUNNING', 'yellow']});
+          }
+          const errorMatch = stdOutput.match(/Found (\d+) error/);
+          if (errorMatch) {
+            if (errorMatch[1] === '0') {
+              log('WORKER_UPDATE', {state: ['OK', 'green']});
+            } else {
+              log('WORKER_UPDATE', {state: ['ERROR', 'red']});
+            }
+          }
+        }
+        log('WORKER_MSG', {level: 'log', msg: stdOutput});
+      });
+      stderr?.on('data', (b) => {
+        log('WORKER_MSG', {level: 'error', msg: b.toString()});
+      });
+      return workerPromise;
+    },
+  };
+}

--- a/src/rewrite-imports.ts
+++ b/src/rewrite-imports.ts
@@ -65,14 +65,14 @@ async function transformHtmlImports(code: string, replaceImport: (specifier: str
 }
 
 export async function transformFileImports(
-  {baseExt, code}: SnowpackSourceFile,
+  {baseExt, contents}: SnowpackSourceFile,
   replaceImport: (specifier: string) => string,
 ) {
   if (baseExt === '.js') {
-    return transformEsmImports(code, replaceImport);
+    return transformEsmImports(contents, replaceImport);
   }
   if (baseExt === '.html') {
-    return transformHtmlImports(code, replaceImport);
+    return transformHtmlImports(contents, replaceImport);
   }
   throw new Error(
     `Incompatible filetype: cannot scan ${baseExt} files for ESM imports. This is most likely an error within Snowpack.`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import rimraf from 'rimraf';
 import cacache from 'cacache';
 import globalCacheDir from 'cachedir';
 import etag from 'etag';
@@ -7,15 +6,22 @@ import projectCacheDir from 'find-cache-dir';
 import findUp from 'find-up';
 import fs from 'fs';
 import got, {CancelableRequest, Response} from 'got';
+import mkdirp from 'mkdirp';
 import open from 'open';
 import path from 'path';
-import {SnowpackConfig, BuildScript} from './config';
-import mkdirp from 'mkdirp';
+import rimraf from 'rimraf';
+import {SnowpackConfig} from './config';
 
 export const PIKA_CDN = `https://cdn.pika.dev`;
 export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
+
+// A note on cache naming/versioning: We currently version our global caches
+// with the version of the last breaking change. This allows us to re-use the
+// same cache across versions until something in the data structure changes.
+// At that point, bump the version in the cache name to create a new unique
+// cache name.
 export const RESOURCE_CACHE = path.join(GLOBAL_CACHE_DIR, 'pkg-cache-1.4');
-export const BUILD_CACHE = path.join(GLOBAL_CACHE_DIR, 'build-cache-1.4');
+export const BUILD_CACHE = path.join(GLOBAL_CACHE_DIR, 'build-cache-2.6');
 
 export const PROJECT_CACHE_DIR = projectCacheDir({name: 'snowpack'});
 export const DEV_DEPENDENCIES_DIR = path.join(PROJECT_CACHE_DIR, 'dev');
@@ -38,6 +44,11 @@ export interface CommandOptions {
 
 export function isYarn(cwd: string) {
   return fs.existsSync(path.join(cwd, 'yarn.lock'));
+}
+
+const UTF8_FORMATS = ['.css', '.html', '.js', '.json', '.svg', '.txt', '.xml'];
+export function getEncodingType(ext: string): 'utf-8' | 'binary' {
+  return UTF8_FORMATS.includes(ext) ? 'utf-8' : 'binary';
 }
 
 export async function readLockfile(cwd: string): Promise<ImportMap | null> {
@@ -232,7 +243,10 @@ export async function clearCache() {
  * `mount ./src --to /_dist_` and `mount src --to /_dist_` match `src/components/Button`
  * `mount src --to /_dist_` does not match `package/components/Button`
  */
-export function findMatchingMountScript(scripts: BuildScript[], spec: string) {
+export function findMatchingMountScript(
+  scripts: Record<string, string>,
+  spec: string,
+): [string, string] | null | undefined {
   // Only match bare module specifiers. relative and absolute imports should not match
   if (
     spec.startsWith('./') ||
@@ -243,9 +257,7 @@ export function findMatchingMountScript(scripts: BuildScript[], spec: string) {
   ) {
     return null;
   }
-  return scripts
-    .filter((script) => script.type === 'mount')
-    .find(({args}) => spec.startsWith(args.fromDisk));
+  return Object.entries(scripts).find(([fromDisk]) => spec.startsWith(fromDisk));
 }
 
 /** Get full extensions of files */
@@ -256,4 +268,15 @@ export function getExt(fileName: string) {
     /** full extension, if applicable (e.g. `.proxy.js`) */
     expandedExt: path.basename(fileName).replace(/[^.]+/, '').toLocaleLowerCase(),
   };
+}
+
+/** Replace file extensions */
+export function replaceExt(
+  fileName: string,
+  newExtension: string,
+  replaceExpandedExt: boolean = false,
+): string {
+  const {baseExt, expandedExt} = getExt(fileName);
+  const extToReplace = new RegExp(`\\${replaceExpandedExt ? expandedExt : baseExt}$`, 'i');
+  return fileName.replace(extToReplace, newExtension);
 }

--- a/test/build/resolve-imports/expected-build/_dist_/components/index.js
+++ b/test/build/resolve-imports/expected-build/_dist_/components/index.js
@@ -1,4 +1,3 @@
 import sort2 from "../sort.js";
 console.log(sort2);
-
 export default "Button";

--- a/test/build/resolve-imports/expected-build/_dist_/index.html
+++ b/test/build/resolve-imports/expected-build/_dist_/index.html
@@ -10,28 +10,27 @@
     <script type="module" src="/_dist_/index.js"></script>
     <script type="module">
       // Path aliases
-      import {flatten} from 'array-flatten';
+      import {flatten} from '/web_modules/array-flatten.js';
       console.log(flatten);
 
       // Importing a file
-      import sort from './sort'; // relative import
-      import sort_ from 'src/sort'; // bare import using mount
-      import sort__ from 'src/sort.js'; // bare import using mount + extension
+      import sort from './sort.js'; // relative import
+      import sort_ from '/_dist_/sort.js'; // bare import using mount
+      import sort__ from '/_dist_/sort.js'; // bare import using mount + extension
       console.log(sort, sort_, sort__);
 
       // Importing a directory index.js file
-      import components from './components'; // relative import 
-      import components_ from './components/index'; // relative import with index appended
+      import components from './components/index.js'; // relative import 
+      import components_ from './components/index.js'; // relative import with index appended
       import components__ from './components/index.js'; // relative import with index appended
-      import components___ from 'src/components'; // bare import using mount
-      import components____ from 'src/components/index'; // bare import using mount and index appended
-      import components_____ from 'src/components/index.js'; // bare import using mount and index.js appended
+      import components___ from '/_dist_/components/index.js'; // bare import using mount
+      import components____ from '/_dist_/components/index.js'; // bare import using mount and index appended
+      import components_____ from '/_dist_/components/index.js'; // bare import using mount and index.js appended
       console.log(components, components_, components__, components___, components____, components_____);
 
-
       // Importing something that isn't JS
-      import styles from './components/style.css'; // relative import 
-      import styles_ from 'src/components/style.css'; // relative import 
+      import styles from './components/style.css.proxy.js'; // relative import 
+      import styles_ from '/_dist_/components/style.css.proxy.js'; // relative import 
       console.log(styles, styles_);
     </script>
   </body>


### PR DESCRIPTION
## Background

See @drwpow's writeup here on the current limitations we face in our current build engine: https://github.com/pikapkg/snowpack/pull/562. These issues affects everyone: maintainers, plugin authors, and users.

## New Plugin API

> Based on @drwpow's original writeup in #562

```ts
export interface SnowpackPlugin {
  /** name of the plugin */
  name: string;
  /** file extensions this plugin takes as input (e.g. [".jsx", ".js", …]) */
  input: string[];
  /** file extensions this plugin outputs (e.g. [".js", ".css"]) */
  output: string[];
  /** transform input to output */
  build?(BuildOptions): Promise<BuildResult>;
  /** bundle  */
  bundle?(BundleOptions): Promise<void>;
}
```

Significant changes/features:

- **Plugins control inputs and outputs.**
  - Examples:
    - Babel plugin: `input: ['.js', '.jsx', '.ts', .tsx'], output: ['.js']`
    - Svelte: `input: ['.svelte'], output: ['.js', '.css']`
    - Vue: `input: ['.vue'], output: ['.js', '.css']`
  - This allows Snowpack to _deterministically_ predict the build pipeline in synchronous time without having to wait for any plugins to execute. It also lets plugins output multiple files, if they need to.
  - This also empowers plugins to resolve files in the dev server (e.g. the Svelte plugin can tell Snowpack that a `.css` file might come from a `.svelte` file, and how to access that). This takes a ton of resolution responsibility away from Snowpack, and onto the plugins that know how to handle these files.
- **Plugins can chain together.** Now, multiple plugins can handle `.js` files, and we’ll process them in the order in which they appear in the `plugins` array in Snowpack config.
- **Build scripts expressed as plugins.** Our custom syntax for "build:" & "run:" required more mental overhead than anticipated. This new change sets the stage to unify everything in the "plugins" array and introduce new plugins for connecting Bash commands (existing build scripts) via plugin.
- **It’s backwards-compatible**. This doesn’t break existing `script` API for Snowpack, which we’ll need to support through `2.x`. It also doesn’t break the current plugin API, though we will work through upgrading our own plugins, updating docs, and reaching out to third-party plugin authors to make this change.

There are also some QoL changes as well:
- **`transform()` has been removed.** Just for simplicity—now everything’s a `build()` (except for `bundle()`, but that’ll only apply to bundling plugins like webpack’s and Parcel’s). This just helps plugin authors deal with less complexity.
- **Bug fixes and perf improvements** uncovered in all this cleanup, especially related to large dependencies like react-dom. - **The dev/build dashboard has been simplified** to reflect this new unified approach to plugins.

Overall, we’re hoping this change makes Snowpack more powerful, more accurate, and more fun to write plugins for.

## Testing

Existing tests cover everything that we're aware of. Drew is working on better Snapshot testing in CSA, which should help test this as well (given how big of a change this is).