### PR TITLE
fix metaDir usage in dev

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -133,8 +133,11 @@ export async function buildFile(
   return output;
 }
 
-export function getMetaUrlPath(urlPath: string, config: SnowpackConfig): string {
+export function getMetaUrlPath(urlPath: string, isDev: boolean, config: SnowpackConfig): string {
   let {baseUrl, metaDir} = config.buildOptions || {};
+  if (isDev) {
+    return path.posix.normalize(path.posix.join('/', metaDir, urlPath));
+  }
   if (URL_HAS_PROTOCOL_REGEX.test(baseUrl)) {
     return baseUrl + path.posix.normalize(path.posix.join(metaDir, urlPath));
   }
@@ -145,11 +148,13 @@ export function wrapImportMeta({
   code,
   hmr,
   env,
+  isDev,
   config,
 }: {
   code: string;
   hmr: boolean;
   env: boolean;
+  isDev: boolean;
   config: SnowpackConfig;
 }) {
   if (!code.includes('import.meta')) {
@@ -159,12 +164,14 @@ export function wrapImportMeta({
     (hmr
       ? `import * as  __SNOWPACK_HMR__ from '${getMetaUrlPath(
           'hmr.js',
+          isDev,
           config,
         )}';\nimport.meta.hot = __SNOWPACK_HMR__.createHotContext(import.meta.url);\n`
       : ``) +
     (env
       ? `import __SNOWPACK_ENV__ from '${getMetaUrlPath(
           'env.js',
+          isDev,
           config,
         )}';\nimport.meta.env = __SNOWPACK_ENV__;\n`
       : ``) +
@@ -177,13 +184,15 @@ let _cssModuleLoader: CSSModuleLoader;
 export async function wrapCssModuleResponse({
   url,
   code,
-  hasHmr = false,
+  isDev,
+  hmr,
   config,
 }: {
   url: string;
   code: string;
   ext: string;
-  hasHmr?: boolean;
+  isDev: boolean;
+  hmr: boolean;
   config: SnowpackConfig;
 }) {
   _cssModuleLoader = _cssModuleLoader || new (require('css-modules-loader-core'))();
@@ -191,9 +200,9 @@ export async function wrapCssModuleResponse({
     throw new Error('Imports in CSS Modules are not yet supported.');
   });
   return `${
-    hasHmr
+    hmr
       ? `
-import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', config)}';
+import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', isDev, config)}';
 import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
 import.meta.hot.accept(({module}) => {
   code = module.code;
@@ -218,18 +227,20 @@ document.head.appendChild(styleEl);`;
 
 export function wrapHtmlResponse({
   code,
-  hasHmr = false,
+  isDev,
+  hmr,
   config,
 }: {
   code: string;
-  hasHmr?: boolean;
+  isDev: boolean;
+  hmr: boolean;
   config: SnowpackConfig;
 }) {
   // replace %PUBLIC_URL% in HTML files (along with surrounding slashes, if any)
   code = code.replace(/\/?%PUBLIC_URL%\/?/g, config.buildOptions.baseUrl);
 
-  if (hasHmr) {
-    code += `<script type="module" src="${getMetaUrlPath('hmr.js', config)}"></script>`;
+  if (hmr) {
+    code += `<script type="module" src="${getMetaUrlPath('hmr.js', isDev, config)}"></script>`;
   }
   return code;
 }
@@ -238,20 +249,22 @@ export function wrapEsmProxyResponse({
   url,
   code,
   ext,
-  hasHmr = false,
+  isDev,
+  hmr,
   config,
 }: {
   url: string;
   code: string;
   ext: string;
-  hasHmr?: boolean;
+  isDev: boolean;
+  hmr: boolean;
   config: SnowpackConfig;
 }) {
   if (ext === '.json') {
     return `${
-      hasHmr
+      hmr
         ? `
-    import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', config)}';
+    import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', isDev, config)}';
     import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
     import.meta.hot.accept(({module}) => {
       json = module.default;
@@ -264,9 +277,9 @@ export default json;`;
 
   if (ext === '.css') {
     return `${
-      hasHmr
+      hmr
         ? `
-import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', config)}';
+import * as __SNOWPACK_HMR_API__ from '${getMetaUrlPath('hmr.js', isDev, config)}';
 import.meta.hot = __SNOWPACK_HMR_API__.createHotContext(import.meta.url);
 import.meta.hot.accept();
 import.meta.hot.dispose(() => {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -182,7 +182,7 @@ export async function command(commandOptions: CommandOptions) {
             await fs.writeFile(cssOutPath, builtFileOutput['.css'], 'utf8');
             contents = `import './${path.basename(cssOutPath)}';\n` + contents;
           }
-          contents = wrapImportMeta({code: contents, env: true, hmr: false, config});
+          contents = wrapImportMeta({code: contents, env: true, isDev: false, hmr: false, config});
 
           // minify install if enabled and there’s no bundler
           if (config.buildOptions.minify && !config._bundler) {
@@ -196,7 +196,9 @@ export async function command(commandOptions: CommandOptions) {
         case '.html': {
           contents = wrapHtmlResponse({
             code: contents,
-            hasHmr: false,
+            isDev: false,
+
+            hmr: false,
             config,
           });
           allFilesToResolveImports[outLoc] = {baseExt, expandedExt, contents, locOnDisk};
@@ -275,12 +277,16 @@ export async function command(commandOptions: CommandOptions) {
           url: proxiedUrl,
           code: proxiedCode,
           ext: proxiedExt,
+          isDev: false,
+          hmr: false,
           config,
         })
       : wrapEsmProxyResponse({
           url: proxiedUrl,
           code: proxiedCode,
           ext: proxiedExt,
+          isDev: false,
+          hmr: false,
           config,
         });
     const proxyFileLoc = proxiedFileLoc + '.proxy.js';

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -74,7 +74,7 @@ import {
   wrapEsmProxyResponse,
   wrapHtmlResponse,
   wrapImportMeta,
-  getMetaDir,
+  getMetaUrlPath,
 } from './build-util';
 import {createImportResolver} from './import-resolver';
 import {command as installCommand} from './install';
@@ -175,6 +175,12 @@ let currentlyRunningCommand: any = null;
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config} = commandOptions;
   const {port: defaultPort, hostname, open, hmr: isHmr} = config.devOptions;
+  // WORKAROUND: Dev always assumes that you're serving from the root URL of your dev server.
+  // However, our build logic uses baseUrl to calculate absolute URLs. Force it to the root URL
+  // when we're in dev mode for now, and look into adding an actual config "dev mode" later.
+  config.buildOptions.baseUrl = '/';
+
+  // Start the startup timer!
   let serverStart = Date.now();
   const port = await getPort(defaultPort);
   // Reset the clock if we had to wait for the user to select a new port.
@@ -396,13 +402,11 @@ export async function command(commandOptions: CommandOptions) {
       }
     });
 
-    const metaDir = getMetaDir(config);
-
-    if (reqPath === `${metaDir}/hmr.js`) {
+    if (reqPath === getMetaUrlPath('/hmr.js', config)) {
       sendFile(req, res, HMR_DEV_CODE, '.js');
       return;
     }
-    if (reqPath === `${metaDir}/env.js`) {
+    if (reqPath === getMetaUrlPath('/env.js', config)) {
       sendFile(req, res, generateEnvModule('development'), '.js');
       return;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -542,7 +542,9 @@ function normalizeConfig(config: SnowpackConfig): SnowpackConfig {
   if (!config.proxy) {
     config.proxy = {} as any;
   }
-
+  
+  // force trailing slash
+  config.buildOptions.baseUrl = config.buildOptions.baseUrl.replace(/\/?$/, '/');
   // remove leading/trailing slashes
   config.buildOptions.metaDir = removeLeadingSlash(
     removeTrailingSlash(config.buildOptions.metaDir),

--- a/test/build/meta-dir-remote-baseurl/expected-build/_dist_/index.js
+++ b/test/build/meta-dir-remote-baseurl/expected-build/_dist_/index.js
@@ -1,4 +1,4 @@
-import __SNOWPACK_ENV__ from '/static/snowpack/env.js';
+import __SNOWPACK_ENV__ from 'https://www.cdn.com/sub_path/static/snowpack/env.js';
 import.meta.env = __SNOWPACK_ENV__;
 
 import React from "https://cdn.pika.dev/react@^16.13.1";


### PR DESCRIPTION
## Changes

#571 added baseUrl support to our `/__snowpack__/` import generator, but ended up breaking dev mode. This PR adds back dev support with a short-term workaround for now, and performs some cleanup as well.

## Test

Our lack of dev command tests strikes again! Tested manually via CSA.