### PR TITLE
Automerge dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'live'
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"

--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -1,0 +1,15 @@
+name: Auto approve dependabot
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Changes

This adds a GitHub action to auto-merge dependabot updates. Now when dependabot bumps versions, it’ll just go straight to `master` (it’ll still make sure all tests & status checks pass).

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
