### PR TITLE
Fix #570 missing package not resolved

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Our [issue tracker](https://github.com/pikapkg/snowpack/issues) is always organi
 # Local Setup
 git clone ${REPO}
 yarn
+yarn lerna bootstrap
 ```
 
 ```bash

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -92,7 +92,12 @@ export function paint(
   let installOutput = '';
   let isInstalling = false;
   let hasBeenCleared = false;
-  let missingWebModule: null | {id: string; spec: string; pkgName: string} = null;
+  let missingWebModule: null | {
+    id: string;
+    spec: string;
+    pkgName: string;
+    pkgExists?: boolean;
+  } = null;
   const allWorkerStates: Record<string, WorkerState> = {};
   const allFileBuilds = new Set<string>();
 
@@ -163,18 +168,28 @@ export function paint(
       return;
     }
     if (missingWebModule) {
-      const {id, pkgName, spec} = missingWebModule;
-      process.stdout.write(`${colors.red(colors.underline(colors.bold('▼ Snowpack')))}\n\n`);
+      const {id, pkgName, spec, pkgExists} = missingWebModule;
+      process.stdout.write(
+        `${colors[pkgExists ? 'yellow' : 'red'](colors.underline(colors.bold('▼ Snowpack')))}\n\n`,
+      );
       if (devMode) {
         process.stdout.write(`  Package ${colors.bold(pkgName)} not found!\n`);
         process.stdout.write(colors.dim(`  in ${id}`));
         process.stdout.write(`\n\n`);
-        process.stdout.write(
-          `  ${colors.bold('Press Enter')} to automatically run ${colors.bold(
-            isYarn(cwd) ? `yarn add ${pkgName}` : `npm install --save ${pkgName}`,
-          )}.\n`,
-        );
-        process.stdout.write(`  Or, Exit Snowpack and install manually to continue.\n`);
+        if (pkgExists) {
+          process.stdout.write(
+            `Please add ${colors.bold(pkgName)} in ${colors.bold(
+              'config.install',
+            )} to avoid Snowpack reinstall the dependencies.`,
+          );
+        } else {
+          process.stdout.write(
+            `  ${colors.bold('Press Enter')} to automatically run ${colors.bold(
+              isYarn(cwd) ? `yarn add ${pkgName}` : `npm install --save ${pkgName}`,
+            )}.\n`,
+          );
+          process.stdout.write(`  Or, Exit Snowpack and install manually to continue.\n`);
+        }
       } else {
         process.stdout.write(`  Dependency ${colors.bold(spec)} not found!\n\n`);
         // process.stdout.write(


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
To support babel macros.

In dev mode, before reinstalling dependencies, do add the missing entry points to `knownEntrypoints` as reinstall will only install the dependencies from configuration, and imports scanned from the source code.

<!-- Before/after screenshots may be helpful.  -->
Before:

![Before](https://i.ibb.co/xM7F6Ly/Screenshot-2020-07-22-at-10-41-40-PM.png)

After:

![After](https://i.ibb.co/Gp0qXqW/Screenshot-2020-07-22-at-10-42-39-PM.png)

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Tested here: https://github.com/JennieJi/snowpack/pull/3

I only reproduced this via babel macros, but installing babel plugin will add too many files. And I didn't have a good idea of how to use the current test runners to test the dev mode... Thus I chose not to add in this branch. @FredKSchott need some advice about this.
