### PR TITLE
Fix for resolving meta dir path to respect baseUrl configuration

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -121,10 +121,10 @@ export function wrapImportMeta({
   }
   return (
     (hmr
-      ? `import * as  __SNOWPACK_HMR__ from '/${buildOptions.metaDir}/hmr.js';\nimport.meta.hot = __SNOWPACK_HMR__.createHotContext(import.meta.url);\n`
+      ? `import * as  __SNOWPACK_HMR__ from '${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/hmr.js';\nimport.meta.hot = __SNOWPACK_HMR__.createHotContext(import.meta.url);\n`
       : ``) +
     (env
-      ? `import __SNOWPACK_ENV__ from '/${buildOptions.metaDir}/env.js';\nimport.meta.env = __SNOWPACK_ENV__;\n`
+      ? `import __SNOWPACK_ENV__ from '${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/env.js';\nimport.meta.env = __SNOWPACK_ENV__;\n`
       : ``) +
     '\n' +
     code
@@ -151,7 +151,7 @@ export async function wrapCssModuleResponse({
   return `${
     hasHmr
       ? `
-import * as __SNOWPACK_HMR_API__ from '/${buildOptions.metaDir}/hmr.js';
+import * as __SNOWPACK_HMR_API__ from '${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/hmr.js';
 import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
 import.meta.hot.accept(({module}) => {
   code = module.code;
@@ -187,7 +187,7 @@ export function wrapHtmlResponse({
   code = code.replace(/\/?%PUBLIC_URL%\/?/g, buildOptions.baseUrl);
 
   if (hasHmr) {
-    code += `<script type="module" src="/${buildOptions.metaDir}/hmr.js"></script>`;
+    code += `<script type="module" src="${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/hmr.js"></script>`;
   }
   return code;
 }
@@ -209,7 +209,7 @@ export function wrapEsmProxyResponse({
     return `${
       hasHmr
         ? `
-    import * as __SNOWPACK_HMR_API__ from '/${buildOptions.metaDir}/hmr.js';
+    import * as __SNOWPACK_HMR_API__ from '${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/hmr.js';
     import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
     import.meta.hot.accept(({module}) => {
       json = module.default;
@@ -224,7 +224,7 @@ export default json;`;
     return `${
       hasHmr
         ? `
-import * as __SNOWPACK_HMR_API__ from '/${buildOptions.metaDir}/hmr.js';
+import * as __SNOWPACK_HMR_API__ from '${buildOptions.baseUrl.replace(/\/$/, '')}/${buildOptions.metaDir}/hmr.js';
 import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
 import.meta.hot.accept();
 import.meta.hot.dispose(() => {

--- a/test/build/base-url/expected-build/_dist_/index.js
+++ b/test/build/base-url/expected-build/_dist_/index.js
@@ -1,3 +1,12 @@
+import __SNOWPACK_ENV__ from '/static/__snowpack__/env.js';
+import.meta.env = __SNOWPACK_ENV__;
+
 import {flatten} from "/static/web_modules/array-flatten.js";
+
+const {MODE} = import.meta.env;
+export function consoleMode() {
+  console.log(MODE);
+}
+
 export default function doNothing() {
 }

--- a/test/build/base-url/package.json
+++ b/test/build/base-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowpack-test-base-url",
-  "description": "This test makes sure that %PUBLIC_URL% present in src/index.html doesn’t exist in the final build",
+  "description": "This test makes sure that %PUBLIC_URL% present in src/index.html doesn’t exist in the final build. It also makes sure that the paths to the meta dir is respecting the baseUrl configuration.",
   "scripts": {
     "start": "node ../../../pkg/dist-node/index.bin.js dev",
     "prepare": "node ../../../pkg/dist-node/index.bin.js",

--- a/test/build/base-url/src/index.js
+++ b/test/build/base-url/src/index.js
@@ -1,5 +1,10 @@
 import {flatten} from 'array-flatten';
 
+const {MODE} = import.meta.env;
+export function consoleMode() {
+  console.log(MODE);
+}
+
 export default function doNothing() {
   // I do nothing 🎉
 }


### PR DESCRIPTION
## Changes
This PR contains a quick fix for resolving ( #571 ) making the paths to meta dir do respect baseUrl configuration. 

## Testing
To test this: Configure baseUrl to `/something-else/` and run build command. The path to the meta dir should now be `/something-else/__snowpack__/`

