### PR TITLE
Fix output swallowed in build

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -193,13 +193,13 @@ export async function command(commandOptions: CommandOptions) {
   // Important! this must be shimmed before command() fires
   const messageBus = new EventEmitter();
   console.log = (...args) => {
-      messageBus.emit(paintEvent.CONSOLE_INFO, {msg: args.join(' ')});
+    messageBus.emit(paintEvent.CONSOLE_INFO, {msg: args.join(' ')});
   };
   console.warn = (...args) => {
-      messageBus.emit(paintEvent.CONSOLE_WARN, {msg: args.join(' ')});
+    messageBus.emit(paintEvent.CONSOLE_WARN, {msg: args.join(' ')});
   };
   console.error = (...args) => {
-      messageBus.emit(paintEvent.CONSOLE_ERROR, {msg: args.join(' ')});
+    messageBus.emit(paintEvent.CONSOLE_ERROR, {msg: args.join(' ')});
   };
 
   // Start painting dev dashboard after successful install

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -190,7 +190,6 @@ export async function command(commandOptions: CommandOptions) {
     serverStart = performance.now();
   }
 
-  // Important! this must be shimmed before command() fires
   const messageBus = new EventEmitter();
   console.log = (...args) => {
     messageBus.emit(paintEvent.CONSOLE_INFO, {msg: args.join(' ')});
@@ -202,7 +201,6 @@ export async function command(commandOptions: CommandOptions) {
     messageBus.emit(paintEvent.CONSOLE_ERROR, {msg: args.join(' ')});
   };
 
-  // Start painting dev dashboard after successful install
   paint(
     messageBus,
     config.plugins.map((p) => p.name),

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -35,6 +35,7 @@ function formatConsoleMessage(id: string, msg: string, color?: string) {
   }
   return consoleOutput;
 }
+
 /**
  * Get the actual port, based on the `defaultPort`.
  * If the default port was not available, then we'll prompt the user if its okay

--- a/test/integration/include-missing-in-package-json/expected-output.txt
+++ b/test/integration/include-missing-in-package-json/expected-output.txt
@@ -1,4 +1,5 @@
 [snowpack] ! installing dependencies…
+Generated an empty chunk: "@material/base/types"
 [snowpack] ✔ install complete
 [snowpack]
   ⦿ web_modules/                     size       gzip       brotli


### PR DESCRIPTION
## Changes

- By swallowing console.log at the top level of dev.ts, we were hiding logs on all non dev command runs
- This moves that logic back into the dev command, but moves it to earlier so that we capture more
- Work still needed / not tackled here: how do we send install logs into the dev console?

## Testing

- Tested manually.
