### PR TITLE
Chore: move types to types/snowpack

### DIFF
--- a/packages/snowpack/src/build/build-import-proxy.ts
+++ b/packages/snowpack/src/build/build-import-proxy.ts
@@ -1,6 +1,6 @@
 import type CSSModuleLoader from 'css-modules-loader-core';
 import path from 'path';
-import {SnowpackConfig} from '../config';
+import {SnowpackConfig} from '../types/snowpack';
 import {getExt, URL_HAS_PROTOCOL_REGEX} from '../util';
 
 export function getMetaUrlPath(urlPath: string, isDev: boolean, config: SnowpackConfig): string {

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 import {promises as fs} from 'fs';
 import path from 'path';
-import {SnowpackBuildMap, SnowpackPlugin} from '../config';
+import {SnowpackBuildMap, SnowpackPlugin} from '../types/snowpack';
 import {getEncodingType, getExt} from '../util';
 
 export interface BuildFileOptions {

--- a/packages/snowpack/src/build/import-resolver.ts
+++ b/packages/snowpack/src/build/import-resolver.ts
@@ -1,13 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import {SnowpackConfig} from '../config';
-import {
-  findMatchingAliasEntry,
-  getExt,
-  ImportMap,
-  replaceExt,
-  URL_HAS_PROTOCOL_REGEX,
-} from '../util';
+import {ImportMap, SnowpackConfig} from '../types/snowpack';
+import {findMatchingAliasEntry, getExt, replaceExt, URL_HAS_PROTOCOL_REGEX} from '../util';
 import srcFileExtensionMapping from './src-file-extension-mapping';
 
 const cwd = process.cwd();

--- a/packages/snowpack/src/commands/add-rm.ts
+++ b/packages/snowpack/src/commands/add-rm.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from 'fs';
 import got from 'got';
 import path from 'path';
-import {CommandOptions} from '../util';
+import {CommandOptions} from '../types/snowpack';
 import {command as installCommand} from './install';
 
 export async function addCommand(addValue: string, commandOptions: CommandOptions) {

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -17,11 +17,12 @@ import {
 import {buildFile, runPipelineOptimizeStep} from '../build/build-pipeline';
 import {createImportResolver} from '../build/import-resolver';
 import srcFileExtensionMapping from '../build/src-file-extension-mapping';
-import {removeLeadingSlash, SnowpackSourceFile} from '../config';
+import {removeLeadingSlash} from '../config';
 import {stopEsbuild} from '../plugins/plugin-esbuild';
 import {transformFileImports} from '../rewrite-imports';
 import {printStats} from '../stats-formatter';
-import {CommandOptions, getEncodingType, getExt, replaceExt} from '../util';
+import {CommandOptions, SnowpackSourceFile} from '../types/snowpack';
+import {getEncodingType, getExt, replaceExt} from '../util';
 import {getInstallTargets, run as installRunner} from './install';
 import {paint} from './paint';
 

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -54,21 +54,19 @@ import {
 import {buildFile as _buildFile, getInputsFromOutput} from '../build/build-pipeline';
 import {createImportResolver} from '../build/import-resolver';
 import srcFileExtensionMapping from '../build/src-file-extension-mapping';
-import {SnowpackBuildMap, SnowpackConfig} from '../config';
 import {EsmHmrEngine} from '../hmr-server-engine';
 import {
   scanCodeImportsExports,
   transformEsmImports,
   transformFileImports,
 } from '../rewrite-imports';
+import {CommandOptions, ImportMap, SnowpackBuildMap, SnowpackConfig} from '../types/snowpack';
 import {
   BUILD_CACHE,
   checkLockfileHash,
-  CommandOptions,
   DEV_DEPENDENCIES_DIR,
   getEncodingType,
   getExt,
-  ImportMap,
   isYarn,
   openInBrowser,
   parsePackageImportSpecifier,

--- a/packages/snowpack/src/commands/install.ts
+++ b/packages/snowpack/src/commands/install.ts
@@ -13,22 +13,25 @@ import path from 'path';
 import rimraf from 'rimraf';
 import {InputOptions, OutputOptions, rollup, RollupError} from 'rollup';
 import validatePackageName from 'validate-npm-package-name';
-import {EnvVarReplacements, SnowpackConfig, SnowpackSourceFile} from '../config.js';
 import {resolveTargetsFromRemoteCDN} from '../resolve-remote.js';
 import {rollupPluginCatchUnresolved} from '../rollup-plugins/rollup-plugin-catch-unresolved.js';
 import {rollupPluginCatchFetch} from '../rollup-plugins/rollup-plugin-catch-fetch';
 import {rollupPluginCss} from '../rollup-plugins/rollup-plugin-css';
 import {rollupPluginDependencyCache} from '../rollup-plugins/rollup-plugin-remote-cdn.js';
-import {
-  DependencyStatsOutput,
-  rollupPluginDependencyStats,
-} from '../rollup-plugins/rollup-plugin-stats.js';
+import {rollupPluginDependencyStats} from '../rollup-plugins/rollup-plugin-stats.js';
 import {rollupPluginWrapInstallTargets} from '../rollup-plugins/rollup-plugin-wrap-install-targets';
-import {InstallTarget, scanDepList, scanImports, scanImportsFromFiles} from '../scan-imports.js';
+import {scanDepList, scanImports, scanImportsFromFiles} from '../scan-imports.js';
 import {printStats} from '../stats-formatter.js';
 import {
   CommandOptions,
+  DependencyStatsOutput,
+  EnvVarReplacements,
   ImportMap,
+  InstallTarget,
+  SnowpackConfig,
+  SnowpackSourceFile,
+} from '../types/snowpack';
+import {
   isTruthy,
   MISSING_PLUGIN_SUGGESTIONS,
   parsePackageImportSpecifier,

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -4,160 +4,25 @@ import {cosmiconfigSync} from 'cosmiconfig';
 import {all as merge} from 'deepmerge';
 import fs from 'fs';
 import http from 'http';
-import type HttpProxy from 'http-proxy';
 import {validate, ValidatorResult} from 'jsonschema';
 import * as colors from 'kleur/colors';
 import path from 'path';
-import {Plugin as RollupPlugin} from 'rollup';
 import yargs from 'yargs-parser';
 import srcFileExtensionMapping from './build/src-file-extension-mapping';
 import {esbuildPlugin} from './plugins/plugin-esbuild';
+import {
+  CLIFlags,
+  DeepPartial,
+  LoadOptions,
+  OptimizeOptions,
+  Proxy,
+  ProxyOptions,
+  SnowpackConfig,
+  SnowpackPlugin,
+} from './types/snowpack';
 
 const CONFIG_NAME = 'snowpack';
 const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/.types/**/*'];
-
-type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<DeepPartial<U>>
-    : T[P] extends ReadonlyArray<infer U>
-    ? ReadonlyArray<DeepPartial<U>>
-    : DeepPartial<T[P]>;
-};
-
-export type EnvVarReplacements = Record<string, string | number | true>;
-
-export type SnowpackBuildMap = Record<string, string>;
-
-/** Standard file interface */
-export interface SnowpackSourceFile {
-  /** base extension (e.g. `.js`) */
-  baseExt: string;
-  /** file contents */
-  contents: string;
-  /** expanded extension (e.g. `.proxy.js` or `.module.css`) */
-  expandedExt: string;
-  /** if no location on disk, assume this exists in memory */
-  locOnDisk: string;
-}
-
-export interface LoadOptions {
-  filePath: string;
-  fileExt: string;
-  isDev: boolean;
-  log: (msg, data) => void;
-}
-
-export interface TransformOptions {
-  filePath: string;
-  fileExt: string;
-  contents: string;
-  isDev: boolean;
-  log: (msg, data) => void;
-}
-
-export interface PluginProxyOptions {
-  fileUrl: string;
-  contents: string;
-  isDev: boolean;
-  log: (msg, data) => void;
-}
-
-export interface RunOptions {
-  isDev: boolean;
-  log: (msg, data) => void;
-}
-
-/** DEPRECATED */
-export type __OldBuildResult = {result: string; resources?: {css?: string}};
-
-/** map of extensions -> code (e.g. { ".js": "[code]", ".css": "[code]" }) */
-export type LoadResult = string | {[fileExtension: string]: string};
-
-export interface OptimizeOptions {
-  buildDirectory: string;
-  log: (msg, level?: 'INFO' | 'WARN' | 'ERROR') => void;
-}
-
-export interface SnowpackPlugin {
-  /** name of the plugin */
-  name: string;
-  resolve?: {
-    /** file extensions that this load function takes as input (e.g. [".jsx", ".js", …]) */
-    input: string[];
-    /** file extensions that this load function outputs (e.g. [".js", ".css"]) */
-    output: string[];
-  };
-  /** load a file that matches resolve.input */
-  load?(options: LoadOptions): Promise<LoadResult | null | undefined | void>;
-  /** transform a file that matches resolve.input */
-  transform?(options: TransformOptions): Promise<string | null | undefined | void>;
-  /** runs a command, unrelated to file building (e.g. TypeScript, ESLint) */
-  run?(options: RunOptions): Promise<unknown>;
-  /** bundle the entire built application */
-  optimize?(options: OptimizeOptions): Promise<void>;
-  /** Known dependencies that should be installed */
-  knownEntrypoints?: string[];
-}
-
-export type ProxyOptions = HttpProxy.ServerOptions & {
-  // Custom on: {} event handlers
-  on: Record<string, Function>;
-};
-export type Proxy = [string, ProxyOptions];
-
-// interface this library uses internally
-export interface SnowpackConfig {
-  install: string[];
-  extends?: string;
-  exclude: string[];
-  knownEntrypoints: string[];
-  webDependencies?: {[packageName: string]: string};
-  proxy: Proxy[];
-  mount: Record<string, string>;
-  alias: Record<string, string>;
-  scripts: Record<string, string>;
-  plugins: SnowpackPlugin[];
-  devOptions: {
-    secure: boolean;
-    hostname: string;
-    port: number;
-    out: string;
-    fallback: string;
-    open: string;
-    hmr: boolean;
-  };
-  installOptions: {
-    dest: string;
-    env: EnvVarReplacements;
-    treeshake?: boolean;
-    installTypes: boolean;
-    sourceMap?: boolean | 'inline';
-    externalPackage: string[];
-    namedExports: string[];
-    rollup: {
-      plugins: RollupPlugin[]; // for simplicity, only Rollup plugins are supported for now
-      dedupe?: string[];
-    };
-  };
-  buildOptions: {
-    baseUrl: string;
-    webModulesUrl: string;
-    clean: boolean;
-    metaDir: string;
-    minify: boolean;
-  };
-  _extensionMap: Record<string, string>;
-}
-
-export interface CLIFlags extends Omit<Partial<SnowpackConfig['installOptions']>, 'env'> {
-  help?: boolean; // display help text
-  version?: boolean; // display Snowpack version
-  reload?: boolean;
-  config?: string; // manual path to config file
-  env?: string[]; // env vars
-  open?: string[];
-  secure?: boolean;
-}
 
 // default settings
 const DEFAULT_CONFIG: Partial<SnowpackConfig> = {

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -5,11 +5,13 @@ import {addCommand, rmCommand} from './commands/add-rm';
 import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
-import {CLIFlags, loadAndValidateConfig, SnowpackConfig, SnowpackPlugin} from './config.js';
+import {loadAndValidateConfig} from './config.js';
+import {CLIFlags} from './types/snowpack';
 import {clearCache, readLockfile} from './util.js';
 
 export {install as unstable_installCommand} from './commands/install';
 export {createConfiguration} from './config.js';
+export * from './types/snowpack';
 
 const cwd = process.cwd();
 
@@ -110,9 +112,3 @@ export async function cli(args: string[]) {
   console.log(`Unrecognized command: ${cmd}`);
   process.exit(1);
 }
-
-/** Snowpack Build Plugin type */
-export type SnowpackPluginFactory<PluginOptions = object> = (
-  snowpackConfig: SnowpackConfig,
-  pluginOptions?: PluginOptions,
-) => SnowpackPlugin;

--- a/packages/snowpack/src/plugins/plugin-esbuild.ts
+++ b/packages/snowpack/src/plugins/plugin-esbuild.ts
@@ -2,7 +2,7 @@ import {Service, startService} from 'esbuild';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import {promises as fs} from 'fs';
-import {SnowpackPlugin, SnowpackConfig} from '../config';
+import {SnowpackPlugin, SnowpackConfig} from '../types/snowpack';
 
 let esbuildService: Service | null = null;
 

--- a/packages/snowpack/src/resolve-remote.ts
+++ b/packages/snowpack/src/resolve-remote.ts
@@ -2,8 +2,8 @@ import cacache from 'cacache';
 import * as colors from 'kleur/colors';
 import PQueue from 'p-queue';
 import validatePackageName from 'validate-npm-package-name';
-import {SnowpackConfig} from './config.js';
-import {fetchCDNResource, ImportMap, PIKA_CDN, RESOURCE_CACHE} from './util.js';
+import {SnowpackConfig, ImportMap} from './types/snowpack';
+import {fetchCDNResource, PIKA_CDN, RESOURCE_CACHE} from './util.js';
 
 /**
  * Given an install specifier, attempt to resolve it from the CDN.

--- a/packages/snowpack/src/rewrite-imports.ts
+++ b/packages/snowpack/src/rewrite-imports.ts
@@ -1,4 +1,4 @@
-import {SnowpackSourceFile} from './config';
+import {SnowpackSourceFile} from './types/snowpack';
 import {HTML_JS_REGEX} from './util';
 
 const {parse} = require('es-module-lexer');

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-stats.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-stats.ts
@@ -2,18 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import {OutputBundle, Plugin} from 'rollup';
 import zlib from 'zlib';
-
-export type DependencyStats = {
-  size: number;
-  gzip: number;
-  brotli?: number;
-  delta?: number;
-};
-type DependencyStatsMap = {
-  [filePath: string]: DependencyStats;
-};
-type DependencyType = 'direct' | 'common';
-export type DependencyStatsOutput = Record<DependencyType, DependencyStatsMap>;
+import {DependencyType, DependencyStatsOutput} from '../types/snowpack';
 
 export function rollupPluginDependencyStats(
   cb: (dependencyInfo: DependencyStatsOutput) => void,

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -1,7 +1,7 @@
 import * as colors from 'kleur/colors';
 import path from 'path';
 import {Plugin} from 'rollup';
-import {InstallTarget} from '../scan-imports';
+import {InstallTarget} from '../types/snowpack';
 
 function autoDetectExports(fileLoc: string): string[] | undefined {
   try {

--- a/packages/snowpack/src/scan-imports.ts
+++ b/packages/snowpack/src/scan-imports.ts
@@ -6,7 +6,7 @@ import mime from 'mime-types';
 import nodePath from 'path';
 import stripComments from 'strip-comments';
 import validatePackageName from 'validate-npm-package-name';
-import {SnowpackConfig, SnowpackSourceFile} from './config';
+import {InstallTarget, SnowpackConfig, SnowpackSourceFile} from './types/snowpack';
 import {findMatchingAliasEntry, getExt, HTML_JS_REGEX, isTruthy} from './util';
 
 const WEB_MODULES_TOKEN = 'web_modules/';
@@ -21,20 +21,6 @@ const ESM_DYNAMIC_IMPORT_REGEX = /import\((?:['"].+['"]|`[^$]+`)\)/gm;
 const HAS_NAMED_IMPORTS_REGEX = /^[\w\s\,]*\{(.*)\}/s;
 const STRIP_AS = /\s+as\s+.*/; // for `import { foo as bar }`, strips “as bar”
 const DEFAULT_IMPORT_REGEX = /import\s+(\w)+(,\s\{[\w\s]*\})?\s+from/s;
-
-/**
- * An install target represents information about a dependency to install.
- * The specifier is the key pointing to the dependency, either as a package
- * name or as an actual file path within node_modules. All other properties
- * are metadata about what is actually being imported.
- */
-export type InstallTarget = {
-  specifier: string;
-  all: boolean;
-  default: boolean;
-  namespace: boolean;
-  named: string[];
-};
 
 function stripJsExtension(dep: string): string {
   return dep.replace(/\.m?js$/i, '');

--- a/packages/snowpack/src/stats-formatter.ts
+++ b/packages/snowpack/src/stats-formatter.ts
@@ -1,5 +1,5 @@
 import * as colors from 'kleur/colors';
-import {DependencyStats, DependencyStatsOutput} from './rollup-plugins/rollup-plugin-stats';
+import {DependencyStats, DependencyStatsOutput} from './types/snowpack';
 
 /** The minimum width, in characters, of each size column */
 const SIZE_COLUMN_WIDTH = 11;

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -1,0 +1,193 @@
+import type HttpProxy from 'http-proxy';
+import {Plugin as RollupPlugin} from 'rollup';
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[P] extends ReadonlyArray<infer U>
+    ? ReadonlyArray<DeepPartial<U>>
+    : DeepPartial<T[P]>;
+};
+
+export type EnvVarReplacements = Record<string, string | number | true>;
+
+export type SnowpackBuildMap = Record<string, string>;
+
+/** Standard file interface */
+export interface SnowpackSourceFile {
+  /** base extension (e.g. `.js`) */
+  baseExt: string;
+  /** file contents */
+  contents: string;
+  /** expanded extension (e.g. `.proxy.js` or `.module.css`) */
+  expandedExt: string;
+  /** if no location on disk, assume this exists in memory */
+  locOnDisk: string;
+}
+
+export interface LoadOptions {
+  filePath: string;
+  fileExt: string;
+  isDev: boolean;
+  log: (msg, data) => void;
+}
+
+export interface TransformOptions {
+  filePath: string;
+  fileExt: string;
+  contents: string;
+  isDev: boolean;
+  log: (msg, data) => void;
+}
+
+export interface PluginProxyOptions {
+  fileUrl: string;
+  contents: string;
+  isDev: boolean;
+  log: (msg, data) => void;
+}
+
+export interface RunOptions {
+  isDev: boolean;
+  log: (msg, data) => void;
+}
+
+/** DEPRECATED */
+export type __OldBuildResult = {result: string; resources?: {css?: string}};
+
+/** map of extensions -> code (e.g. { ".js": "[code]", ".css": "[code]" }) */
+export type LoadResult = string | {[fileExtension: string]: string};
+
+export interface OptimizeOptions {
+  buildDirectory: string;
+  log: (msg, level?: 'INFO' | 'WARN' | 'ERROR') => void;
+}
+
+export interface SnowpackPlugin {
+  /** name of the plugin */
+  name: string;
+  resolve?: {
+    /** file extensions that this load function takes as input (e.g. [".jsx", ".js", …]) */
+    input: string[];
+    /** file extensions that this load function outputs (e.g. [".js", ".css"]) */
+    output: string[];
+  };
+  /** load a file that matches resolve.input */
+  load?(options: LoadOptions): Promise<LoadResult | null | undefined | void>;
+  /** transform a file that matches resolve.input */
+  transform?(options: TransformOptions): Promise<string | null | undefined | void>;
+  /** controls how a non-JS file should be imported into JS. */
+  proxy?(options: PluginProxyOptions): string | null | undefined | void;
+  /** runs a command, unrelated to file building (e.g. TypeScript, ESLint) */
+  run?(options: RunOptions): Promise<unknown>;
+  /** optimize the entire built application */
+  optimize?(options: OptimizeOptions): Promise<void>;
+  /** Known dependencies that should be installed */
+  knownEntrypoints?: string[];
+}
+
+/** Snowpack Build Plugin type */
+export type SnowpackPluginFactory<PluginOptions = object> = (
+  snowpackConfig: SnowpackConfig,
+  pluginOptions?: PluginOptions,
+) => SnowpackPlugin;
+
+export type ProxyOptions = HttpProxy.ServerOptions & {
+  // Custom on: {} event handlers
+  on: Record<string, Function>;
+};
+export type Proxy = [string, ProxyOptions];
+
+// interface this library uses internally
+export interface SnowpackConfig {
+  install: string[];
+  extends?: string;
+  exclude: string[];
+  knownEntrypoints: string[];
+  webDependencies?: {[packageName: string]: string};
+  proxy: Proxy[];
+  mount: Record<string, string>;
+  alias: Record<string, string>;
+  scripts: Record<string, string>;
+  plugins: SnowpackPlugin[];
+  devOptions: {
+    secure: boolean;
+    hostname: string;
+    port: number;
+    out: string;
+    fallback: string;
+    open: string;
+    hmr: boolean;
+  };
+  installOptions: {
+    dest: string;
+    env: EnvVarReplacements;
+    treeshake?: boolean;
+    installTypes: boolean;
+    sourceMap?: boolean | 'inline';
+    externalPackage: string[];
+    namedExports: string[];
+    rollup: {
+      plugins: RollupPlugin[]; // for simplicity, only Rollup plugins are supported for now
+      dedupe?: string[];
+    };
+  };
+  buildOptions: {
+    baseUrl: string;
+    webModulesUrl: string;
+    clean: boolean;
+    metaDir: string;
+    minify: boolean;
+  };
+  _extensionMap: Record<string, string>;
+}
+
+export interface CLIFlags extends Omit<Partial<SnowpackConfig['installOptions']>, 'env'> {
+  help?: boolean; // display help text
+  version?: boolean; // display Snowpack version
+  reload?: boolean;
+  config?: string; // manual path to config file
+  env?: string[]; // env vars
+  open?: string[];
+  secure?: boolean;
+}
+
+export interface ImportMap {
+  imports: {[packageName: string]: string};
+}
+
+export interface CommandOptions {
+  cwd: string;
+  config: SnowpackConfig;
+  lockfile: ImportMap | null;
+  pkgManifest: any;
+}
+
+/**
+ * An install target represents information about a dependency to install.
+ * The specifier is the key pointing to the dependency, either as a package
+ * name or as an actual file path within node_modules. All other properties
+ * are metadata about what is actually being imported.
+ */
+export type InstallTarget = {
+  specifier: string;
+  all: boolean;
+  default: boolean;
+  namespace: boolean;
+  named: string[];
+};
+
+export type DependencyStats = {
+  size: number;
+  gzip: number;
+  brotli?: number;
+  delta?: number;
+};
+
+export type DependencyType = 'direct' | 'common';
+
+export type DependencyStatsMap = {
+  [filePath: string]: DependencyStats;
+};
+
+export type DependencyStatsOutput = Record<DependencyType, DependencyStatsMap>;

--- a/packages/snowpack/src/util.ts
+++ b/packages/snowpack/src/util.ts
@@ -10,7 +10,7 @@ import mkdirp from 'mkdirp';
 import open from 'open';
 import path from 'path';
 import rimraf from 'rimraf';
-import {SnowpackConfig} from './config';
+import {ImportMap, SnowpackConfig} from './types/snowpack';
 
 export const PIKA_CDN = `https://cdn.pika.dev`;
 export const GLOBAL_CACHE_DIR = globalCacheDir('snowpack');
@@ -31,17 +31,6 @@ export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
 // NOTE(fks): Must match empty script elements to work properly.
 export const HTML_JS_REGEX = /(<script.*?type="?module"?.*?>)(.*?)<\/script>/gms;
 export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
-
-export interface ImportMap {
-  imports: {[packageName: string]: string};
-}
-
-export interface CommandOptions {
-  cwd: string;
-  config: SnowpackConfig;
-  lockfile: ImportMap | null;
-  pkgManifest: any;
-}
 
 export function isYarn(cwd: string) {
   return fs.existsSync(path.join(cwd, 'yarn.lock'));


### PR DESCRIPTION
## Changes

This puts all the types for Snowpack into a `types/snowpack.ts` file. This removes most of our circular dependencies in the process, and cleans up the structure (the chief offender was importing `config` everywhere just for its types).

This is a superficial change in TypeScript, and doesn’t affect any functionality.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

If Snowpack builds (CI passes), then this PR should be good to go.

<!-- For someone unfamiliar with the issue, how should this be tested? -->
