### PR TITLE
Finalize the plugin interface

### DIFF
--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -156,20 +156,22 @@ export async function command(commandOptions: CommandOptions) {
       const {baseExt: fileExt} = getExt(locOnDisk);
       let outLoc = locOnDisk.replace(dirDisk, dirDest);
       let builtLocOnDisk = locOnDisk;
-      const extToReplace = srcFileExtensionMapping[fileExt];
+      const extToReplace = config._extensionMap[fileExt] || srcFileExtensionMapping[fileExt];
       if (extToReplace) {
         outLoc = replaceExt(outLoc, extToReplace);
         builtLocOnDisk = replaceExt(builtLocOnDisk, extToReplace);
       }
-      const fileContents = await fs.readFile(locOnDisk, getEncodingType(extToReplace || fileExt));
-      const builtFileOutput = await buildFile(locOnDisk, fileContents, {
+      const builtFileOutput = await buildFile(locOnDisk, {
         buildPipeline: config.plugins,
         messageBus,
         isDev: false,
       });
       allBuiltFromFiles.add(locOnDisk);
       const {baseExt, expandedExt} = getExt(outLoc);
-      let contents = builtFileOutput[srcFileExtensionMapping[fileExt] || fileExt];
+      let contents =
+        builtFileOutput[
+          config._extensionMap[fileExt] || srcFileExtensionMapping[fileExt] || fileExt
+        ];
       if (!contents) {
         continue;
       }
@@ -179,7 +181,7 @@ export async function command(commandOptions: CommandOptions) {
         case '.js': {
           if (builtFileOutput['.css']) {
             await fs.mkdir(path.dirname(cssOutPath), {recursive: true});
-            await fs.writeFile(cssOutPath, builtFileOutput['.css'], 'utf8');
+            await fs.writeFile(cssOutPath, builtFileOutput['.css'], 'utf-8');
             contents = `import './${path.basename(cssOutPath)}';\n` + contents;
           }
           contents = wrapImportMeta({code: contents, env: true, isDev: false, hmr: false, config});

--- a/packages/snowpack/src/commands/import-resolver.ts
+++ b/packages/snowpack/src/commands/import-resolver.ts
@@ -33,7 +33,12 @@ export function getImportStats(dirLoc: string, spec: string): fs.Stats | false {
 }
 
 /** Resolve an import based on the state of the file/folder found on disk. */
-function resolveSourceSpecifier(spec: string, stats: fs.Stats | false, isBundled: boolean) {
+function resolveSourceSpecifier(
+  spec: string,
+  stats: fs.Stats | false,
+  isBundled: boolean,
+  config: SnowpackConfig,
+) {
   if (stats && stats.isDirectory()) {
     const trailingSlash = spec.endsWith('/') ? '' : '/';
     spec = spec + trailingSlash + 'index.js';
@@ -41,7 +46,7 @@ function resolveSourceSpecifier(spec: string, stats: fs.Stats | false, isBundled
     spec = spec + '.js';
   }
   const {baseExt} = getExt(spec);
-  const extToReplace = srcFileExtensionMapping[baseExt];
+  const extToReplace = config._extensionMap[baseExt] || srcFileExtensionMapping[baseExt];
   if (extToReplace) {
     spec = replaceExt(spec, extToReplace);
   }
@@ -73,13 +78,13 @@ export function createImportResolver({
     if (mountScript) {
       const [fromDisk, toUrl] = mountScript;
       const importStats = getImportStats(cwd, spec);
-      spec = resolveSourceSpecifier(spec, importStats, isBundled);
+      spec = resolveSourceSpecifier(spec, importStats, isBundled, config);
       spec = spec.replace(fromDisk, toUrl);
       return spec;
     }
     if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {
       const importStats = getImportStats(path.dirname(fileLoc), spec);
-      spec = resolveSourceSpecifier(spec, importStats, isBundled);
+      spec = resolveSourceSpecifier(spec, importStats, isBundled, config);
       return spec;
     }
     if (dependencyImportMap && dependencyImportMap.imports[spec]) {

--- a/packages/snowpack/src/plugins/plugin-build-script.ts
+++ b/packages/snowpack/src/plugins/plugin-build-script.ts
@@ -1,25 +1,33 @@
 import execa from 'execa';
 import npmRunPath from 'npm-run-path';
+import {promises as fs} from 'fs';
+import {SnowpackPlugin, SnowpackConfig} from '../config';
 const cwd = process.cwd();
 
-export function buildScriptPlugin({
-  input,
-  output,
-  cmd,
-}: {
-  input: string[];
-  output: string[];
-  cmd: string;
-}) {
+export function buildScriptPlugin(
+  _: SnowpackConfig,
+  {
+    input,
+    output,
+    cmd,
+  }: {
+    input: string[];
+    output: string[];
+    cmd: string;
+  },
+): SnowpackPlugin {
   if (output.length !== 1) {
     throw new Error('Requires one output.');
   }
   return {
     name: `build:${cmd.split(' ')[0]}`,
-    input: input,
-    output: output,
-    async build({contents, filePath, log}) {
+    resolve: {
+      input: input,
+      output: output,
+    },
+    async load({filePath, log}) {
       const cmdWithFile = cmd.replace('$FILE', filePath);
+      const contents = await fs.readFile(filePath, 'utf-8');
       try {
         const {stdout, stderr} = await execa.command(cmdWithFile, {
           env: npmRunPath.env(),

--- a/packages/snowpack/src/plugins/plugin-run-script.ts
+++ b/packages/snowpack/src/plugins/plugin-run-script.ts
@@ -1,15 +1,23 @@
 import execa from 'execa';
 import npmRunPath from 'npm-run-path';
+import {SnowpackPlugin, SnowpackConfig} from '../config';
 const cwd = process.cwd();
 
-export function runScriptPlugin({cmd, watch: _watchCmd}: {cmd: string; watch?: string}) {
+export function runScriptPlugin(
+  _config: SnowpackConfig,
+  {
+    cmd,
+    watch: _watchCmd,
+  }: {
+    cmd: string;
+    watch?: string;
+  },
+): SnowpackPlugin {
   const cmdProgram = cmd.split(' ')[0];
   const watchCmd = _watchCmd && _watchCmd.replace('$1', cmd);
 
   return {
     name: `run:${cmdProgram}`,
-    input: [],
-    output: [],
     async run({isDev, log}) {
       const workerPromise = execa.command(isDev ? watchCmd || cmd : cmd, {
         env: npmRunPath.env(),

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-css.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-css.ts
@@ -41,7 +41,7 @@ export function rollupPluginCss() {
       if (!id.endsWith('.css')) {
         return null;
       }
-      const code = await fs.readFile(id, {encoding: 'utf8'});
+      const code = await fs.readFile(id, {encoding: 'utf-8'});
       const humanReadableName = id.replace(/.*node_modules[\/\\]/, '').replace(/[\/\\]/g, '/');
       return getInjectorCode(humanReadableName, code);
     },

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-remote-cdn.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-remote-cdn.ts
@@ -92,7 +92,7 @@ export function rollupPluginDependencyCache({
         const typesTarballUrl = typesUrl.replace(/(mode=types.*?)\/.*/, '$1/all.tgz');
         allTypesToInstall.add(typesTarballUrl);
       }
-      return cachedResult.data.toString('utf8');
+      return cachedResult.data.toString('utf-8');
     },
     async writeBundle(options: OutputOptions) {
       if (!installTypes) {

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-stats.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-stats.ts
@@ -67,7 +67,7 @@ export function rollupPluginDependencyStats(
         const contents = Buffer.isBuffer(raw)
           ? raw
           : typeof raw === 'string'
-          ? Buffer.from(raw, 'utf8')
+          ? Buffer.from(raw, 'utf-8')
           : Buffer.from(raw);
         if (fileName.startsWith('common')) {
           commonDependencies.push({fileName, contents});

--- a/packages/snowpack/src/util.ts
+++ b/packages/snowpack/src/util.ts
@@ -55,7 +55,7 @@ export function getEncodingType(ext: string): 'utf-8' | 'binary' {
 export async function readLockfile(cwd: string): Promise<ImportMap | null> {
   try {
     var lockfileContents = fs.readFileSync(path.join(cwd, 'snowpack.lock.json'), {
-      encoding: 'utf8',
+      encoding: 'utf-8',
     });
   } catch (err) {
     // no lockfile found, ignore and continue
@@ -70,7 +70,7 @@ export async function writeLockfile(loc: string, importMap: ImportMap): Promise<
   for (const key of Object.keys(importMap.imports).sort()) {
     sortedImportMap.imports[key] = importMap.imports[key];
   }
-  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), {encoding: 'utf8'});
+  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), {encoding: 'utf-8'});
 }
 
 export function fetchCDNResource(
@@ -142,7 +142,7 @@ export function resolveDependencyManifest(dep: string, cwd: string): [string | n
       const manifestPath =
         fullPath.substring(0, indexOfSearch + searchPath.length + 1) + 'package.json';
       result[0] = manifestPath;
-      const manifestStr = fs.readFileSync(manifestPath, {encoding: 'utf8'});
+      const manifestStr = fs.readFileSync(manifestPath, {encoding: 'utf-8'});
       result[1] = JSON.parse(manifestStr);
     }
   } catch (err) {


### PR DESCRIPTION
## Changes

- Based on conversation with @drwpow to move our plugin interface closer to Rollup's
- Separate the single `build()` method into `load()` and `transform()` methods
- Move `input` & `output` into a nested `resolve` property.
- Resolve https://github.com/pikapkg/snowpack/discussions/618

## Testing

Waiting for the monorepo to test.

~~**Note:** Docs and a final cleanup pass are still TODO, but I wanted to get this out sooner so that everyone had a chance to see the actual code changes.~~ Docs finished and comments added.