### PR TITLE
Add react-dom/server.js as synthetic CJS package

### DIFF
--- a/docs/docs/03-main-concepts.md
+++ b/docs/docs/03-main-concepts.md
@@ -42,7 +42,7 @@ After Snowpack builds your dependencies, any package can be imported and run dir
 <!-- This runs directly in the browser with `snowpack dev` -->
 <body>
   <script type='module'>
-    import * as React from 'react';
+    import React from 'react';
     console.log(React);
   </script>
 </body>

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -61,6 +61,7 @@ class ErrorWithHint extends Error {
 const CJS_PACKAGES_TO_AUTO_DETECT = [
   'react/index.js',
   'react-dom/index.js',
+  'react-dom/server.js',
   'react-is/index.js',
   'prop-types/index.js',
   'scheduler/index.js',


### PR DESCRIPTION
## Changes

From the discussion here: https://www.pika.dev/npm/snowpack/discuss/433, I realized we don’t auto-detect `react-dom/server` like we do `react-dom`. This adds one to the list.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
