### PR TITLE
Revert "Don’t use workspaces in Lerna"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,9 @@
 {
   "version": "independent",
-  "packages": ["packages/@snowpack/*", "packages/*"],
-  "npmClient": "yarn"
+  "packages": [
+    "packages/@snowpack/*",
+    "packages/*"
+  ],
+  "npmClient": "yarn",
+  "useWorkspaces": true
 }


### PR DESCRIPTION


## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
This reverts commit 2a575b5a981ff8ed2919fd8a6fbe6dd0c377f3a1.

This PR fix that `lerna bootstrap` throw EWORKSPACES error.
```
info cli using local version of lerna
lerna notice cli v3.22.1
lerna info versioning independent
lerna ERR! EWORKSPACES Yarn workspaces are configured in package.json, but not enabled in lerna.json!
lerna ERR! EWORKSPACES Please choose one: useWorkspaces = true in lerna.json, or remove package.json workspaces config
```

The `lerna bootstrap` still failed when I removed package.json workspaces config. So I revert the deleting of `useWorkspaces = true`.

## Testing

No testing.
<!-- For someone unfamiliar with the issue, how should this be tested? -->
