### PR TITLE
Restore READMEs lost in migration

### DIFF
--- a/packages/create-snowpack-app/README.md
+++ b/packages/create-snowpack-app/README.md
@@ -1,0 +1,55 @@
+# Create Snowpack App (CSA)
+
+```
+npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm]
+```
+
+## Official App Templates
+
+- [@snowpack/app-template-blank](/templates/app-template-blank)
+- [@snowpack/app-template-blank-typescript](/templates/app-template-blank-typescript)
+- [@snowpack/app-template-11ty](/templates/app-template-11ty)
+- [@snowpack/app-template-lit-element-typescript](/templates/app-template-lit-element-typescript)
+- [@snowpack/app-template-lit-element](/templates/app-template-lit-element)
+- [@snowpack/app-template-preact](/templates/app-template-preact)
+- [@snowpack/app-template-react-typescript](/templates/app-template-react-typescript)
+- [@snowpack/app-template-react](/templates/app-template-react)
+- [@snowpack/app-template-svelte](/templates/app-template-svelte)
+- [@snowpack/app-template-vue](/templates/app-template-vue)
+
+### Featured Community Templates
+
+- [snowpack-template-preset-env](https://github.com/argyleink/snowpack-template-preset-env) (PostCSS + Babel)
+- [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit) (11ty +
+  Snowpack + tailwindcss)
+- [app-template-reason-react](https://github.com/jihchi/app-template-reason-react) (ReasonML (BuckleScript) & reason-react on top of [@snowpack/app-template-react](/templates/app-template-react))
+- [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
+- [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
+- PRs that add a link to this list are welcome!
+
+## Official Snowpack Plugins
+
+### Dev Environment
+
+- [@snowpack/plugin-dotenv](/packages/plugin-dotenv)
+
+### Build
+
+- [@snowpack/plugin-babel](/packages/plugin-babel)
+- [@snowpack/plugin-svelte](/packages/plugin-svelte)
+- [@snowpack/plugin-vue](/packages/plugin-vue)
+
+### Transform
+
+- [@snowpack/plugin-react-refresh](/packages/plugin-react-refresh)
+
+### Bundle
+
+- [@snowpack/plugin-parcel](/packages/plugin-parcel)
+- [@snowpack/plugin-webpack](/packages/plugin-webpack)
+
+### Featured Community Plugins
+
+- [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
+- [snowpack-plugin-import-map](https://github.com/zhoukekestar/snowpack-plugin-import-map) A more easy way to map your imports to Pika CDN instead of [import-maps.json](https://github.com/WICG/import-maps).
+- PRs that add a link to this list are welcome!

--- a/packages/snowpack/README.md
+++ b/packages/snowpack/README.md
@@ -4,9 +4,9 @@
 
 **Snowpack is a modern, lightweight toolchain for web application development.** Traditional dev bundlers like webpack or Parcel need to rebuild & rebundle entire chunks of your application every time you save a single file. This introduces lag between changing a file and seeing those changes reflected in the browser, sometimes as slow as several seconds.
 
-Snowpack solves this problem by serving your application **unbundled in development.** Any time you change a file, Snowpack never rebuilds more than a single file. There's no bundling to speak of, just a few milliseconds of single-file rebuilding and then an instant update in the browser via HMR. We call this new approach **O(1) Build Tooling.** You can read more about it in our [Snowpack 2.0 Release Post.](https://www.snowpack.dev/posts/2020-05-26-snowpack-2-0-release/)
+Snowpack solves this problem by serving your application **unbundled in development.** Any time you change a file, Snowpack never rebuilds more than a single file. There's no bundling to speak of, just a few milliseconds of single-file rebuilding and then an instant update in the browser via HMR. We call this new approach **O(1) Build Tooling.** You can read more about it in our [Snowpack 2.0 Release Post.](https://www.snowpack.dev/posts/2020-05-26-snowpack-2-0-release/) 
 
-When you're ready to deploy your web application to users, you can add back a traditional bundler like Webpack or Parcel. With Snowpack you get bundled & optimized production performance without sacrificing dev speed by adding an unnecessary bundler,
+When you're ready to deploy your web application to users, you can add back a traditional bundler like Webpack or Parcel. With Snowpack you get bundled & optimized production performance without sacrificing dev speed by adding an unnecessary bundler, 
 
 ### Key Features
 
@@ -17,7 +17,3 @@ When you're ready to deploy your web application to users, you can add back a tr
 - Connect your favorite tools with custom [build scripts](https://www.snowpack.dev/posts/2020-05-26-snowpack-2-0-release/#build-scripts) & [third-party plugins.](https://www.snowpack.dev/posts/2020-05-26-snowpack-2-0-release/#build-plugins)
 
 **💁 More info at the official [Snowpack website ➞](https://snowpack.dev)**
-
-## Create Snowpack App (CSA)
-
-For starter apps and templates, see [create-snowpack-app](./packages/create-snowpack-app).


### PR DESCRIPTION
## Changes

We accidentally deleted the README from the `snowpack` npm deployment (whoops!) and we were missing one in `create-snowpack-app`.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

No testing; this is just READMEs.

<!-- For someone unfamiliar with the issue, how should this be tested? -->
