### PR TITLE
add mdx, svgr plugins to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For starter apps and templates, see [create-snowpack-app](./packages/create-snow
 - [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
 - [snowpack-plugin-import-map](https://github.com/zhoukekestar/snowpack-plugin-import-map) A more easy way to map your imports to Pika CDN instead of [import-maps.json](https://github.com/WICG/import-maps).
 - [snowpack-plugin-less](https://github.com/fansenze/snowpack-plugin-less) Use the [Less](https://github.com/less/less.js) compiler to build `.less` files from source.
+- [snowpack-plugin-mdx](https://github.com/jaredLunde/snowpack-plugin-mdx) Use the [MDX](https://github.com/mdx-js/mdx/tree/master/packages/mdx) compiler to build `.mdx` and `.md` files from source.
 - [snowpack-plugin-sass](https://github.com/fansenze/snowpack-plugin-sass) Use the [node-sass](https://github.com/sass/node-sass) to build `.sass/.scss` files from source.
+- [snowpack-plugin-svgr](https://github.com/jaredLunde/snowpack-plugin-svgr) Use [SVGR](https://github.com/gregberge/svgr) to transform `.svg` files into React components.
 - [snowpack-plugin-stylus](https://github.com/fansenze/snowpack-plugin-stylus) Use the [Stylus](https://github.com/stylus/stylus) compiler to build `.styl` files from source.
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes

This adds links to plugins for [MDX](https://github.com/mdx-js/mdx/tree/master/packages/mdx) and [SVGR](https://github.com/gregberge/svgr) to the README
