### PR TITLE
Add app-template-svelte-typescript template

### DIFF
--- a/packages/create-snowpack-app/README.md
+++ b/packages/create-snowpack-app/README.md
@@ -14,6 +14,7 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [@snowpack/app-template-preact](../@snowpack/app-template-preact)
 - [@snowpack/app-template-react-typescript](../@snowpack/app-template-react-typescript)
 - [@snowpack/app-template-react](../@snowpack/app-template-react)
+- [@snowpack/app-template-svelte-typescript](../@snowpack/app-template-svelte-typescript)
 - [@snowpack/app-template-svelte](../@snowpack/app-template-svelte)
 - [@snowpack/app-template-vue](../@snowpack/app-template-vue)
 


### PR DESCRIPTION
## Changes

Add missing `app-template-svelte-typescript` template.

## Testing

Run locally and make sure a svelte with TypeScript is generated under `snowpack-svelte-ts` folder.

```sh
npx create-snowpack-app snowpack-svelte-ts --template @snowpack/@snowpack/app-template-svelte-typescript
```
