### PR TITLE
fix bundler plugin usage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -439,7 +439,11 @@ function loadPlugins(
   config.plugins.forEach((ref) => {
     const pluginName = Array.isArray(ref) ? ref[0] : ref;
     const pluginOptions = Array.isArray(ref) ? ref[1] : {};
-    plugins.push(loadPluginFromConfig(pluginName, pluginOptions));
+    const plugin = loadPluginFromConfig(pluginName, pluginOptions);
+    if (plugin.bundle) {
+      bundler = plugin;
+    }
+      plugins.push(plugin);
   });
 
   // if no mounted directories, mount root


### PR DESCRIPTION
## Changes

Quick followup to #567. We missed the use of a bundler plugin.

## Testing

No time to add a test now, but this should have been caught by manual testing. 
Now that we have this better plugin system, we can add some plugin-related build tests in a future PR.
