### PR TITLE
Fix transform() bug

### DIFF
--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -108,9 +108,9 @@ async function runPipelineTransformStep(
         urlPath: `./${path.basename(rootFileName + destExt)}`,
       });
       if (typeof result === 'string') {
-        output[srcExt] = result;
+        output[destExt] = result;
       } else if (result && typeof result === 'object' && (result as {result: string}).result) {
-        output[srcExt] = (result as {result: string}).result;
+        output[destExt] = (result as {result: string}).result;
       }
     }
   }


### PR DESCRIPTION
## Changes

Found the bug that https://www.pika.dev/npm/snowpack/discuss/510 was referring to 😅. I encountered this trying to run `.vue` files through a post-transformation in #684.

This should actually be merged & published soon; without it `transform()` plugins actually don’t work at all.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

This is difficult to test. I encountered this by running the #684 PostCSS plugin locally.

<!-- For someone unfamiliar with the issue, how should this be tested? -->
