### PR TITLE
fix import resolver issue on Windows

### DIFF
--- a/packages/snowpack/src/build/import-resolver.ts
+++ b/packages/snowpack/src/build/import-resolver.ts
@@ -75,12 +75,7 @@ export function createImportResolver({
       // is already the key in the import map. The aliased "to" value is also an entry.
       const importMapEntry = dependencyImportMap.imports[spec];
       if (importMapEntry) {
-        let resolved = path.posix.resolve(config.buildOptions.webModulesUrl, importMapEntry);
-        // Windows fix: temporarily use backslashes until fully resolved (will be transformed to forward slashes later)
-        if (path.sep === '\\') {
-          resolved = resolved.replace(/\//g, '\\');
-        }
-        return resolved;
+        return path.posix.resolve(config.buildOptions.webModulesUrl, importMapEntry);
       }
     }
     return false;


### PR DESCRIPTION
## Changes

- Resolves #687
- https://github.com/pikapkg/snowpack/commit/76dbafc33aebb88c0556e86a25a0a4a0b20b81f7#diff-f91a146b2dcfdeed6a1841e72afd35a3R78 introduced a regression where importResolver would return a windows path instead of a valid URL import.
- This PR reverts that change, and then handles the original Windows issue in a new location, outside of the import resolver.

## Testing

Should be covered by existing tests.
