### PR TITLE
Dev server improvements

### DIFF
--- a/packages/@snowpack/app-template-svelte-typescript/package.json
+++ b/packages/@snowpack/app-template-svelte-typescript/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.2.2",
     "snowpack": "^2.7.7",
-    "svelte-check": "^0.1.59",
+    "svelte-check": "^1.0.0",
     "svelte-preprocess": "^4.0.8",
     "typescript": "^3.9.7"
   },

--- a/packages/@snowpack/app-template-svelte-typescript/snowpack.config.json
+++ b/packages/@snowpack/app-template-svelte-typescript/snowpack.config.json
@@ -12,7 +12,7 @@
         "watch": "$1 --watch"
       }
     ],
-    ["@snowpack/plugin-run-script", {"cmd": "svelte-check"}]
+    ["@snowpack/plugin-run-script", {"cmd": "svelte-check --output human", "watch": "$1 --watch", "output": "stream"}]
   ],
   "installOptions": {
     "installTypes": true

--- a/packages/@snowpack/app-template-svelte/package.json
+++ b/packages/@snowpack/app-template-svelte/package.json
@@ -22,7 +22,7 @@
     "@testing-library/svelte": "^3.0.0",
     "jest": "^26.2.2",
     "snowpack": "^2.7.7",
-    "svelte-check": "^0.1.59"
+    "svelte-check": "^1.0.0"
   },
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4"
 }

--- a/packages/@snowpack/plugin-run-script/README.md
+++ b/packages/@snowpack/plugin-run-script/README.md
@@ -30,7 +30,8 @@ Supply any CLI command in `cmd`. Note that this is the same as running the comma
 
 ## Plugin Options
 
-| Name    |   Type   | Description                                                                 |
-| :------ | :------: | :-------------------------------------------------------------------------- |
-| `cmd`   | `string` | The CLI command to run. Note that this will run **before** Snowpack builds. |
-| `watch` | `string` | (optional) A watch command to run during the dev server.                    |
+| Name    |   Type   | Description                                                                   |
+| :------ | :------: | :---------------------------------------------------------------------------- |
+| `cmd`   | `string` | The CLI command to run. Note that this will run **before** Snowpack builds.   |
+| `watch` | `string` | (optional) A watch command to run during the dev server.                      |
+| `output` | `"stream" | "dashboard"` | (optional) Set how the output should be recorded during dev. |

