### PR TITLE
Add back legacy transform() plugin support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -351,12 +351,6 @@ function loadPlugins(
       plugin.input = input;
       plugin.output = output;
     }
-    // Backwards compatibility for the deprecated transform() function
-    if (plugin.transform) {
-      plugin.input = ['.js', '.css', '.html'];
-      plugin.output = ['.js', '.css', '.html'];
-      plugin.build = plugin.transform;
-    }
     plugin.input = plugin.input
       ? Array.isArray(plugin.input)
         ? plugin.input


### PR DESCRIPTION
See: https://www.pika.dev/npm/snowpack/discuss/473

## Changes
Our naive attempt to support the old `transform()` plugin function ran into issues when it was meant to transform a file other than JS/CSS/HTML. It's impossible to represent this in our new system (which is whitelisted by file extension) so instead of trying we'll just keep supporting it until v3.0. 

The good news is that since `transform()` can't support change file extensions and could only ever exist on its own, the handling for this is pretty straightforward.

## Testing

~~TODO~~ Looks like we don't have plugin tests. Tested manually in CSA repo instead.
