### PR TITLE
Add support for mjs file extension

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -10,11 +10,6 @@ export interface BuildFileOptions {
   isDev: boolean;
 }
 
-const IS_PREACT = /from\s+['"]preact['"]/;
-export function checkIsPreact(filePath: string, contents: string) {
-  return filePath.endsWith('.jsx') && IS_PREACT.test(contents);
-}
-
 export function getInputsFromOutput(fileLoc: string, plugins: SnowpackPlugin[]) {
   const {baseExt} = getExt(fileLoc);
   const potentialInputs = new Set([fileLoc]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -456,7 +456,7 @@ function loadPlugins(
   // if no mounted directories, mount root
   if (!Object.keys(mountedDirs).length) mountedDirs['.'] = '/';
 
-  const needsDefaultPlugin = new Set(['.js', '.jsx', '.ts', '.tsx']);
+  const needsDefaultPlugin = new Set(['.js', '.mjs', '.jsx', '.ts', '.tsx']);
   plugins
     .reduce((arr, a) => arr.concat(a.input), [] as string[])
     .forEach((ext) => needsDefaultPlugin.delete(ext));

--- a/src/plugins/plugin-esbuild.ts
+++ b/src/plugins/plugin-esbuild.ts
@@ -5,9 +5,18 @@ import path from 'path';
 let esbuildService: Service | null = null;
 
 const IS_PREACT = /from\s+['"]preact['"]/;
-export function checkIsPreact(filePath: string, contents: string) {
+function checkIsPreact(filePath: string, contents: string) {
   return filePath.endsWith('.jsx') && IS_PREACT.test(contents);
 }
+
+function getLoader(filePath: string): 'js' | 'jsx' | 'ts' | 'tsx' {
+  const ext = path.extname(filePath);
+  if (ext === '.js' || ext === '.mjs') {
+    return 'js';
+  }
+  return ext.substr(1) as  'jsx' | 'ts' | 'tsx';
+}
+
 
 export function esbuildPlugin({input}: {input: string[]}) {
   return {
@@ -18,7 +27,7 @@ export function esbuildPlugin({input}: {input: string[]}) {
       esbuildService = esbuildService || (await startService());
       const isPreact = checkIsPreact(filePath, contents);
       const {js, warnings} = await esbuildService!.transform(contents, {
-        loader: path.extname(filePath).substr(1) as 'jsx' | 'ts' | 'tsx',
+        loader: getLoader(filePath),
         jsxFactory: isPreact ? 'h' : undefined,
         jsxFragment: isPreact ? 'Fragment' : undefined,
       });

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,7 +47,7 @@ export function isYarn(cwd: string) {
   return fs.existsSync(path.join(cwd, 'yarn.lock'));
 }
 
-const UTF8_FORMATS = ['.css', '.html', '.js', '.json', '.svg', '.txt', '.xml'];
+const UTF8_FORMATS = ['.css', '.html', '.js', '.mjs', '.json', '.svg', '.txt', '.xml'];
 export function getEncodingType(ext: string): 'utf-8' | 'binary' {
   return UTF8_FORMATS.includes(ext) ? 'utf-8' : 'binary';
 }

--- a/test/build/resolve-imports/expected-build/_dist_/test-mjs.js
+++ b/test/build/resolve-imports/expected-build/_dist_/test-mjs.js
@@ -1,0 +1,2 @@
+import {flatten} from "/web_modules/array-flatten.js";
+console.log(flatten);

--- a/test/build/resolve-imports/src/test-mjs.mjs
+++ b/test/build/resolve-imports/src/test-mjs.mjs
@@ -1,0 +1,3 @@
+// Path aliases
+import {flatten} from 'array-flatten';
+console.log(flatten);


### PR DESCRIPTION
See: https://www.pika.dev/npm/snowpack/discuss/480
We missed supporting `.mjs` source files with our default build. This adds that support. 

## Testing

Test added.
