### PR TITLE
Fix fast-refresh plugin

### DIFF
--- a/packages/@snowpack/plugin-react-refresh/plugin.js
+++ b/packages/@snowpack/plugin-react-refresh/plugin.js
@@ -56,7 +56,7 @@ if (import.meta.hot) {
 module.exports = function reactRefreshTransform(snowpackConfig) {
   return {
     name: '@snowpack/plugin-react-refresh',
-    transform({contents, fileExt, isDev}) {
+    transform({contents, fileExt, filePath, isDev}) {
       // Use long-form "=== false" to handle older Snowpack versions
       if (snowpackConfig.devOptions.hmr === false) {
         return;

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -727,6 +727,7 @@ export async function command(commandOptions: CommandOptions) {
     try {
       responseOutput = await buildFile(fileLoc);
     } catch (err) {
+      console.error(reqPath, err);
       sendError(req, res, 500);
       return;
     }


### PR DESCRIPTION
## Changes

It looks like #659 missed pulling the `filePath` value out of the transform arguments, which leads to all files processed by this plugin failing to build. This change fixes that, and adds some additional logging to make similar issues more obvious to debug in the future.

## Testing

The current issue can be reproduced pretty easily in a fresh snowpack react app by just installing `@snowpack/plugin-react-refresh` and adding it to the `plugins` array, then running `npm start`. The app that opens will be blank, and the devtools network panel shows a 500 loading `/_dist_/App.js`. After making this change to the plugin, the app will load & fast refresh appears to work correctly.
