### PR TITLE
Add ts-node for dev

### DIFF
--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -94,6 +94,7 @@
     "yargs-parser": "^18.1.3"
   },
   "devDependencies": {
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.7"
   }
 }

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -18,7 +18,8 @@
   },
   "bin": {
     "sp": "pkg/dist-node/index.bin.js",
-    "snowpack": "pkg/dist-node/index.bin.js"
+    "snowpack": "pkg/dist-node/index.bin.js",
+    "snowpack-ts": "./scripts/ts-node.js"
   },
   "@pika/pack": {
     "pipeline": [
@@ -91,5 +92,8 @@
     "validate-npm-package-name": "^3.0.0",
     "ws": "^7.3.0",
     "yargs-parser": "^18.1.3"
+  },
+  "devDependencies": {
+    "ts-node": "^8.10.2"
   }
 }

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -19,7 +19,7 @@
   "bin": {
     "sp": "pkg/dist-node/index.bin.js",
     "snowpack": "pkg/dist-node/index.bin.js",
-    "snowpack-ts": "./scripts/ts-node.js"
+    "snowpack-ts": "scripts/ts-node.js"
   },
   "@pika/pack": {
     "pipeline": [

--- a/packages/snowpack/scripts/ts-node.bin.ts
+++ b/packages/snowpack/scripts/ts-node.bin.ts
@@ -1,0 +1,3 @@
+import { cli } from '../src/index'
+
+cli(process.argv)

--- a/packages/snowpack/scripts/ts-node.js
+++ b/packages/snowpack/scripts/ts-node.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const tsNode = require('ts-node/dist/bin');
+
+const curArgs = process.argv.slice(2);
+const tsNodeArgs = curArgs.splice(0, curArgs.indexOf('--'));
+const snowpackArgs = curArgs.splice(curArgs.indexOf('--') + 1);
+
+const rootPath = path.resolve(__dirname, '../');
+const tsConfigPath = path.resolve(rootPath, './tsconfig.ts-node.json');
+const tsNodeBinPath = path.resolve(__dirname, './ts-node.bin.ts');
+
+const args = tsNodeArgs.concat(['-P', tsConfigPath, '--dir', rootPath, tsNodeBinPath]).concat(snowpackArgs);
+
+tsNode.main(args);

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -76,7 +76,9 @@ import {
 } from '../util';
 import {command as installCommand} from './install';
 import {getPort, paint} from './paint';
-const HMR_DEV_CODE = readFileSync(path.join(__dirname, '../assets/hmr.js'));
+
+const srcPath = __dirname.slice(0, __dirname.indexOf('/src/'))
+const HMR_DEV_CODE = readFileSync(path.join(srcPath, './assets/hmr.js'));
 
 const DEFAULT_PROXY_ERROR_HANDLER = (
   err: Error,

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -77,8 +77,14 @@ import {
 import {command as installCommand} from './install';
 import {getPort, paint} from './paint';
 
-const srcPath = __dirname.slice(0, __dirname.indexOf('/src/'))
-const HMR_DEV_CODE = readFileSync(path.join(srcPath, './assets/hmr.js'));
+const indexOfSrc = __dirname.indexOf('/src/');
+const srcPath = __dirname.slice(0, indexOfSrc);
+const hrmDevFilePath =
+  indexOfSrc === -1
+    ? path.join(__dirname, '../assets/hmr.js')
+    : path.join(srcPath, './assets/hmr.js');
+
+const HMR_DEV_CODE = readFileSync(hrmDevFilePath);
 
 const DEFAULT_PROXY_ERROR_HANDLER = (
   err: Error,

--- a/packages/snowpack/src/commands/install.ts
+++ b/packages/snowpack/src/commands/install.ts
@@ -14,15 +14,15 @@ import {performance} from 'perf_hooks';
 import rimraf from 'rimraf';
 import {InputOptions, OutputOptions, rollup, RollupError} from 'rollup';
 import validatePackageName from 'validate-npm-package-name';
-import {resolveTargetsFromRemoteCDN} from '../resolve-remote.js';
-import {rollupPluginCatchUnresolved} from '../rollup-plugins/rollup-plugin-catch-unresolved.js';
+import {resolveTargetsFromRemoteCDN} from '../resolve-remote';
+import {rollupPluginCatchUnresolved} from '../rollup-plugins/rollup-plugin-catch-unresolved';
 import {rollupPluginCatchFetch} from '../rollup-plugins/rollup-plugin-catch-fetch';
 import {rollupPluginCss} from '../rollup-plugins/rollup-plugin-css';
-import {rollupPluginDependencyCache} from '../rollup-plugins/rollup-plugin-remote-cdn.js';
-import {rollupPluginDependencyStats} from '../rollup-plugins/rollup-plugin-stats.js';
+import {rollupPluginDependencyCache} from '../rollup-plugins/rollup-plugin-remote-cdn';
+import {rollupPluginDependencyStats} from '../rollup-plugins/rollup-plugin-stats';
 import {rollupPluginWrapInstallTargets} from '../rollup-plugins/rollup-plugin-wrap-install-targets';
-import {scanDepList, scanImports, scanImportsFromFiles} from '../scan-imports.js';
-import {printStats} from '../stats-formatter.js';
+import {scanDepList, scanImports, scanImportsFromFiles} from '../scan-imports';
+import {printStats} from '../stats-formatter';
 import {
   CommandOptions,
   DependencyStatsOutput,
@@ -41,7 +41,7 @@ import {
   writeLockfile,
   isPackageAliasEntry,
   findMatchingAliasEntry,
-} from '../util.js';
+} from '../util';
 
 type InstallResultCode = 'SUCCESS' | 'ASSET' | 'FAIL';
 

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -5,12 +5,12 @@ import {addCommand, rmCommand} from './commands/add-rm';
 import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
-import {loadAndValidateConfig} from './config.js';
+import {loadAndValidateConfig} from './config';
 import {CLIFlags} from './types/snowpack';
-import {clearCache, readLockfile} from './util.js';
+import {clearCache, readLockfile} from './util';
 
 export {install as unstable_installCommand} from './commands/install';
-export {createConfiguration} from './config.js';
+export {createConfiguration} from './config';
 export * from './types/snowpack';
 
 const cwd = process.cwd();

--- a/packages/snowpack/src/resolve-remote.ts
+++ b/packages/snowpack/src/resolve-remote.ts
@@ -3,7 +3,7 @@ import * as colors from 'kleur/colors';
 import PQueue from 'p-queue';
 import validatePackageName from 'validate-npm-package-name';
 import {SnowpackConfig, ImportMap} from './types/snowpack';
-import {fetchCDNResource, PIKA_CDN, RESOURCE_CACHE} from './util.js';
+import {fetchCDNResource, PIKA_CDN, RESOURCE_CACHE} from './util';
 
 /**
  * Given an install specifier, attempt to resolve it from the CDN.

--- a/packages/snowpack/tsconfig.ts-node.json
+++ b/packages/snowpack/tsconfig.ts-node.json
@@ -1,0 +1,18 @@
+{
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "jsx": "react"
+  },
+  "include": ["src/**/*", "@types/**/*", "scripts/ts-node.bin.ts"],
+  "exclude": ["node_modules"]
+}

--- a/test/build/base-url/package.json
+++ b/test/build/base-url/package.json
@@ -5,9 +5,7 @@
   "description": "This test makes sure that %PUBLIC_URL% present in src/index.html doesn’t exist in the final build",
   "scripts": {
     "start": "snowpack dev",
-    "testbuild": "snowpack build",
-    "start:ts": "snowpack-ts dev",
-    "testbuild:ts": "snowpack-ts build"
+    "testbuild": "snowpack build"
   },
   "snowpack": {
     "mount": {

--- a/test/build/base-url/package.json
+++ b/test/build/base-url/package.json
@@ -5,7 +5,9 @@
   "description": "This test makes sure that %PUBLIC_URL% present in src/index.html doesn’t exist in the final build",
   "scripts": {
     "start": "snowpack dev",
-    "testbuild": "snowpack build"
+    "testbuild": "snowpack build",
+    "start:ts": "snowpack-ts dev",
+    "testbuild:ts": "snowpack-ts build"
   },
   "snowpack": {
     "mount": {


### PR DESCRIPTION
## Changes

Add `ts-node` for run snowpack ts source directly, may be it can speed up our dev flow.

```shell
cd snowpack/packages/snowpack
npm link
```
New bin `snowpack-ts` will be add to global.

We can use it as normal pre builded bin `snowpack`, such as:

```shell
snowpack-ts --help
snowpack-ts build
```

We can config `ts-node` by edit `snowpack/packages/snowpack/tsconfig.ts-node.json` or by pass args to ts-node:

```shell
snowpack-ts -T -- --help
```

The args before `--` will be pass to `ts-node`, agrs after `--` will be pass to `snowpack`.

In default we enable `ts-node` `transpileOnly` option for speed up compile time( without type check ).

It will cost 2s in my mac to compile.

```shell
time snowpack-ts --help
# MacBook Pro (15-inch, 2018), 2.2 GHz Intel Core i7, 16 GB 2400 MHz DDR4
# snowpack-ts --help  2.07s user 0.10s system 152% cpu 1.429 total
```

Hope this tool can help we have a better dev experience.

Thanks for hard work on snowpack.

- https://github.com/TypeStrong/ts-node