### PR TITLE
fix alias with trailing slash

### DIFF
--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -492,6 +492,7 @@ function normalizeAlias(config: SnowpackConfig, createMountAlias: boolean) {
       replacement.startsWith('../') ||
       replacement.startsWith('/')
     ) {
+      delete cleanAlias[target];
       cleanAlias[addTrailingSlash(target)] = addTrailingSlash(path.resolve(cwd, replacement));
     }
   }

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -492,10 +492,8 @@ function normalizeAlias(config: SnowpackConfig, createMountAlias: boolean) {
       replacement.startsWith('../') ||
       replacement.startsWith('/')
     ) {
-      cleanAlias[target] = path.resolve(cwd, replacement);
-      if (hasTrailingSlash(replacement)) {
-        cleanAlias[target] = addTrailingSlash(cleanAlias[target]);
-      }
+      delete cleanAlias[target];
+      cleanAlias[addTrailingSlash(target)] = addTrailingSlash(path.resolve(cwd, replacement));
     }
   }
   return cleanAlias;
@@ -834,10 +832,6 @@ export function removeLeadingSlash(path: string) {
 
 export function removeTrailingSlash(path: string) {
   return path.replace(/[/\\]+$/, '');
-}
-
-export function hasTrailingSlash(path: string) {
-  return path.match(/\/$/);
 }
 
 export function addLeadingSlash(path: string) {

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -482,7 +482,7 @@ function normalizeAlias(config: SnowpackConfig, createMountAlias: boolean) {
   if (createMountAlias) {
     for (const mountDir of Object.keys(config.mount)) {
       if (mountDir !== '.') {
-        cleanAlias[removeTrailingSlash(mountDir)] = `./${mountDir}`;
+        cleanAlias[addTrailingSlash(mountDir)] = addTrailingSlash(`./${mountDir}`);
       }
     }
   }
@@ -492,7 +492,6 @@ function normalizeAlias(config: SnowpackConfig, createMountAlias: boolean) {
       replacement.startsWith('../') ||
       replacement.startsWith('/')
     ) {
-      delete cleanAlias[target];
       cleanAlias[addTrailingSlash(target)] = addTrailingSlash(path.resolve(cwd, replacement));
     }
   }

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -493,6 +493,9 @@ function normalizeAlias(config: SnowpackConfig, createMountAlias: boolean) {
       replacement.startsWith('/')
     ) {
       cleanAlias[target] = path.resolve(cwd, replacement);
+      if (hasTrailingSlash(replacement)) {
+        cleanAlias[target] = addTrailingSlash(cleanAlias[target]);
+      }
     }
   }
   return cleanAlias;
@@ -831,6 +834,10 @@ export function removeLeadingSlash(path: string) {
 
 export function removeTrailingSlash(path: string) {
   return path.replace(/[/\\]+$/, '');
+}
+
+export function hasTrailingSlash(path: string) {
+  return path.match(/\/$/);
 }
 
 export function addLeadingSlash(path: string) {

--- a/test/build/resolve-imports/expected-build/_dist_/index.js
+++ b/test/build/resolve-imports/expected-build/_dist_/index.js
@@ -7,10 +7,11 @@ console.log(flatten, aliasedDep);
 import sort from './sort.js'; // relative import
 import sort_ from './sort.js'; // bare import using alias
 import sort__ from './sort.js'; // bare import using alias + extension
-console.log(sort, sort_, sort__);
+import sort___ from './sort.js'; // bare import using alias with trailing slash
+console.log(sort, sort_, sort__, sort___);
 
 // Importing a directory index.js file
-import components from './components/index.js'; // relative import 
+import components from './components/index.js'; // relative import
 import components______ from './components/index.js'; // relative import with trailing slash
 import components_ from './components/index.js'; // relative import with index appended
 import components__ from './components/index.js'; // relative import with index appended
@@ -21,6 +22,6 @@ console.log(components, components_, components__, components___, components____
 
 
 // Importing something that isn't JS
-import styles from './components/style.css.proxy.js'; // relative import 
-import styles_ from './components/style.css.proxy.js'; // relative import 
+import styles from './components/style.css.proxy.js'; // relative import
+import styles_ from './components/style.css.proxy.js'; // relative import
 console.log(styles, styles_);

--- a/test/build/resolve-imports/package.json
+++ b/test/build/resolve-imports/package.json
@@ -9,7 +9,8 @@
   "snowpack": {
     "alias": {
       "aliased-dep": "array-flatten",
-      "@app": "./src"
+      "@app": "./src",
+      "@/": "./src/"
     },
     "mount": {
       "./src": "/_dist_"

--- a/test/build/resolve-imports/src/index.js
+++ b/test/build/resolve-imports/src/index.js
@@ -7,10 +7,11 @@ console.log(flatten, aliasedDep);
 import sort from './sort'; // relative import
 import sort_ from '@app/sort'; // bare import using alias
 import sort__ from '@app/sort.js'; // bare import using alias + extension
-console.log(sort, sort_, sort__);
+import sort___ from '@/sort'; // bare import using alias with trailing slash
+console.log(sort, sort_, sort__, sort___);
 
 // Importing a directory index.js file
-import components from './components'; // relative import 
+import components from './components'; // relative import
 import components______ from './components/'; // relative import with trailing slash
 import components_ from './components/index'; // relative import with index appended
 import components__ from './components/index.js'; // relative import with index appended
@@ -21,6 +22,6 @@ console.log(components, components_, components__, components___, components____
 
 
 // Importing something that isn't JS
-import styles from './components/style.css'; // relative import 
-import styles_ from '@app/components/style.css'; // relative import 
+import styles from './components/style.css'; // relative import
+import styles_ from '@app/components/style.css'; // relative import
 console.log(styles, styles_);


### PR DESCRIPTION
## Changes
Fix alias with trailing slash.

Currently, if we config alias as: 

```
    "alias": {
      "@/": "./src/"
    }
```
The result is incorrect as:

```
// from
import sort___ from '@/sort';
// current result
import sort___ from '../srcsort.js'; 
// expect result
import sort___ from './sort.js';
```

It is common use for config alias with trailing slash, for example in tsconfig.json:
```
{
  "compilerOptions": {
    "paths": {
      "@/*": ["./*"]
    }
  }
}
```
And we also need to resolve `@ant-design`, `@/components` correctly. So we can't use alias `@` directly.

Please consider to support alias `@/` and other alias with trailing slash. Thanks.

## Testing

run test on: `test/build/resolve-imports`