--- a/packages/@snowpack/plugin-run-script/plugin.js
+++ b/packages/@snowpack/plugin-run-script/plugin.js
@@ -3,11 +3,11 @@ const npmRunPath = require('npm-run-path');
 const cwd = process.cwd();
 
 function runScriptPlugin(_, {cmd, watch}) {
-  const cmdProgram = cmd.split(' ')[0];
+  const [cmdProgram] = cmd.split(' ');
   const watchCmd = watch && watch.replace('$1', cmd);
 
   return {
-    name: `run:${cmdProgram}`,
+    name: cmdProgram,
     async run({isDev, log}) {
       const workerPromise = execa.command(isDev ? watchCmd || cmd : cmd, {
         env: npmRunPath.env(),

--- a/packages/@snowpack/plugin-run-script/plugin.js
+++ b/packages/@snowpack/plugin-run-script/plugin.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const npmRunPath = require('npm-run-path');
 const cwd = process.cwd();
 
-function runScriptPlugin(_, {cmd, watch}) {
+function runScriptPlugin(_, {cmd, watch, output}) {
   const [cmdProgram] = cmd.split(' ');
   const watchCmd = watch && watch.replace('$1', cmd);
 
@@ -16,33 +16,35 @@ function runScriptPlugin(_, {cmd, watch}) {
         cwd,
       });
       const {stdout, stderr} = workerPromise;
-      stdout &&
-        stdout.on('data', (b) => {
-          let stdOutput = b.toString();
-          if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
-            log('WORKER_RESET', {});
+      function dataListener(chunk) {
+        let stdOutput = chunk.toString();
+        if (output === 'stream') {
+          log('CONSOLE_INFO', {id: cmdProgram, msg: stdOutput});
+          return;
+        }
+        if (stdOutput.includes('\u001bc') || stdOutput.includes('\x1Bc')) {
+          log('WORKER_RESET', {});
+          log('WORKER_UPDATE', {state: ['RUNNING', 'yellow']});
+          stdOutput = stdOutput.replace(/\x1Bc/, '').replace(/\u001bc/, '');
+        }
+        if (cmdProgram === 'tsc') {
+          if (/Watching for file changes./gm.test(stdOutput)) {
             log('WORKER_UPDATE', {state: ['RUNNING', 'yellow']});
-            stdOutput = stdOutput.replace(/\x1Bc/, '').replace(/\u001bc/, '');
           }
-          if (cmdProgram === 'tsc') {
-            if (/Watching for file changes./gm.test(stdOutput)) {
-              log('WORKER_UPDATE', {state: ['RUNNING', 'yellow']});
-            }
-            const errorMatch = stdOutput.match(/Found (\d+) error/);
-            if (errorMatch) {
-              if (errorMatch[1] === '0') {
-                log('WORKER_UPDATE', {state: ['OK', 'green']});
-              } else {
-                log('WORKER_UPDATE', {state: ['ERROR', 'red']});
-              }
+          const errorMatch = stdOutput.match(/Found (\d+) error/);
+          if (errorMatch) {
+            if (errorMatch[1] === '0') {
+              log('WORKER_UPDATE', {state: ['OK', 'green']});
+              stdOutput = stdOutput.trim();
+            } else {
+              log('WORKER_UPDATE', {state: ['ERROR', 'red']});
             }
           }
-          log('WORKER_MSG', {level: 'log', msg: stdOutput});
-        });
-      stderr &&
-        stderr.on('data', (err) => {
-          log('WORKER_MSG', {level: 'error', msg: err.toString()});
-        });
+        }
+        log('WORKER_MSG', {level: 'log', msg: stdOutput});
+      }
+      stdout && stdout.on('data', dataListener);
+      stderr && stderr.on('data', dataListener);
       return workerPromise;
     },
   };

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -67,12 +67,6 @@ async function runPipelineLoadStep(
         filePath: srcPath,
         isDev,
         isHmrEnabled,
-        // @ts-ignore: internal API only
-        log: (msg, data: any = {}) => {
-          if (data && data.msg) {
-            pluginLogger.info(`${data.msg} [${debugPath}]`);
-          }
-        },
       });
       pluginLogger.debug(`load() successful [${debugPath}]`);
 
@@ -80,9 +74,6 @@ async function runPipelineLoadStep(
 
       if (typeof result === 'string') {
         const mainOutputExt = step.resolve.output[0];
-        if (devMessageBus && isDev) {
-          devMessageBus.emit('SUCCESS', {id: step.name});
-        }
         return {
           [mainOutputExt]: {
             code: result,
@@ -102,19 +93,11 @@ async function runPipelineLoadStep(
           // if source maps disabled, don’t return any
           if (!sourceMaps) result[ext].map = undefined;
         });
-        if (devMessageBus && isDev) {
-          devMessageBus.emit('SUCCESS', {id: step.name});
-        }
         return result;
-      } else {
-        if (devMessageBus && isDev) {
-          devMessageBus.emit('SUCCESS', {id: step.name});
-        }
-        continue;
       }
     } catch (err) {
       if (devMessageBus && isDev) {
-        devMessageBus.emit('ERROR', {id: step.name, msg: err.toString() || err});
+        devMessageBus.emit('CONSOLE_ERROR', {id: step.name, msg: err.toString() || err});
       } else {
         pluginLogger.error(err);
       }
@@ -163,34 +146,22 @@ async function runPipelineTransformStep(
           fileExt: destExt,
           filePath,
           isDev,
-          // @ts-ignore: internal API only
-          log: (msg, data: any = {}) => {
-            if (data && data.msg) {
-              pluginLogger.info(`${data.msg} [${path.relative(process.cwd(), filePath)}]`);
-            }
-          },
           // @ts-ignore: Deprecated
           urlPath: `./${path.basename(rootFileName + destExt)}`,
         });
         pluginLogger.debug(`transform() successful [${debugPath}]`);
-
         // if step returned a value, only update code (don’t touch .map)
         if (typeof result === 'string') {
           output[destExt].code = result;
         } else if (result && typeof result === 'object' && (result as {result: string}).result) {
           output[destExt].code = (result as {result: string}).result;
         }
-
         // if source maps disabled, don’t return any
         if (!sourceMaps) output[destExt].map = undefined;
-
-        if (devMessageBus && isDev) {
-          devMessageBus.emit('SUCCESS', {id: step.name});
-        }
       }
     } catch (err) {
       if (devMessageBus && isDev) {
-        devMessageBus.emit('ERROR', {id: step.name, msg: err.toString() || err});
+        devMessageBus.emit('CONSOLE_ERROR', {id: step.name, msg: err.toString() || err});
       } else {
         pluginLogger.error(err);
       }

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -410,6 +410,7 @@ export async function command(commandOptions: CommandOptions) {
     delete buildPipelineFiles[fileLoc];
   }
   async function onWatchEvent(fileLoc: string) {
+    logger.info(colors.cyan('File changed...'));
     const [fromDisk, dirDest] =
       mountedDirectories.find(([fromDisk]) => fileLoc.startsWith(fromDisk)) || [];
     if (!fromDisk || !dirDest) {

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -214,7 +214,9 @@ class FileBuilder {
   async writeProxyToDisk(originalFileLoc: string) {
     const proxiedCode = this.output[originalFileLoc];
     const importProxyFileLoc = originalFileLoc + '.proxy.js';
-    const proxiedUrl = originalFileLoc.substr(this.config.devOptions.out.length).replace(/\\/g, '/');
+    const proxiedUrl = originalFileLoc
+      .substr(this.config.devOptions.out.length)
+      .replace(/\\/g, '/');
     const proxyCode = await wrapImportProxy({
       url: proxiedUrl,
       code: proxiedCode,
@@ -404,6 +406,7 @@ export async function command(commandOptions: CommandOptions) {
 
   // "--watch" mode - Start watching the file system.
   // Defer "chokidar" loading to here, to reduce impact on overall startup time
+  logger.info(colors.cyan('Watching for changes...'));
   const chokidar = await import('chokidar');
 
   function onDeleteEvent(fileLoc: string) {

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -260,6 +260,7 @@ export async function command(commandOptions: CommandOptions) {
     if (!proxyOptions.on.error) {
       proxyServer.on('error', DEFAULT_PROXY_ERROR_HANDLER);
     }
+    console.log(`Proxy created: ${pathPrefix} -> ${proxyOptions.target || proxyOptions.forward}`)
   });
 
   const readCredentials = async (cwd: string) => {

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -29,7 +29,6 @@ import isCompressible from 'compressible';
 import merge from 'deepmerge';
 import etag from 'etag';
 import {EventEmitter} from 'events';
-import execa from 'execa';
 import {existsSync, promises as fs, readFileSync} from 'fs';
 import http from 'http';
 import HttpProxy from 'http-proxy';
@@ -37,9 +36,9 @@ import http2 from 'http2';
 import https from 'https';
 import * as colors from 'kleur/colors';
 import mime from 'mime-types';
-import npmRunPath from 'npm-run-path';
 import os from 'os';
 import path from 'path';
+import {performance} from 'perf_hooks';
 import onProcessExit from 'signal-exit';
 import stream from 'stream';
 import url from 'url';
@@ -69,7 +68,6 @@ import {
   DEV_DEPENDENCIES_DIR,
   getEncodingType,
   getExt,
-  isYarn,
   jsSourceMappingURL,
   openInBrowser,
   parsePackageImportSpecifier,
@@ -78,7 +76,7 @@ import {
   updateLockfileHash,
 } from '../util';
 import {command as installCommand} from './install';
-import {getPort, paint} from './paint';
+import {getPort, paint, paintEvent} from './paint';
 const HMR_DEV_CODE = readFileSync(path.join(__dirname, '../assets/hmr.js'));
 
 const DEFAULT_PROXY_ERROR_HANDLER = (
@@ -137,6 +135,8 @@ const sendFile = (
     }
   }
 
+  messageBus.emit(paintEvent.SUCCESS, {id: 'snowpack'});
+
   if (/\bgzip\b/.test(acceptEncoding) && stream.Readable.from) {
     const bodyStream = stream.Readable.from([body]);
     headers['Content-Encoding'] = 'gzip';
@@ -180,79 +180,42 @@ function getUrlFromFile(
   return null;
 }
 
-let currentlyRunningCommand: any = null;
+// Important! this must be shimmed before command() fires
+const messageBus = new EventEmitter();
+console.log = (...args) => {
+  args.forEach((msg) => {
+    messageBus.emit(paintEvent.INFO, {msg});
+  });
+};
+console.warn = (...args) => {
+  args.forEach((msg) => {
+    messageBus.emit(paintEvent.WARN, {msg});
+  });
+};
+console.error = (...args) => {
+  args.forEach((msg) => {
+    messageBus.emit(paintEvent.ERROR, {msg});
+  });
+};
 
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config, logLevel = 'info'} = commandOptions;
   const {port: defaultPort, hostname, open, hmr: isHmr} = config.devOptions;
 
   // Start the startup timer!
-  let serverStart = Date.now();
+  let serverStart = performance.now();
   const port = await getPort(defaultPort);
   // Reset the clock if we had to wait for the user to select a new port.
   if (port !== defaultPort) {
-    serverStart = Date.now();
+    serverStart = performance.now();
   }
 
   const inMemoryBuildCache = new Map<string, SnowpackBuildMap>();
   const filesBeingDeleted = new Set<string>();
   const filesBeingBuilt = new Map<string, Promise<SnowpackBuildMap>>();
-  const messageBus = new EventEmitter();
   const mountedDirectories: [string, string][] = Object.entries(config.mount).map(
     ([fromDisk, toUrl]) => {
       return [path.resolve(cwd, fromDisk), toUrl];
-    },
-  );
-
-  console.log = (...args) => {
-    messageBus.emit('CONSOLE', {level: 'log', args});
-  };
-  console.warn = (...args) => {
-    messageBus.emit('CONSOLE', {level: 'warn', args});
-  };
-  console.error = (...args) => {
-    messageBus.emit('CONSOLE', {level: 'error', args});
-  };
-
-  // Start painting immediately, so we can surface errors & warnings to the
-  // user, and they can watch the server starting up. Search for ”SERVER_START”
-  // for the actual start event below.
-  paint(
-    messageBus,
-    config.plugins.map((p) => p.name),
-    undefined,
-    {
-      addPackage: async (pkgName: string) => {
-        isLiveReloadPaused = true;
-        messageBus.emit('INSTALLING');
-        currentlyRunningCommand = execa(
-          isYarn(cwd) ? 'yarn' : 'npm',
-          isYarn(cwd) ? ['add', pkgName] : ['install', '--save', pkgName],
-          {
-            env: npmRunPath.env(),
-            extendEnv: true,
-            shell: true,
-            cwd,
-          },
-        );
-        currentlyRunningCommand.stdout.on('data', (data) => process.stdout.write(data));
-        currentlyRunningCommand.stderr.on('data', (data) => process.stderr.write(data));
-        await currentlyRunningCommand;
-        currentlyRunningCommand = installCommand({...installCommandOptions, logLevel: 'error'});
-        await currentlyRunningCommand;
-        await updateLockfileHash(DEV_DEPENDENCIES_DIR);
-        await cacache.rm.all(BUILD_CACHE);
-        inMemoryBuildCache.clear();
-        currentlyRunningCommand = null;
-
-        dependencyImportMap = JSON.parse(
-          await fs
-            .readFile(dependencyImportMapLoc, {encoding: 'utf-8'})
-            .catch(() => `{"imports": {}}`),
-        );
-        messageBus.emit('INSTALL_COMPLETE');
-        isLiveReloadPaused = false;
-      },
     },
   );
 
@@ -275,6 +238,12 @@ export async function command(commandOptions: CommandOptions) {
     await updateLockfileHash(DEV_DEPENDENCIES_DIR);
   }
 
+  // Start painting dev dashboard after successful install
+  paint(
+    messageBus,
+    config.plugins.map((p) => p.name),
+  );
+
   let dependencyImportMap: ImportMap = {imports: {}};
   try {
     dependencyImportMap = JSON.parse(
@@ -282,28 +251,6 @@ export async function command(commandOptions: CommandOptions) {
     );
   } catch (err) {
     // no import-map found, safe to ignore
-  }
-
-  /** Rerun `snowpack install` while dev server is running */
-  async function reinstallDependencies() {
-    if (!currentlyRunningCommand) {
-      isLiveReloadPaused = true;
-      messageBus.emit('INSTALLING');
-      currentlyRunningCommand = installCommand({...installCommandOptions, logLevel: 'error'});
-      await currentlyRunningCommand.then(async () => {
-        dependencyImportMap = JSON.parse(
-          await fs
-            .readFile(dependencyImportMapLoc, {encoding: 'utf-8'})
-            .catch(() => `{"imports": {}}`),
-        );
-        await updateLockfileHash(DEV_DEPENDENCIES_DIR);
-        await cacache.rm.all(BUILD_CACHE);
-        inMemoryBuildCache.clear();
-        messageBus.emit('INSTALL_COMPLETE');
-        isLiveReloadPaused = false;
-        currentlyRunningCommand = null;
-      });
-    }
   }
 
   const devProxies = {};
@@ -362,22 +309,19 @@ export async function command(commandOptions: CommandOptions) {
 
   for (const runPlugin of config.plugins) {
     if (runPlugin.run) {
-      messageBus.emit('WORKER_START', {id: runPlugin.name});
-      runPlugin
-        .run({
+      try {
+        await runPlugin.run({
           isDev: true,
           isHmrEnabled: isHmr,
           // @ts-ignore: internal API only
           log: (msg, data) => {
             messageBus.emit(msg, {...data, id: runPlugin.name});
           },
-        })
-        .then(() => {
-          messageBus.emit('WORKER_COMPLETE', {id: runPlugin.name, error: null});
-        })
-        .catch((err) => {
-          messageBus.emit('WORKER_COMPLETE', {id: runPlugin.name, error: err});
         });
+        messageBus.emit(paintEvent.SUCCESS, {id: runPlugin.name});
+      } catch (err) {
+        messageBus.emit(paintEvent.ERROR, {id: runPlugin.name, msg: err.toString() || err});
+      }
     }
   }
 
@@ -396,16 +340,14 @@ export async function command(commandOptions: CommandOptions) {
       reqPath = replaceExt(reqPath, '.map', '');
     }
 
-    // const requestStart = Date.now();
     res.on('finish', () => {
       const {method, url} = req;
       const {statusCode} = res;
       if (statusCode !== 200) {
-        messageBus.emit('SERVER_RESPONSE', {
+        messageBus.emit(paintEvent.SERVER_RESPONSE, {
           method,
           url,
           statusCode,
-          // processingTime: Date.now() - requestStart,
         });
       }
     });
@@ -493,10 +435,6 @@ export async function command(commandOptions: CommandOptions) {
 
     const fileLoc = await getFileFromUrl(reqPath);
 
-    if (isRoute) {
-      messageBus.emit('NEW_SESSION');
-    }
-
     if (!fileLoc) {
       const prefix = colors.red('  ✘ ');
       console.error(`[404] ${reqUrl}\n${attemptedFileLoads.map((loc) => prefix + loc).join('\n')}`);
@@ -515,6 +453,7 @@ export async function command(commandOptions: CommandOptions) {
       }
       const fileBuilderPromise = (async () => {
         const builtFileOutput = await _buildFile(fileLoc, {
+          devMessageBus: messageBus,
           plugins: config.plugins,
           isDev: true,
           isHmrEnabled: isHmr,
@@ -526,11 +465,11 @@ export async function command(commandOptions: CommandOptions) {
       })();
       filesBeingBuilt.set(fileLoc, fileBuilderPromise);
       try {
-        messageBus.emit('BUILD_FILE', {id: fileLoc, isBuilding: true});
+        messageBus.emit(paintEvent.BUILD_FILE, {id: fileLoc, isBuilding: true});
         return await fileBuilderPromise;
       } finally {
         filesBeingBuilt.delete(fileLoc);
-        messageBus.emit('BUILD_FILE', {id: fileLoc, isBuilding: false});
+        messageBus.emit(paintEvent.BUILD_FILE, {id: fileLoc, isBuilding: false});
       }
     }
 
@@ -617,7 +556,6 @@ export async function command(commandOptions: CommandOptions) {
       responseExt: string,
       wrappedResponse: string,
     ): Promise<string> {
-      let missingWebModule: {spec: string; pkgName: string} | null = null;
       const resolveImportSpecifier = createImportResolver({
         fileLoc,
         dependencyImportMap,
@@ -640,27 +578,9 @@ export async function command(commandOptions: CommandOptions) {
             }
             return resolvedImportUrl;
           }
-          // If that fails, return a placeholder import and attempt to resolve.
-          const [packageName] = parsePackageImportSpecifier(spec);
-          const [depManifestLoc] = resolveDependencyManifest(packageName, cwd);
-          const doesPackageExist = !!depManifestLoc;
-          if (doesPackageExist) {
-            reinstallDependencies();
-          } else {
-            missingWebModule = {
-              spec: spec,
-              pkgName: packageName,
-            };
-          }
-          // Return a placeholder while Snowpack goes out and tries to re-install (or warn)
-          // on the missing package.
           return spec;
         },
       );
-      messageBus.emit('MISSING_WEB_MODULE', {
-        id: fileLoc,
-        data: missingWebModule,
-      });
       return wrappedResponse;
     }
 
@@ -905,12 +825,12 @@ export async function command(commandOptions: CommandOptions) {
     .filter((i) => i.family === 'IPv4' && i.internal === false)
     .map((i) => i.address);
   const protocol = config.devOptions.secure ? 'https:' : 'http:';
-  messageBus.emit('SERVER_START', {
+  messageBus.emit(paintEvent.SERVER_START, {
     protocol,
     hostname,
     port,
     ips,
-    startTimeMs: Date.now() - serverStart,
+    startTimeMs: performance.now() - serverStart,
   });
 
   // Open the user's browser
@@ -952,7 +872,7 @@ export async function command(commandOptions: CommandOptions) {
       .map(([fileLoc]) => `${path.dirname(fileLoc!)}/**`),
   );
   function onDepWatchEvent() {
-    reinstallDependencies().then(() => hmrEngine.broadcastMessage({type: 'reload'}));
+    hmrEngine.broadcastMessage({type: 'reload'});
   }
   const depWatcher = chokidar.watch([...symlinkedFileLocs], {
     cwd: '/', // we’re using absolute paths, so watch from root

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -260,7 +260,7 @@ export async function command(commandOptions: CommandOptions) {
     if (!proxyOptions.on.error) {
       proxyServer.on('error', DEFAULT_PROXY_ERROR_HANDLER);
     }
-    console.log(`Proxy created: ${pathPrefix} -> ${proxyOptions.target || proxyOptions.forward}`)
+    console.log(`Proxy created: ${pathPrefix} -> ${proxyOptions.target || proxyOptions.forward}`);
   });
 
   const readCredentials = async (cwd: string) => {

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -101,7 +101,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
       process.stdout.write(`  ${colors.bold(colors.cyan(`${protocol}//${hostname}:${port}`))}`);
       for (const ip of ips) {
         process.stdout.write(
-          `  ${colors.cyan(` • `)}${colors.bold(colors.cyan(`${protocol}//${ip}:${port}`))}`,
+          `${colors.cyan(` • `)}${colors.bold(colors.cyan(`${protocol}//${ip}:${port}`))}`,
         );
       }
       process.stdout.write('\n');

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -169,9 +169,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
     repaint();
   });
   bus.on(paintEvent.CONSOLE_INFO, ({id = 'snowpack', msg}) => {
-    for (const msgLine of msg
-      .split('\n')
-      .filter(Boolean)) {
+    for (const msgLine of msg.split('\n').filter(Boolean)) {
       const formatted = NO_COLOR_ENABLED
         ? `[${id}] ${msgLine}`
         : `${colors.dim(`[${id}]`)} ${msgLine}`;
@@ -183,9 +181,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
     repaint();
   });
   bus.on(paintEvent.CONSOLE_WARN, ({id = 'snowpack', msg}) => {
-    for (const msgLine of msg
-      .split('\n')
-      .filter(Boolean)) {
+    for (const msgLine of msg.split('\n').filter(Boolean)) {
       const formatted = NO_COLOR_ENABLED
         ? `[${id}] ${msgLine}`
         : `${colors.dim(`[${id}]`)} ${colors.yellow(`${msgLine}`)}`;
@@ -197,9 +193,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
     repaint();
   });
   bus.on(paintEvent.CONSOLE_ERROR, ({id = 'snowpack', msg}) => {
-    for (const msgLine of msg
-      .split('\n')
-      .filter(Boolean)) {
+    for (const msgLine of msg.split('\n').filter(Boolean)) {
       const formatted = NO_COLOR_ENABLED
         ? `[${id}] ${msgLine}`
         : `${colors.dim(`[${id}]`)} ${colors.red(`${msgLine}`)}`;

--- a/packages/snowpack/src/util.ts
+++ b/packages/snowpack/src/util.ts
@@ -34,10 +34,6 @@ export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gms;
 
 export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
 
-export function isYarn(cwd: string) {
-  return fs.existsSync(path.join(cwd, 'yarn.lock'));
-}
-
 const UTF8_FORMATS = ['.css', '.html', '.js', '.map', '.mjs', '.json', '.svg', '.txt', '.xml'];
 export function getEncodingType(ext: string): 'utf-8' | 'binary' {
   return UTF8_FORMATS.includes(ext) ? 'utf-8' : 'binary';

--- a/test/integration/include-missing-in-package-json/expected-output.txt
+++ b/test/integration/include-missing-in-package-json/expected-output.txt
@@ -1,5 +1,4 @@
 [snowpack] ! installing dependencies…
-Generated an empty chunk: "@material/base/types"
 [snowpack] ✔ install complete
 [snowpack]
   ⦿ web_modules/                     size       gzip       brotli

--- a/yarn.lock
+++ b/yarn.lock
@@ -14000,12 +14000,13 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-check@^0.1.59:
-  version "0.1.59"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-0.1.59.tgz#c318a4d9b517b9e4d161bd8f4aa526e5351c09f5"
-  integrity sha512-6nK3fAB7wUYd1NwusIO1Gts12dKMA8asynC4mRJaHfB7CQDO7/vLeYx4DLdS/VkHuq6io1INzYNsdsjlEHMuoQ==
+svelte-check@^1.0.0:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.0.13.tgz#19acb1e895dc43286f28575e8d2e85eb0f191885"
+  integrity sha512-5dDd1q6f3qauGinsmR9oJ7lrc2JXU+fBUdwUaaBmNw9jsDizlLw4GhMZg6+Rq1JMsx3e6gnBSMzv7/tfsrF8Zw==
   dependencies:
     chalk "^4.0.0"
+    chokidar "^3.4.1"
     glob "^7.1.6"
     minimist "^1.2.5"
     svelte-language-server "*"


### PR DESCRIPTION
## Changes

This improves the dev server logging. Now:

- ✅ All `console.*` messages log and keep (even across page loads!)
- ✅ Plugins can `throw` and the output will bubble up to the dev server
- ✅ Dev server shows state as `ERROR` or `READY`, along with error log (error persists even after fix)

### Screenshots

#### Default (no errors)

![Screen Shot 2020-08-11 at 5 27 14 PM](https://user-images.githubusercontent.com/1369770/89962062-db904f80-dc00-11ea-94cd-073b603ea18a.png)

#### React

![2020-08-11 17-33-18 2020-08-11 17_34_28](https://user-images.githubusercontent.com/1369770/89961984-a08e1c00-dc00-11ea-90ff-13864f71bdef.gif)

#### Vue

![Screen Shot 2020-08-11 at 6 26 59 PM](https://user-images.githubusercontent.com/1369770/89961992-a8e65700-dc00-11ea-87f2-3f74f1c93933.png)

#### Svelte

![Screen Shot 2020-08-11 at 5 55 56 PM](https://user-images.githubusercontent.com/1369770/89962034-c61b2580-dc00-11ea-86c9-a9b15ccda211.png)

#### Lit Element

![Screen Shot 2020-08-11 at 6 01 03 PM](https://user-images.githubusercontent.com/1369770/89961997-ad127480-dc00-11ea-943e-985b1140f525.png)

How about the status bar at bottom? Any changes needed there?

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
