### PR TITLE
Chore: Remove snowpack from plugin devDeps

### DIFF
--- a/packages/@snowpack/plugin-build-script/package.json
+++ b/packages/@snowpack/plugin-build-script/package.json
@@ -9,8 +9,5 @@
   "dependencies": {
     "execa": "^4.0.3",
     "npm-run-path": "^4.0.1"
-  },
-  "devDependencies": {
-    "snowpack": "^2.7.6"
   }
 }

--- a/packages/@snowpack/plugin-run-script/package.json
+++ b/packages/@snowpack/plugin-run-script/package.json
@@ -9,8 +9,5 @@
   "dependencies": {
     "execa": "^4.0.3",
     "npm-run-path": "^4.0.1"
-  },
-  "devDependencies": {
-    "snowpack": "^2.7.6"
   }
 }


### PR DESCRIPTION
## Changes

This doesn’t affect anything; it just removes some unnecessary devDeps from 2 plugins for consistency.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
