### PR TITLE
fix: run `yarn build` failed

### DIFF
--- a/packages/snowpack/tsconfig.json
+++ b/packages/snowpack/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitAny": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "skipLibCheck": true,
     "jsx": "react"
   },
   "include": ["src/**/*", "@types/**/*"],


### PR DESCRIPTION
## Problem
 tsc throws `react index.d.ts errors` when running `yarn build`

OS: Windows10

![image](https://user-images.githubusercontent.com/16207345/89244247-9a180700-d638-11ea-9eb9-8a3df5f3196f.png)

## Changes

/packages/snowpack/tsconfig.ts
add  `"skipLibCheck": true,`


