### PR TITLE
support to alias assets in node_modules

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -304,7 +304,7 @@ export async function command(commandOptions: CommandOptions) {
       ) {
         const proxiedCode = await fs.readFile(installedFileLoc, {encoding: 'utf-8'});
         const importProxyFileLoc = installedFileLoc + '.proxy.js';
-        const proxiedUrl = installedFileLoc.substr(installDest.length).replace(/\\/g, '/');
+        const proxiedUrl = installedFileLoc.substr(buildDirectoryLoc.length).replace(/\\/g, '/');
         const proxyCode = await wrapImportProxy({
           url: proxiedUrl,
           code: proxiedCode,

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -3872,7 +3872,9 @@ console.log(
 // Importing something that isn't JS
 import styles from './components/style.css.proxy.js'; // relative import
 import styles_ from './components/style.css.proxy.js'; // relative import
-console.log(styles, styles_);"
+console.log(styles, styles_);
+import adSvg from '../TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js';
+console.log(adSvg);"
 `;
 
 exports[`snowpack build resolve-imports: _dist_/sort.js 1`] = `"export default (arr) => arr.sort();"`;
@@ -3881,6 +3883,8 @@ exports[`snowpack build resolve-imports: _dist_/test-mjs.js 1`] = `
 "import {flatten} from \\"../TEST_WMU/array-flatten.js\\";
 console.log(flatten);"
 `;
+
+exports[`snowpack build resolve-imports: TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js 1`] = `"export default \\"/TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg\\";"`;
 
 exports[`snowpack build resolve-imports: TEST_WMU/array-flatten.js 1`] = `
 "/**
@@ -3911,8 +3915,10 @@ export { flatten };"
 exports[`snowpack build resolve-imports: TEST_WMU/import-map.json 1`] = `
 "{
   \\"imports\\": {
+    \\"@fortawesome/fontawesome-free/svgs/solid/ad.svg\\": \\"./@fortawesome/fontawesome-free/svgs/solid/ad.svg\\",
     \\"aliased-dep\\": \\"./array-flatten.js\\",
-    \\"array-flatten\\": \\"./array-flatten.js\\"
+    \\"array-flatten\\": \\"./array-flatten.js\\",
+    \\"fasvgs/solid/ad.svg\\": \\"./@fortawesome/fontawesome-free/svgs/solid/ad.svg\\"
   }
 }"
 `;
@@ -3927,6 +3933,8 @@ Array [
   "_dist_/index.js",
   "_dist_/sort.js",
   "_dist_/test-mjs.js",
+  "TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg",
+  "TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js",
   "TEST_WMU/array-flatten.js",
   "TEST_WMU/import-map.json",
 ]

--- a/test/build/resolve-imports/package.json
+++ b/test/build/resolve-imports/package.json
@@ -9,6 +9,7 @@
   "snowpack": {
     "alias": {
       "aliased-dep": "array-flatten",
+      "fasvgs": "@fortawesome/fontawesome-free/svgs",
       "@app": "./src",
       "@/": "./src/",
       "%": "."
@@ -26,6 +27,7 @@
     }
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "array-flatten": "^3.0.0",
     "snowpack": "^2.7.0"
   }

--- a/test/build/resolve-imports/src/index.js
+++ b/test/build/resolve-imports/src/index.js
@@ -34,3 +34,6 @@ console.log(
 import styles from './components/style.css'; // relative import
 import styles_ from '@app/components/style.css'; // relative import
 console.log(styles, styles_);
+
+import adSvg from 'fasvgs/solid/ad.svg';
+console.log(adSvg);

--- a/test/integration/__snapshots__/install.test.js.snap
+++ b/test/integration/__snapshots__/install.test.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snowpack install config-alias: @fortawesome/fontawesome-free/svgs/solid/ad.svg 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 512 512\\"><path d=\\"M157.52 272h36.96L176 218.78 157.52 272zM352 256c-13.23 0-24 10.77-24 24s10.77 24 24 24 24-10.77 24-24-10.77-24-24-24zM464 64H48C21.5 64 0 85.5 0 112v288c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V112c0-26.5-21.5-48-48-48zM250.58 352h-16.94c-6.81 0-12.88-4.32-15.12-10.75L211.15 320h-70.29l-7.38 21.25A16 16 0 0 1 118.36 352h-16.94c-11.01 0-18.73-10.85-15.12-21.25L140 176.12A23.995 23.995 0 0 1 162.67 160h26.66A23.99 23.99 0 0 1 212 176.13l53.69 154.62c3.61 10.4-4.11 21.25-15.11 21.25zM424 336c0 8.84-7.16 16-16 16h-16c-4.85 0-9.04-2.27-11.98-5.68-8.62 3.66-18.09 5.68-28.02 5.68-39.7 0-72-32.3-72-72s32.3-72 72-72c8.46 0 16.46 1.73 24 4.42V176c0-8.84 7.16-16 16-16h16c8.84 0 16 7.16 16 16v160z\\"/></svg>"`;
+
 exports[`snowpack install config-alias: allFiles 1`] = `
 Array [
+  "@fortawesome/fontawesome-free/svgs/solid/ad.svg",
   "import-map.json",
   "preact/compat.js",
   "vue-currency-input/dist/vue-currency-input.esm.js",
@@ -11,6 +14,8 @@ Array [
 exports[`snowpack install config-alias: import-map.json 1`] = `
 "{
   \\"imports\\": {
+    \\"@fortawesome/fontawesome-free/svgs/solid/ad.svg\\": \\"./@fortawesome/fontawesome-free/svgs/solid/ad.svg\\",
+    \\"fasvgs/solid/ad.svg\\": \\"./@fortawesome/fontawesome-free/svgs/solid/ad.svg\\",
     \\"preact/compat\\": \\"./preact/compat.js\\",
     \\"react\\": \\"./preact/compat.js\\",
     \\"react-dom\\": \\"./preact/compat.js\\",

--- a/test/integration/config-alias/package.json
+++ b/test/integration/config-alias/package.json
@@ -11,7 +11,8 @@
       "react": "preact/compat",
       "react-dom": "preact/compat",
       "vue": "vue/dist/vue.esm.browser.js",
-      "vue-currency-input": "vue-currency-input/dist/vue-currency-input.esm.js"
+      "vue-currency-input": "vue-currency-input/dist/vue-currency-input.esm.js",
+      "fasvgs": "@fortawesome/fontawesome-free/svgs"
     },
     "install": [
       "react",
@@ -22,6 +23,7 @@
     }
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "preact": "^10.4.6",
     "vue": "^2.6.12",
     "vue-currency-input": "^1.21.0"

--- a/test/integration/config-alias/src/index.js
+++ b/test/integration/config-alias/src/index.js
@@ -1,1 +1,2 @@
 import 'vue-currency-input';
+import 'fasvgs/solid/ad.svg';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fortawesome/fontawesome-free@^5.14.0":
+  version "5.14.0"
+  resolved "https://bnpm.byted.org/@fortawesome/fontawesome-free/download/@fortawesome/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
+  integrity sha1-o3HpECnr8mUBXmT4G/v30ijJaB8=
+
 "@iarna/toml@^2.2.0":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,8 +1340,8 @@
 
 "@fortawesome/fontawesome-free@^5.14.0":
   version "5.14.0"
-  resolved "https://bnpm.byted.org/@fortawesome/fontawesome-free/download/@fortawesome/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
-  integrity sha1-o3HpECnr8mUBXmT4G/v30ijJaB8=
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
+  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
 
 "@iarna/toml@^2.2.0":
   version "2.2.5"


### PR DESCRIPTION
## Changes

See the [example demo](https://github.com/MoonBall/snowpack/blob/example-support-alias-node_modules-assets/packages/%40snowpack/app-template-react/src/App.jsx). I add [an alias `fasvgs` for `@fortawesome/fontawesome-free/svgs`](https://github.com/MoonBall/snowpack/blob/example-support-alias-node_modules-assets/packages/%40snowpack/app-template-react/snowpack.config.json#L4), and use it in [App.jsx](https://github.com/MoonBall/snowpack/blob/example-support-alias-node_modules-assets/packages/%40snowpack/app-template-react/src/App.jsx#L4).

You can see the overview of the usage by view [the diff](https://github.com/MoonBall/snowpack/compare/support-alias-node_modules-assets...MoonBall:example-support-alias-node_modules-assets). 
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Test added.
<!-- For someone unfamiliar with the issue, how should this be tested? -->
