### PR TITLE
granular chunking in plugin-webpack

### DIFF
--- a/packages/@snowpack/plugin-webpack/plugin.js
+++ b/packages/@snowpack/plugin-webpack/plugin.js
@@ -14,6 +14,78 @@ function insertAfter(newNode, existingNode) {
   existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
 }
 
+function parseHTMLFiles({ srcDirectory }) {
+  // Get all html files from the output folder
+  const pattern = srcDirectory + "/**/*.html";
+  const htmlFiles = glob
+    .sync(pattern)
+    .map((htmlPath) => path.relative(srcDirectory, htmlPath));
+
+  const doms = {};
+  const jsEntries = {};
+  for (const htmlFile of htmlFiles) {
+    const dom = new JSDOM(fs.readFileSync(path.join(srcDirectory, htmlFile)));
+
+    //Find all local script, use it as the entrypoint
+    const scripts = Array.from(dom.window.document.querySelectorAll("script"))
+      .filter((el) => el.type.trim().toLowerCase() === "module")
+      .filter((el) => !/^[a-zA-Z]+:\/\//.test(el.src));
+
+    for (const el of scripts) {
+      const src = el.src.trim();
+      const parsedPath = path.parse(src);
+      const name = parsedPath.name;
+      if (!(name in jsEntries)) {
+        jsEntries[name] = {
+          path: path.join(srcDirectory, src),
+          occurrences: [],
+        };
+      }
+      jsEntries[name].occurrences.push({ script: el, dom });
+    }
+
+    doms[htmlFile] = dom;
+  }
+  return { doms, jsEntries };
+}
+
+function emitHTMLFiles({ doms, jsEntries, stats, baseUrl, destDirectory }) {
+  const entrypoints = stats.toJson({ assets: false, hash: true }).entrypoints;
+
+  //Now that webpack is done, modify the html files to point to the newly compiled resources
+  Object.keys(jsEntries).forEach((name) => {
+    if (entrypoints[name] !== undefined && entrypoints[name]) {
+      const assetFiles = entrypoints[name].assets || [];
+      const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
+      const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
+
+      for (const occurrence of jsEntries[name].occurrences) {
+        const originalScriptEl = occurrence.script;
+        const dom = occurrence.dom;
+        const head = dom.window.document.querySelector("head");
+
+        for (const jsFile of jsFiles) {
+          const scriptEl = dom.window.document.createElement("script");
+          scriptEl.src = path.posix.join(baseUrl, jsFile);
+          insertAfter(scriptEl, originalScriptEl);
+        }
+        for (const cssFile of cssFiles) {
+          const linkEl = dom.window.document.createElement("link");
+          linkEl.setAttribute("rel", "stylesheet");
+          linkEl.href = path.posix.join(baseUrl, cssFile);
+          head.append(linkEl);
+        }
+        originalScriptEl.remove();
+      }
+    }
+  });
+
+  //And write our modified html files out to the destination
+  for (const [htmlFile, dom] of Object.entries(doms)) {
+    fs.writeFileSync(path.join(destDirectory, htmlFile), dom.serialize());
+  }
+}
+
 module.exports = function plugin(config, args) {
   // Deprecated: args.mode
   if (args.mode && args.mode !== "production") {
@@ -55,37 +127,9 @@ module.exports = function plugin(config, args) {
         extendConfig = (cfg) => ({ ...cfg, ...args.extendConfig });
       }
 
-      // Get all html files from the output folder
-      const pattern = srcDirectory + "/**/*.html";
-      const htmlFiles = glob.sync(pattern)
-          .map(htmlPath => path.relative(srcDirectory, htmlPath));
+      const { doms, jsEntries } = parseHTMLFiles({ srcDirectory });
 
-      const doms = {};
-      const entries = {};
-      for (const htmlFile of htmlFiles) {
-          const dom = new JSDOM(
-            fs.readFileSync(path.join(srcDirectory, htmlFile))
-          );
-
-          //Find all local script, use it as the entrypoint
-          const scripts = Array.from(dom.window.document.querySelectorAll("script"))
-            .filter((el) => el.type.trim().toLowerCase() === "module")
-            .filter((el) => !/^[a-zA-Z]+:\/\//.test(el.src));
-
-          for (const el of scripts) {
-            const src = el.src.trim();
-            const parsedPath = path.parse(src);
-            const name = parsedPath.name;
-            if (!(name in entries)) {
-                entries[name] = { path: path.join(srcDirectory, src), occurrences: [] };
-            }
-            entries[name].occurrences.push({ script: el, dom });
-          }
-
-          doms[htmlFile] = dom;
-      }
-
-      if (Object.keys(entries).length === 0) {
+      if (Object.keys(jsEntries).length === 0) {
         throw new Error("Can't bundle without script tag in html");
       }
 
@@ -186,8 +230,8 @@ module.exports = function plugin(config, args) {
         ],
       };
       let entry = {};
-      for (name in entries) {
-        entry[name] = entries[name].path;
+      for (name in jsEntries) {
+        entry[name] = jsEntries[name].path;
       }
       const extendedConfig = extendConfig({
         ...webpackConfig,
@@ -219,54 +263,17 @@ module.exports = function plugin(config, args) {
         console.log(
           stats.toString(
             extendedConfig.stats
-            ? extendedConfig.stats
-            : {
-              colors: true,
-              all: false,
-              assets: true,
-            }
+              ? extendedConfig.stats
+              : {
+                  colors: true,
+                  all: false,
+                  assets: true,
+                }
           )
         );
       }
 
-      const entrypoints = stats.toJson({ assets: false, hash: true })
-        .entrypoints;
-
-      //Now that webpack is done, modify the html files to point to the newly compiled resources
-      Object.keys(entries).forEach((name) => {
-        if (entrypoints[name] !== undefined && entrypoints[name]) {
-          const assetFiles = entrypoints[name].assets || [];
-          const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
-          const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
-
-          for (const occurrence of entries[name].occurrences) {
-            const originalScriptEl = occurrence.script;
-            const dom = occurrence.dom;
-            const head = dom.window.document.querySelector("head");
-
-            for (const jsFile of jsFiles) {
-              const scriptEl = dom.window.document.createElement("script");
-              scriptEl.src = path.posix.join(baseUrl, jsFile);
-              insertAfter(scriptEl, originalScriptEl);
-            }
-            for (const cssFile of cssFiles) {
-              const linkEl = dom.window.document.createElement("link");
-              linkEl.setAttribute("rel", "stylesheet");
-              linkEl.href = path.posix.join(baseUrl, cssFile);
-              head.append(linkEl);
-            }
-            originalScriptEl.remove();
-          }
-        }
-      });
-
-      //And write our modified html files out to the destination
-      for (const [htmlFile, dom] of Object.entries(doms)) {
-          fs.writeFileSync(
-            path.join(destDirectory, htmlFile),
-            dom.serialize()
-          );
-      }
+      emitHTMLFiles({ doms, jsEntries, stats, baseUrl, destDirectory });
     },
   };
 };

--- a/packages/@snowpack/plugin-webpack/plugin.js
+++ b/packages/@snowpack/plugin-webpack/plugin.js
@@ -89,6 +89,9 @@ function emitHTMLFiles({ doms, jsEntries, stats, baseUrl, destDirectory }) {
 }
 
 function getSplitChunksConfig({ numEntries }) {
+  /**
+   * Implements a version of granular chunking, as described at https://web.dev/granular-chunking-nextjs/.
+   */
   return {
     chunks: "all",
     maxInitialRequests: 25,


### PR DESCRIPTION
Migrated this PR from pikapkg/create-snowpack-app/pull/190, since that repo is being deprecated. I cleanly applied the same diff to the new files.

---

Resolves pikapkg/create-snowpack-app/issues/177.

This very closely follows [the guidance from Google](https://web.dev/granular-chunking-nextjs), and is similar to the webpack chunking strategies used by Next and Gatsby. This implementation is directly based on the reference implementation from that article: https://glitch.com/edit/#!/webpack-granular-split-chunks

- Libraries larger than 150KB are pulled into their own chunk
- Modules used on _all_ pages are pulled into a common chunk.
- As many shared chunks as needed are created (up to 25)
- The minimum size for a chunk to be generated is 20KB
- The Webpack runtime / manifest is pulled into its own chunk for better long-term caching of other assets.

The only significant difference between this config and the reference implementation is that we don't treat `react`, `react-dom`, etc... specially. In Gatsby / Next these framework libraries are pulled into a separate commons chunk, under the assumption that they'll be updated less frequently than other common modules (allowing a higher cache-hit rate across deployments). This is trickier to do as a Snowpack plugin, because we don't know which framework(s) are being used in a project. With this config, all NPM libraries are treated the same.

Note to reviewers: the first commit is a simple refactoring. It might be easier to read separately.