### PR TITLE
Export plugin type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {addCommand, rmCommand} from './commands/add-rm';
 import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
-import {CLIFlags, loadAndValidateConfig} from './config.js';
+import {CLIFlags, loadAndValidateConfig, SnowpackConfig, SnowpackPlugin} from './config.js';
 import {clearCache, readLockfile} from './util.js';
 
 export {install as unstable_installCommand} from './commands/install';
@@ -110,3 +110,9 @@ export async function cli(args: string[]) {
   console.log(`Unrecognized command: ${cmd}`);
   process.exit(1);
 }
+
+/** Snowpack Build Plugin type */
+export type SnowpackPluginFactory<PluginOptions = object> = (
+  snowpackConfig: SnowpackConfig,
+  pluginOptions?: PluginOptions,
+) => SnowpackPlugin;


### PR DESCRIPTION
## Changes

For the upcoming 2.7 plugin system, we don’t have an easy-to-use type for people to use. This adds one.

![Screen Shot 2020-07-22 at 5 13 23 PM](https://user-images.githubusercontent.com/1369770/88238353-abc3dc80-cc3e-11ea-80ad-ad47daa7821d.png)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

This has been tested in [snowpack-plugin-starter-template](https://github.com/pikapkg/snowpack-plugin-starter-template)

<!-- For someone unfamiliar with the issue, how should this be tested? -->
