### PR TITLE
fix: incorrect anchor point

### DIFF
--- a/docs/docs/05-configuration.md
+++ b/docs/docs/05-configuration.md
@@ -1,6 +1,6 @@
 ## Configuration
 
-Snowpack's behavior can be configured by CLI flags, a custom Snowpack config file, or both. [See the table below for the full list of supported options](#configuration-options).
+Snowpack's behavior can be configured by CLI flags, a custom Snowpack config file, or both. [See the table below for the full list of supported options](#all-config-options).
 
 ### Config Files
 
@@ -92,7 +92,7 @@ $ snowpack dev --no-bundle
   - *Default:`false`, or `true` when run with `snowpack build`*
   - Treeshake your dependencies to optimize your installed files. Snowpack will scan your application to detect which exact imports are used from each package, and then will remove any unused imports from the final install via dead-code elimination (aka tree shaking).
 - **`installTypes`** | `boolean`
-  - Install TypeScript type declarations with your packages. Requires changes to your [tsconfig.json](#TypeScript) to pick up these types.
+  - Install TypeScript type declarations with your packages. Requires changes to your [tsconfig.json](#typescript) to pick up these types.
 - **`alias`** | `{[mapFromPackageName: string]: string}`
   - Alias an installed package name. This applies to imports within your application and within your installed dependency graph.
   - Example: `"alias": {"react": "preact/compat", "react-dom": "preact/compat"}`


### PR DESCRIPTION
## Changes

fix two anchor point in `05-configuration.md`

## Testing

before: 
  1. https://www.snowpack.dev/#configuration-options
  1. https://www.snowpack.dev/#TypeScript

now: 
  1. http://192.168.100.103:8080/#all-config-options
  1. http://192.168.100.103:8080/#typescript

In addition, [there is another failure of the anchor](https://www.snowpack.dev/#installing-non-js-packages), but I can't find the corresponding chapters, maybe it is no longer the anchor?
