### PR TITLE
Easier nodejs polyfills via --polyfill-node

### DIFF
--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -89,6 +89,7 @@
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^2.23.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "signal-exit": "^3.0.3",
     "strip-comments": "^2.0.1",
     "tar": "^6.0.1",

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
     dest: 'web_modules',
     externalPackage: [],
     installTypes: false,
+    polyfillNode: false,
     env: {},
     namedExports: [],
     rollup: {
@@ -102,6 +103,7 @@ const configSchema = {
         externalPackage: {type: 'array', items: {type: 'string'}},
         treeshake: {type: 'boolean'},
         installTypes: {type: 'boolean'},
+        polyfillNode: {type: 'boolean'},
         sourceMap: {oneOf: [{type: 'boolean'}, {type: 'string'}]},
         alias: {
           type: 'object',

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-catch-unresolved.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-catch-unresolved.ts
@@ -17,7 +17,7 @@ export function rollupPluginCatchUnresolved(): Plugin {
       if (isNodeBuiltin(id)) {
         this.warn({
           id: importer,
-          message: `"${id}" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved)`,
+          message: `Import "${id}" (Node.js built-in) is not available in the browser. Run with --polyfill-node to fix.`,
         });
       } else {
         this.warn({

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -124,6 +124,7 @@ export interface SnowpackConfig {
     env: EnvVarReplacements;
     treeshake?: boolean;
     installTypes: boolean;
+    polyfillNode: boolean;
     sourceMap?: boolean | 'inline';
     externalPackage: string[];
     namedExports: string[];

--- a/test/integration/config-polyfill-node/expected-install/import-map.json
+++ b/test/integration/config-polyfill-node/expected-install/import-map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "node-builtin-pkg": "./node-builtin-pkg.js"
+  }
+}

--- a/test/integration/config-polyfill-node/expected-install/node-builtin-pkg.js
+++ b/test/integration/config-polyfill-node/expected-install/node-builtin-pkg.js
@@ -1,0 +1,252 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// resolves . and .. elements in a path array with directory names there
+// must be no slashes, empty elements, or device names (c:\) in the array
+// (so also no leading and trailing slashes - it does not distinguish
+// relative and absolute paths)
+function normalizeArray(parts, allowAboveRoot) {
+  // if the path tries to go above the root, `up` ends up > 0
+  var up = 0;
+  for (var i = parts.length - 1; i >= 0; i--) {
+    var last = parts[i];
+    if (last === '.') {
+      parts.splice(i, 1);
+    } else if (last === '..') {
+      parts.splice(i, 1);
+      up++;
+    } else if (up) {
+      parts.splice(i, 1);
+      up--;
+    }
+  }
+
+  // if the path is allowed to go above the root, restore leading ..s
+  if (allowAboveRoot) {
+    for (; up--; up) {
+      parts.unshift('..');
+    }
+  }
+
+  return parts;
+}
+
+// Split a filename into [root, dir, basename, ext], unix version
+// 'root' is just a slash, or nothing.
+var splitPathRe =
+    /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
+var splitPath = function(filename) {
+  return splitPathRe.exec(filename).slice(1);
+};
+
+// path.resolve([from ...], to)
+// posix version
+function resolve() {
+  var resolvedPath = '',
+      resolvedAbsolute = false;
+
+  for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+    var path = (i >= 0) ? arguments[i] : '/';
+
+    // Skip empty and invalid entries
+    if (typeof path !== 'string') {
+      throw new TypeError('Arguments to path.resolve must be strings');
+    } else if (!path) {
+      continue;
+    }
+
+    resolvedPath = path + '/' + resolvedPath;
+    resolvedAbsolute = path.charAt(0) === '/';
+  }
+
+  // At this point the path should be resolved to a full absolute path, but
+  // handle relative paths to be safe (might happen when process.cwd() fails)
+
+  // Normalize the path
+  resolvedPath = normalizeArray(filter(resolvedPath.split('/'), function(p) {
+    return !!p;
+  }), !resolvedAbsolute).join('/');
+
+  return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
+}
+// path.normalize(path)
+// posix version
+function normalize(path) {
+  var isPathAbsolute = isAbsolute(path),
+      trailingSlash = substr(path, -1) === '/';
+
+  // Normalize the path
+  path = normalizeArray(filter(path.split('/'), function(p) {
+    return !!p;
+  }), !isPathAbsolute).join('/');
+
+  if (!path && !isPathAbsolute) {
+    path = '.';
+  }
+  if (path && trailingSlash) {
+    path += '/';
+  }
+
+  return (isPathAbsolute ? '/' : '') + path;
+}
+// posix version
+function isAbsolute(path) {
+  return path.charAt(0) === '/';
+}
+
+// posix version
+function join() {
+  var paths = Array.prototype.slice.call(arguments, 0);
+  return normalize(filter(paths, function(p, index) {
+    if (typeof p !== 'string') {
+      throw new TypeError('Arguments to path.join must be strings');
+    }
+    return p;
+  }).join('/'));
+}
+
+
+// path.relative(from, to)
+// posix version
+function relative(from, to) {
+  from = resolve(from).substr(1);
+  to = resolve(to).substr(1);
+
+  function trim(arr) {
+    var start = 0;
+    for (; start < arr.length; start++) {
+      if (arr[start] !== '') break;
+    }
+
+    var end = arr.length - 1;
+    for (; end >= 0; end--) {
+      if (arr[end] !== '') break;
+    }
+
+    if (start > end) return [];
+    return arr.slice(start, end - start + 1);
+  }
+
+  var fromParts = trim(from.split('/'));
+  var toParts = trim(to.split('/'));
+
+  var length = Math.min(fromParts.length, toParts.length);
+  var samePartsLength = length;
+  for (var i = 0; i < length; i++) {
+    if (fromParts[i] !== toParts[i]) {
+      samePartsLength = i;
+      break;
+    }
+  }
+
+  var outputParts = [];
+  for (var i = samePartsLength; i < fromParts.length; i++) {
+    outputParts.push('..');
+  }
+
+  outputParts = outputParts.concat(toParts.slice(samePartsLength));
+
+  return outputParts.join('/');
+}
+
+var sep = '/';
+var delimiter = ':';
+
+function dirname(path) {
+  var result = splitPath(path),
+      root = result[0],
+      dir = result[1];
+
+  if (!root && !dir) {
+    // No dirname whatsoever
+    return '.';
+  }
+
+  if (dir) {
+    // It has a dirname, strip trailing slash
+    dir = dir.substr(0, dir.length - 1);
+  }
+
+  return root + dir;
+}
+
+function basename(path, ext) {
+  var f = splitPath(path)[2];
+  // TODO: make this comparison case-insensitive on windows?
+  if (ext && f.substr(-1 * ext.length) === ext) {
+    f = f.substr(0, f.length - ext.length);
+  }
+  return f;
+}
+
+
+function extname(path) {
+  return splitPath(path)[3];
+}
+var path = {
+  extname: extname,
+  basename: basename,
+  dirname: dirname,
+  sep: sep,
+  delimiter: delimiter,
+  relative: relative,
+  join: join,
+  isAbsolute: isAbsolute,
+  normalize: normalize,
+  resolve: resolve
+};
+function filter (xs, f) {
+    if (xs.filter) return xs.filter(f);
+    var res = [];
+    for (var i = 0; i < xs.length; i++) {
+        if (f(xs[i], i, xs)) res.push(xs[i]);
+    }
+    return res;
+}
+
+// String.prototype.substr - negative index don't work in IE8
+var substr = 'ab'.substr(-1) === 'b' ?
+    function (str, start, len) { return str.substr(start, len) } :
+    function (str, start, len) {
+        if (start < 0) start = str.length + start;
+        return str.substr(start, len);
+    }
+;
+
+var path$1 = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  resolve: resolve,
+  normalize: normalize,
+  isAbsolute: isAbsolute,
+  join: join,
+  relative: relative,
+  sep: sep,
+  delimiter: delimiter,
+  dirname: dirname,
+  basename: basename,
+  extname: extname,
+  'default': path
+});
+
+const FOO = 42;
+console.log(path$1);
+
+export { FOO };

--- a/test/integration/config-polyfill-node/expected-output.txt
+++ b/test/integration/config-polyfill-node/expected-output.txt
@@ -1,0 +1,5 @@
+[snowpack] ! installing dependencies…
+[snowpack] ✔ install complete
+[snowpack] 
+  ⦿ web_modules/            size       gzip       brotli   
+    └─ node-builtin-pkg.js    XXXX KB    XXXX KB    XXXX KB

--- a/test/integration/config-polyfill-node/package.json
+++ b/test/integration/config-polyfill-node/package.json
@@ -1,18 +1,21 @@
 {
   "private": true,
   "version": "1.0.1",
-  "name": "@snowpack/test-error-node-builtin-unresolved",
+  "name": "@snowpack/test-config-polyfill-node",
   "scripts": {
     "testinstall": "snowpack"
   },
   "snowpack": {
     "exclude": ["packages/**/*"],
     "install": [
-      "bad-node-builtin-pkg"
-    ]
+      "node-builtin-pkg"
+    ],
+    "installOptions": {
+      "polyfillNode": true
+    }
   },
   "dependencies": {
-    "bad-node-builtin-pkg": "file:./packages/bad-node-builtin-pkg"
+    "node-builtin-pkg": "file:./packages/node-builtin-pkg"
   },
   "devDependencies": {
     "snowpack": "^2.7.0"

--- a/test/integration/config-polyfill-node/packages/node-builtin-pkg/entrypoint.js
+++ b/test/integration/config-polyfill-node/packages/node-builtin-pkg/entrypoint.js
@@ -1,0 +1,3 @@
+export const FOO = 42;
+import * as path from 'path';
+console.log(path);

--- a/test/integration/config-polyfill-node/packages/node-builtin-pkg/package.json
+++ b/test/integration/config-polyfill-node/packages/node-builtin-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.2.3",
+  "name": "node-builtin-pkg",
+  "module": "entrypoint.js"
+}

--- a/test/integration/error-file-ext/expected-output.txt
+++ b/test/integration/error-file-ext/expected-output.txt
@@ -1,4 +1,4 @@
 [snowpack] ! installing dependencies…
 [snowpack] Failed to load ../../../node_modules/error-file-ext-dep-b/index.vue
   Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)
-[snowpack] install skipped (nothing to install)
+[snowpack] Install failed.

--- a/test/integration/error-missing-dep/expected-output.txt
+++ b/test/integration/error-missing-dep/expected-output.txt
@@ -1,3 +1,3 @@
 [snowpack] ! installing dependencies…
 [snowpack] Package "fake-module" not found. Have you installed it?
-[snowpack] install skipped (nothing to install)
+[snowpack] Install failed.

--- a/test/integration/error-node-builtin-unresolved/expected-output.txt
+++ b/test/integration/error-node-builtin-unresolved/expected-output.txt
@@ -1,6 +1,4 @@
 [snowpack] ! installing dependencies…
 [snowpack] ../../../node_modules/bad-node-builtin-pkg/entrypoint.js
-   "XXXX" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved)
-[snowpack] "XXXX" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved). See https://www.snowpack.dev/#troubleshooting
-[snowpack] Entry module cannot be external (http).
-[snowpack] install skipped (nothing to install)
+   Import "http" (Node.js built-in) is not available in the browser. Run with --polyfill-node to fix.
+[snowpack] Install failed.

