### PR TITLE
Fix send no js file such as css file directly when match webModulesUrl

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -673,7 +673,7 @@ export async function command(commandOptions: CommandOptions) {
     const fileContents = await fs.readFile(fileLoc, getEncodingType(requestedFileExt));
 
     // 3. Send dependencies directly, since they were already build & resolved at install time.
-    if (reqPath.startsWith(config.buildOptions.webModulesUrl)) {
+    if (reqPath.startsWith(config.buildOptions.webModulesUrl) && reqPath.endsWith('.js')) {
       sendFile(req, res, fileContents, responseFileExt);
       return;
     }


### PR DESCRIPTION
Thanks for 2.7 released.

## Changes
> Send dependencies directly, since they were already build & resolved at install time.

It should be only include '.js' file. Otherwise import something no js assets from node_modules will failed.

## Testing

```js
// import 'antd/dist/antd.css'
// import 'antd/dist/antd.css.map'
```