### PR TITLE
Extended tsconfig.json compiler options with "isolatedModules": true

### DIFF
--- a/packages/@snowpack/app-scripts-lit-element/tsconfig.base.json
+++ b/packages/@snowpack/app-scripts-lit-element/tsconfig.base.json
@@ -8,6 +8,8 @@
     "paths": { "*": ["web_modules/.types/*"] },
     "allowSyntheticDefaultImports": true,
     "importsNotUsedAsValues": "error",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */

--- a/packages/@snowpack/app-scripts-preact/tsconfig.base.json
+++ b/packages/@snowpack/app-scripts-preact/tsconfig.base.json
@@ -9,6 +9,8 @@
     "paths": { "*": ["web_modules/.types/*"] },
     "allowSyntheticDefaultImports": true,
     "importsNotUsedAsValues": "error",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */

--- a/packages/@snowpack/app-scripts-react/tsconfig.base.json
+++ b/packages/@snowpack/app-scripts-react/tsconfig.base.json
@@ -8,6 +8,8 @@
     "paths": { "*": ["web_modules/.types/*"] },
     "allowSyntheticDefaultImports": true,
     "importsNotUsedAsValues": "error",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */

--- a/packages/@snowpack/app-template-blank-typescript/tsconfig.json
+++ b/packages/@snowpack/app-template-blank-typescript/tsconfig.json
@@ -6,6 +6,8 @@
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
     "importsNotUsedAsValues": "error",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */

--- a/packages/@snowpack/app-template-lit-element-typescript/tsconfig.json
+++ b/packages/@snowpack/app-template-lit-element-typescript/tsconfig.json
@@ -11,6 +11,8 @@
     // Don't change these unless you know what you're doing.
     // See: https://github.com/microsoft/TypeScript/issues/25430
     "baseUrl": "./",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     "paths": { "*": ["web_modules/.types/*"] }
     // Feel free to add/edit new config options below:
     // ...

--- a/packages/@snowpack/app-template-react-typescript/tsconfig.json
+++ b/packages/@snowpack/app-template-react-typescript/tsconfig.json
@@ -8,6 +8,8 @@
     // Don't change these unless you know what you're doing.
     // See: https://github.com/microsoft/TypeScript/issues/25430
     "baseUrl": "./",
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     "paths": { "*": ["web_modules/.types/*"] }
     // Feel free to add/edit new config options below:
     // ...

--- a/packages/@snowpack/app-template-svelte-typescript/tsconfig.json
+++ b/packages/@snowpack/app-template-svelte-typescript/tsconfig.json
@@ -5,6 +5,8 @@
     "target": "esnext",
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
+    /* more strict checking for errors that per-file transpilers like `esbuild` would crash */
+    "isolatedModules": true,
     /* noEmit - We only use TypeScript for type checking. */
     "noEmit": true,
     /* Additional Options */


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Extended CSA typescript-based templates. Added `"isolatedModules": true` compiler flag as otherwise single file transpilers as the [esbuild](https://github.com/evanw/esbuild) used within [plugin-build](https://github.com/mprinc/snowpack/tree/master/packages/snowpack/src/plugins/plugin-esbuild.ts)

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

The transpilers strategy of nihilating TypeScript interfaces brings inconsistency with the final code.

Take for example 3 TS files with `a.ts -> b.ts -> c.ts` dependencies:

**`c.ts`**:

```ts
export interface IC{
    hello(name:string):string;
}
```

both `esbuild` and `tsc` would eliminate this interface. Good!

**`b.ts`**:

```ts
export {IC} from './c';
```

`tsc` would here parse `c.ts` as well and understand that it is an interface and remove the export:
```ts
// no export
```

while `esbuild` will not consult `c.ts` (it can even not exist :) ) and falsely leave the export:

```ts
export {IC} from "./c";
```

If we use it in `a.ts`:

```ts
import {IC} from './b';

export class A implements IC{
    hello(name:string):string{
        return `Hello ${name}`;
    }
}
```

Which hurts JS engine :)

```
Uncaught SyntaxError: The requested module './c.js' does not provide an export named 'IC'
```

---

Having the option set will warn on this error with regular `tsc` use, 

```
src/b.ts:1:9 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
```

and force us in **`b.ts`** to use:

```ts
export type {IC} from './c';
```

which is now safe for `esbuild` to eliminate the export.