### PR TITLE
CJS packages with auto-detected named exports should still expose the default export

### DIFF
--- a/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -82,6 +82,7 @@ export function rollupPluginWrapInstallTargets(
       const normalizedFileLoc = fileLoc.split(path.win32.sep).join(path.posix.sep);
       if (!isTreeshake && isAutoDetect(normalizedFileLoc)) {
         uniqueNamedImports = autoDetectExports(fileLoc) || uniqueNamedImports;
+        treeshakeSummary.default = true;
       }
       const result = `
         ${treeshakeSummary.namespace ? `export * from '${normalizedFileLoc}';` : ''}

--- a/test/integration/config-named-exports/expected-install/mock-test-package.js
+++ b/test/integration/config-named-exports/expected-install/mock-test-package.js
@@ -2,7 +2,7 @@ var entrypoint = {
     export1: 'foo',
     export2: 'bar',
 };
-
+export default entrypoint;
 var export1 = entrypoint.export1;
 var export2 = entrypoint.export2;
 export { export1, export2 };

--- a/test/integration/package-react/expected-install/react-dom.js
+++ b/test/integration/package-react/expected-install/react-dom.js
@@ -26218,6 +26218,7 @@ var reactDom = createCommonjsModule(function (module) {
 
 var __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = reactDom.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 var createPortal = reactDom.createPortal;
+export default reactDom;
 var findDOMNode = reactDom.findDOMNode;
 var flushSync = reactDom.flushSync;
 var hydrate = reactDom.hydrate;

--- a/test/integration/package-react/expected-install/react.js
+++ b/test/integration/package-react/expected-install/react.js
@@ -1,5 +1,5 @@
 import { r as react } from './common/index-ceda4ad0.js';
-
+export { r as default } from './common/index-ceda4ad0.js';
 
 
 var Children = react.Children;


### PR DESCRIPTION
## Changes

Currently, auto-detected named exports will expose all named exports, but not the default export. This causes issues when we build a package in the abstract and have no scanned install targets.

## Testing

Covered by existing tests.
