### PR TITLE
Fix alias path in windows

### DIFF
--- a/packages/snowpack/src/build/import-resolver.ts
+++ b/packages/snowpack/src/build/import-resolver.ts
@@ -64,7 +64,10 @@ export function createImportResolver({
       let result = spec.replace(from, to);
       const importStats = getImportStats(cwd, result);
       result = resolveSourceSpecifier(result, importStats, config);
-      result = path.posix.relative(path.dirname(fileLoc), result);
+      // Replacing separators in relative path instead of using path.posix.relative
+      // Since path.posix.relative will return ../C:\\some\\path when given a Windows
+      // absolute path in the form of C:\\some\\path (result)
+      result = path.relative(path.dirname(fileLoc), result).split(path.sep).join(path.posix.sep);
       if (!result.startsWith('.')) {
         result = './' + result;
       }

--- a/packages/snowpack/src/build/import-resolver.ts
+++ b/packages/snowpack/src/build/import-resolver.ts
@@ -64,10 +64,8 @@ export function createImportResolver({
       let result = spec.replace(from, to);
       const importStats = getImportStats(cwd, result);
       result = resolveSourceSpecifier(result, importStats, config);
-      // Replacing separators in relative path instead of using path.posix.relative
-      // Since path.posix.relative will return ../C:\\some\\path when given a Windows
-      // absolute path in the form of C:\\some\\path (result)
-      result = path.relative(path.dirname(fileLoc), result).split(path.sep).join(path.posix.sep);
+      // replace Windows backslashes at the end, after resolution
+      result = path.relative(path.dirname(fileLoc), result).replace(/\\/g, '/');
       if (!result.startsWith('.')) {
         result = './' + result;
       }


### PR DESCRIPTION
## Changes

Earlier today I upgraded from version 2.6.4 to 2.7.7 and configured the new mount and alias options. On my Mac everything worked great, but on my Windows machine it started giving me these errors showing some really strange looking paths:

![image](https://user-images.githubusercontent.com/6934200/89761690-d1a50a00-daa3-11ea-9da7-dd045f08b297.png)

I looked into it a bit and realized that the culprit is the `path.posix.relative` function not being able to handle absolute paths in Windows properly (see comment for details).

Took a while for me to debug and arrive at this fix, but the fix itself ended up being quite simple, just a matter of using the platform dependent `path.relative` function and the replacing separators in the result.

Before:
![image](https://user-images.githubusercontent.com/6934200/89761412-2bf19b00-daa3-11ea-90a7-4a9e0c7e2d37.png)


After:
![image](https://user-images.githubusercontent.com/6934200/89761499-5ba0a300-daa3-11ea-832e-8e3aa19e13bc.png)

Open to suggestions on alternative approaches to fixing the issue that might be more robust. This feels a bit naive but seems to be working for me so far.

## Testing

I believe this should be reproducible on any Windows machine with some aliases configured. Wasn't sure how to actually write an automated test for it though, since it's platform-dependent. Open to suggestions here also.