### PR TITLE
Update Svelte templates to take advantage of new TS support in Svelte (#643)

### DIFF
--- a/packages/@snowpack/app-template-svelte-typescript/package.json
+++ b/packages/@snowpack/app-template-svelte-typescript/package.json
@@ -14,16 +14,17 @@
     "test": "jest"
   },
   "dependencies": {
-    "svelte": "^3.21.0"
+    "svelte": "^3.24.0"
   },
   "devDependencies": {
     "@snowpack/app-scripts-svelte": "^1.7.0",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/svelte": "^3.0.0",
+    "@tsconfig/svelte": "^1.0.3",
     "@types/jest": "^26.0.4",
     "jest": "^25.4.0",
     "snowpack": "^2.6.4",
-    "svelte-check": "^0.1.53",
+    "svelte-check": "^0.1.59",
     "svelte-preprocess": "^4.0.8",
     "typescript": "^3.9.7"
   },

--- a/packages/@snowpack/app-template-svelte-typescript/src/App.svelte
+++ b/packages/@snowpack/app-template-svelte-typescript/src/App.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	let message:string = 'Learn Svelte with Typescript';
 </script>
 

--- a/packages/@snowpack/app-template-svelte-typescript/tsconfig.json
+++ b/packages/@snowpack/app-template-svelte-typescript/tsconfig.json
@@ -1,11 +1,10 @@
-{
+{ 
+  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
-    "moduleResolution": "node",
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
-    "importsNotUsedAsValues": "error",
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */

--- a/packages/@snowpack/app-template-svelte/package.json
+++ b/packages/@snowpack/app-template-svelte/package.json
@@ -14,14 +14,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "svelte": "^3.21.0"
+    "svelte": "^3.24.0"
   },
   "devDependencies": {
     "@snowpack/app-scripts-svelte": "^1.7.0",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/svelte": "^3.0.0",
     "jest": "^25.4.0",
-    "snowpack": "^2.6.4"
+    "snowpack": "^2.6.4",
+    "svelte-check": "^0.1.59"
   },
   "gitHead": "795f4311d79a70cc9f19f21b512b7f8675d73f17"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,6 +2842,11 @@
   dependencies:
     "@testing-library/dom" "^7.0.3"
 
+"@tsconfig/svelte@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-1.0.3.tgz#7e29c4fd771af94faa3e5dde4b717a1ad8625583"
+  integrity sha512-rk+BuV7fNAE33bywtzgNCbPSVEITOeR9zFPeHHJaD9lTcmjZQQRe5fOGJtsdyG3JJKoAZ4JSYVbll4CvWhC3sA==
+
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
@@ -14371,10 +14376,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-check@^0.1.53:
-  version "0.1.55"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-0.1.55.tgz#7e5261123302db4d6ed54a4ab2ed3f4d3cc9fd82"
-  integrity sha512-jdTmpMe1WLQyciNLZ3/8ApwPmpbKbF0RLu480GDapLp+eAjtVMY1j1afWSUgkc6aeTEvoMA29MnICz+rI6mrYA==
+svelte-check@^0.1.59:
+  version "0.1.59"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-0.1.59.tgz#c318a4d9b517b9e4d161bd8f4aa526e5351c09f5"
+  integrity sha512-6nK3fAB7wUYd1NwusIO1Gts12dKMA8asynC4mRJaHfB7CQDO7/vLeYx4DLdS/VkHuq6io1INzYNsdsjlEHMuoQ==
   dependencies:
     chalk "^4.0.0"
     glob "^7.1.6"
@@ -14441,7 +14446,7 @@ svelte2tsx@*:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte@3.24.0, svelte@^3.18.2, svelte@^3.21.0:
+svelte@3.24.0, svelte@^3.18.2, svelte@^3.21.0, svelte@^3.24.0:
   version "3.24.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.24.0.tgz#6565a42c9705796fa66c6abb4fedc09f4323a4a8"
   integrity sha512-VFXom6EP2DK83kxy4ZlBbaZklSbZIrpNH3oNXlPYHJUuW4q1OuAr3ZoYbfIVTVYPDgrI7Yq0gQcOhDlAtO4qfw==


### PR DESCRIPTION
## Changes

- updated `svelte` and `svelte-check` to latest versions in both the TS and JS templates
- Made changes to the TS template based on @drwpow's suggestions in #643

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

- run `yarn start` and `yarn build` commands in both `app-template-svelte` and `app-template-svelte-typescript`
  - all should run/complete without error.
- run `npx svelte-check` in `app-template-svelte-typescript`
  - it should complete without errors