### PR TITLE
Fix typo in the release post

### DIFF
--- a/docs/posts/2020-05-26-snowpack-2-0-release.md
+++ b/docs/posts/2020-05-26-snowpack-2-0-release.md
@@ -43,7 +43,7 @@ This has several advantages over the traditional bundled dev approach:
 - O(1) builds are faster.
 - O(1) builds are predictable.
 - O(1) builds are easy to reason about & configure.
-- Project size doesn't effect build time during development.
+- Project size doesn't affect build time during development.
 - Individual files cache better.
 
 That last point is key: every built file is cached individually and reused indefinitely. **If you never change a file, you will never need to re-build it again.**


### PR DESCRIPTION
`effect` is a noun, however a verb is expected here

## Changes
typo: `effect` -> `affect`

<img width="818" alt="Screen Shot 2020-07-27 at 8 57 53 PM" src="https://user-images.githubusercontent.com/26398225/88544423-f208a980-d04b-11ea-94df-1dadc5e86536.png">


## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
