### PR TITLE
Fix #554 import specifier match regexp to ignore complicated expressions

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -60,6 +60,7 @@ import {
   transformEsmImports,
   transformFileImports,
 } from '../rewrite-imports';
+import {matchImportSpecifier} from '../scan-imports';
 import {CommandOptions, ImportMap, SnowpackBuildMap, SnowpackConfig} from '../types/snowpack';
 import {
   BUILD_CACHE,
@@ -590,8 +591,7 @@ export async function command(commandOptions: CommandOptions) {
           const resolvedImports = rawImports.map((imp) => {
             let spec = code.substring(imp.s, imp.e);
             if (imp.d > -1) {
-              const importSpecifierMatch = spec.match(/^\s*['"](.*)['"]\s*$/m);
-              spec = importSpecifierMatch![1];
+              spec = matchImportSpecifier(spec) || '';
             }
             return path.posix.resolve(path.posix.dirname(reqPath), spec);
           });

--- a/packages/snowpack/src/rewrite-imports.ts
+++ b/packages/snowpack/src/rewrite-imports.ts
@@ -1,5 +1,6 @@
 import {SnowpackSourceFile} from './types/snowpack';
 import {HTML_JS_REGEX} from './util';
+import {matchImportSpecifier} from './scan-imports';
 
 const {parse} = require('es-module-lexer');
 
@@ -17,8 +18,7 @@ export async function scanCodeImportsExports(code: string): Promise<any[]> {
     // imp.d > -1 === dynamic import
     if (imp.d > -1) {
       const importStatement = code.substring(imp.s, imp.e);
-      const importSpecifierMatch = importStatement.match(/^\s*['"](.*)['"]\s*$/m);
-      return !!importSpecifierMatch;
+      return !!matchImportSpecifier(importStatement);
     }
     return true;
   });
@@ -33,8 +33,7 @@ export async function transformEsmImports(
   for (const imp of imports.reverse()) {
     let spec = rewrittenCode.substring(imp.s, imp.e);
     if (imp.d > -1) {
-      const importSpecifierMatch = spec.match(/^\s*['"](.*)['"]\s*$/m);
-      spec = importSpecifierMatch![1];
+      spec = matchImportSpecifier(spec) || '';
     }
     let rewrittenImport = replaceImport(spec);
     if (imp.d > -1) {

--- a/packages/snowpack/src/scan-imports.ts
+++ b/packages/snowpack/src/scan-imports.ts
@@ -47,6 +47,11 @@ function removeSpecifierQueryString(specifier: string) {
   return specifier;
 }
 
+export function matchImportSpecifier(importStatement: string) {
+  const matched = importStatement.match(/^\s*('([^']+)'|"([^"]+)")\s*$/m);
+  return matched?.[2] || matched?.[3] || null;
+}
+
 function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier) {
   // import.meta: we can ignore
   if (imp.d === -2) {
@@ -58,8 +63,7 @@ function getWebModuleSpecifierFromCode(code: string, imp: ImportSpecifier) {
   }
   // Dynamic imports: a bit trickier to parse. Today, we only support string literals.
   const importStatement = code.substring(imp.s, imp.e);
-  const importSpecifierMatch = importStatement.match(/^\s*['"](.*)['"]\s*$/m);
-  return importSpecifierMatch ? importSpecifierMatch[1] : null;
+  return matchImportSpecifier(importStatement);
 }
 
 /**

--- a/test/integration/include/dir/d.tsx
+++ b/test/integration/include/dir/d.tsx
@@ -1,5 +1,6 @@
 // test 4: dynamic export
 import(`bad:${'template'}-string`);
+import('single quote -' + 'bad:template-string');
 
 const badVariable = 'bad:cant-scan-a-variable';
 import(badVariable);


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
1. extract import specifier match reg to a function in scan-imports.ts
2. fix the reg exp to recognise plain string only, so it will skip parsing, replacing this part and fix #554 
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Test dynamic imports with expressions like this:

`import('single quote -' + 'bad:template-string');`

`import("double quote -" + "bad:template-string");`