### PR TITLE
Add minimum node version to engines

### DIFF
--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -20,6 +20,9 @@
     "sp": "pkg/dist-node/index.bin.js",
     "snowpack": "pkg/dist-node/index.bin.js"
   },
+  "engines": {
+    "node": ">=10.19.0"
+  },
   "@pika/pack": {
     "pipeline": [
       [


### PR DESCRIPTION
## Changes

This adds a minimum supported node version, as discussed in https://github.com/pikapkg/snowpack/discussions/696

## Testing

Not really much to test here.  I guess you could nvm install 10.19.0 to ensure that this works, but I'm not sure how to test.  Maybe `npm link` hits the `engines`?  Not sure.  