--- a/test/integration/error-node-builtin-unresolved/expected-output.win.txt
+++ b/test/integration/error-node-builtin-unresolved/expected-output.win.txt
@@ -1,6 +1,0 @@
-[snowpack] ! installing dependencies…
-[snowpack] "XXXX" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved). See https://www.snowpack.dev/#troubleshooting
-[snowpack] Entry module cannot be external (http).
-[snowpack] install skipped (nothing to install)
-[snowpack] ../../../node_modules/bad-node-builtin-pkg/entrypoint.js
-   "XXXX" (Node.js built-in) could not be resolved. (https://www.snowpack.dev/#node-built-in-could-not-be-resolved)

--- a/test/integration/install.test.js
+++ b/test/integration/install.test.js
@@ -34,9 +34,6 @@ function stripConfigErrorPath(stdout) {
 function stripResolveErrorPath(stdout) {
   return stdout.replace(/" via "(.*)"/g, '" via "XXX"');
 }
-function stripNodeBuiltIn(stdout) {
-  return stdout.replace(/"[^"]+"(\s+\(Node.js built-in\))/g, '"XXXX"$1'); // these errors don’t throw in the same order each time, so test quantity, not order
-}
 function stripStacktrace(stdout) {
   return stdout.replace(/^\s+at\s+.*/gm, ''); // this is OK to show to the user but annoying to have in a test
 }
@@ -89,7 +86,7 @@ describe('snowpack install', () => {
         stripWhitespace(
           stripConfigErrorPath(
             stripResolveErrorPath(
-              stripBenchmark(stripChunkHash(stripStats(stripStacktrace(stripNodeBuiltIn(all))))),
+              stripBenchmark(stripChunkHash(stripStats(stripStacktrace((all))))),
             ),
           ),
         ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10388,6 +10388,9 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+"node-builtin-pkg@file:./test/integration/config-polyfill-node/packages/node-builtin-pkg":
+  version "1.2.3"
+
 "node-env-mock-pkg@file:./test/integration/node-env/packages/node-env-mock-pkg":
   version "1.2.3"
 
@@ -12890,6 +12893,22 @@ rollup-plugin-babel@^4.3.0:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-inject@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz#e4233855bfba6c0c12a312fd6649dff9a13ee9f4"
+  integrity sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==
+  dependencies:
+    estree-walker "^0.6.1"
+    magic-string "^0.25.3"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-node-polyfills@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz#53092a2744837164d5b8a28812ba5f3ff61109fd"
+  integrity sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==
+  dependencies:
+    rollup-plugin-inject "^3.0.0"
 
 rollup-plugin-svelte@^5.1.1, rollup-plugin-svelte@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
Resolves #639 

## Changes

- Right now, polyfilling means going out, finding the right plugin, installing it, and connecting it properly to Snowpack
- This PR makes that much easier with a new, built-in polyfill support via `--polyfill-node` & `installOptions.polyfillNode`
- Also, couldn't help myself and cleaned up some error reporting in the install command.

## Testing

- Test added.