### PR TITLE
Remove plugin-webpack limitation info in the README.md

### DIFF
--- a/packages/@snowpack/plugin-webpack/README.md
+++ b/packages/@snowpack/plugin-webpack/README.md
@@ -21,10 +21,6 @@ npm install --save-dev @snowpack/plugin-webpack
 }
 ```
 
-### Limitations
-
-Currently only works for Single Page Applications (SPA) with a single HTML entrypoint. See https://github.com/pikapkg/create-snowpack-app/issues/74 for more info.
-
 ### Plugin Options
 
 - `sourceMap: boolean` - Enable sourcemaps in the bundled output.


### PR DESCRIPTION
## Changes

Remove Limitations section of README because multiple HTML is supported. Mentioned issue was solved (https://github.com/pikapkg/create-snowpack-app/issues/74)