### PR TITLE
Dev server logging improvements 2

### DIFF
--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -84,7 +84,6 @@
     "npm-run-path": "^4.0.1",
     "open": "^7.0.4",
     "p-queue": "^6.2.1",
-    "pino": "^6.5.0",
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^2.23.0",
@@ -96,7 +95,5 @@
     "ws": "^7.3.0",
     "yargs-parser": "^18.1.3"
   },
-  "devDependencies": {
-    "@types/pino": "^6.3.0"
-  }
+  "devDependencies": {}
 }

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -53,14 +53,14 @@ async function runPipelineLoadStep(
 
     try {
       const debugPath = path.relative(process.cwd(), srcPath);
-      logger.debug(`[${step.name}] load() starting: [${debugPath}]`);
+      logger.debug(`[${step.name}] load() starting… [${debugPath}]`);
       const result = await step.load({
         fileExt: srcExt,
         filePath: srcPath,
         isDev,
         isHmrEnabled,
       });
-      logger.debug(`[${step.name}] load() successful [${debugPath}]`);
+      logger.debug(`[${step.name}] ✔ load() success [${debugPath}]`);
 
       validatePluginLoadResult(step, result);
 
@@ -137,7 +137,7 @@ async function runPipelineTransformStep(
           // @ts-ignore: Deprecated
           urlPath: `./${path.basename(rootFileName + destExt)}`,
         });
-        logger.debug(`[${step.name}] transform() successful [${debugPath}]`);
+        logger.debug(`[${step.name}] ✔ transform() success [${debugPath}]`);
         // if step returned a value, only update code (don’t touch .map)
         if (typeof result === 'string') {
           output[destExt].code = result;
@@ -174,7 +174,7 @@ export async function runPipelineOptimizeStep(buildDirectory: string, {plugins}:
           logger.info(msg);
         },
       });
-      logger.debug(`[${step.name}] optimize() successful`);
+      logger.debug(`[${step.name}] ✔ optimize() success`);
     } catch (err) {
       logger.error(`[${step.name}] ${err}`);
     }

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -86,7 +86,9 @@ async function runPipelineLoadStep(
         return result;
       }
     } catch (err) {
-      logger.error(err, {name: step.name});
+      // note: for many plugins like Babel, `err.toString()` is needed to display full output
+      logger.error(err.toString() || err, {name: step.name});
+      if (!isDev) process.exit(1); // exit in build
     }
   }
 
@@ -142,7 +144,9 @@ async function runPipelineTransformStep(
         if (!sourceMaps) output[destExt].map = undefined;
       }
     } catch (err) {
-      logger.error(err, {name: step.name});
+      // note: for many plugins like Babel, `err.toString()` is needed to display full output
+      logger.error(err.toString() || err, {name: step.name});
+      if (!isDev) process.exit(1); // exit in build
     }
   }
 
@@ -166,7 +170,8 @@ export async function runPipelineOptimizeStep(buildDirectory: string, {plugins}:
       });
       logger.debug('✔ optimize() success', {name: step.name});
     } catch (err) {
-      logger.error(err, {name: step.name});
+      logger.error(err.toString() || err, {name: step.name});
+      process.exit(1); // exit on error
     }
   }
   return null;

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import {SnowpackBuildMap, SnowpackPlugin} from '../types/snowpack';
 import {getEncodingType, getExt, replaceExt} from '../util';
 import {validatePluginLoadResult} from '../config';
-import logger from '../logger';
+import {logger} from '../logger';
 
 export interface BuildFileOptions {
   isDev: boolean;

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -17,14 +17,12 @@ import {
 import {buildFile, runPipelineOptimizeStep} from '../build/build-pipeline';
 import {createImportResolver} from '../build/import-resolver';
 import {removeLeadingSlash} from '../config';
-import createLogger from '../logger';
+import logger from '../logger';
 import {stopEsbuild} from '../plugins/plugin-esbuild';
 import {transformFileImports} from '../rewrite-imports';
 import {CommandOptions, ImportMap, SnowpackConfig, SnowpackSourceFile} from '../types/snowpack';
 import {cssSourceMappingURL, getEncodingType, jsSourceMappingURL, replaceExt} from '../util';
 import {getInstallTargets, run as installRunner} from './install';
-
-const logger = createLogger({name: 'snowpack'});
 
 async function installOptimizedDependencies(
   scannedFiles: SnowpackSourceFile[],
@@ -87,7 +85,6 @@ class FileBuilder {
       isDev: false,
       isHmrEnabled: false,
       sourceMaps: this.config.buildOptions.sourceMaps,
-      logLevel: 'info',
     });
     for (const [fileExt, buildResult] of Object.entries(builtFileOutput)) {
       let {code, map} = buildResult;
@@ -229,9 +226,7 @@ class FileBuilder {
 }
 
 export async function command(commandOptions: CommandOptions) {
-  const {cwd, config, logLevel = 'info'} = commandOptions;
-
-  logger.level = logLevel;
+  const {cwd, config} = commandOptions;
 
   const buildDirectoryLoc = config.devOptions.out;
   const internalFilesBuildLoc = path.join(buildDirectoryLoc, config.buildOptions.metaDir);
@@ -285,7 +280,6 @@ export async function command(commandOptions: CommandOptions) {
     const installDest = path.join(buildDirectoryLoc, config.buildOptions.webModulesUrl);
     const installResult = await installOptimizedDependencies(scannedFiles, installDest, {
       ...commandOptions,
-      logLevel: 'error',
     });
     if (!installResult.success || installResult.hasError || !installResult.importMap) {
       process.exit(1);

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -154,7 +154,7 @@ class FileBuilder {
         // Until supported, just exit here.
         if (!resolvedImportUrl) {
           isSuccess = false;
-          console.error(`${file.locOnDisk} - Could not resolve unkonwn import "${spec}".`);
+          logger.error(`${file.locOnDisk} - Could not resolve unkonwn import "${spec}".`);
           return spec;
         }
         // Ignore "http://*" imports
@@ -425,7 +425,7 @@ export async function command(commandOptions: CommandOptions) {
       await installDependencies();
       resolveSuccess = await changedPipelineFile.resolveImports(installResult.importMap!);
       if (!resolveSuccess) {
-        console.error('Exiting...');
+        logger.error('Exiting...');
         process.exit(1);
       }
     }

--- a/packages/snowpack/src/commands/build.ts
+++ b/packages/snowpack/src/commands/build.ts
@@ -17,7 +17,7 @@ import {
 import {buildFile, runPipelineOptimizeStep} from '../build/build-pipeline';
 import {createImportResolver} from '../build/import-resolver';
 import {removeLeadingSlash} from '../config';
-import logger from '../logger';
+import {logger} from '../logger';
 import {stopEsbuild} from '../plugins/plugin-esbuild';
 import {transformFileImports} from '../rewrite-imports';
 import {CommandOptions, ImportMap, SnowpackConfig, SnowpackSourceFile} from '../types/snowpack';

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -179,7 +179,7 @@ function getUrlFromFile(
 }
 
 export async function command(commandOptions: CommandOptions) {
-  const {cwd, config, logLevel = 'info'} = commandOptions;
+  const {cwd, config} = commandOptions;
   const {port: defaultPort, hostname, open, hmr: isHmr} = config.devOptions;
 
   // Start the startup timer!
@@ -455,7 +455,6 @@ export async function command(commandOptions: CommandOptions) {
           isDev: true,
           isHmrEnabled: isHmr,
           sourceMaps: config.buildOptions.sourceMaps,
-          logLevel,
         });
         inMemoryBuildCache.set(fileLoc, builtFileOutput);
         return builtFileOutput;

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -54,7 +54,7 @@ import {buildFile as _buildFile, getInputsFromOutput} from '../build/build-pipel
 import {createImportResolver} from '../build/import-resolver';
 import srcFileExtensionMapping from '../build/src-file-extension-mapping';
 import {EsmHmrEngine} from '../hmr-server-engine';
-import logger from '../logger';
+import {logger} from '../logger';
 import {
   scanCodeImportsExports,
   transformEsmImports,
@@ -190,6 +190,18 @@ export async function command(commandOptions: CommandOptions) {
   }
 
   const messageBus = new EventEmitter();
+
+  // note: this would cause an infinite loop if not for the logger.on(…) in `paint.ts`.
+  console.log = (...args) => {
+    logger.info(args[0]);
+  };
+  console.warn = (...args) => {
+    logger.warn(args[0]);
+  };
+  console.error = (...args) => {
+    logger.error(args[0]);
+  };
+
   paint(
     messageBus,
     config.plugins.map((p) => p.name),

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -130,7 +130,7 @@ const sendFile = (
     if (err) {
       res.end();
       logger.error(`✘ An error occurred while compressing ${colors.bold(req.url)}`);
-      logger.error(err);
+      logger.error(err.toString() || err);
     }
   }
 
@@ -729,7 +729,7 @@ ${err}`);
       return await requestHandler(req, res);
     } catch (err) {
       logger.error(`[500] ${req.url}`);
-      logger.error(err);
+      logger.error(err.toString() || err);
       return sendError(req, res, 500);
     }
   })

--- a/packages/snowpack/src/commands/install.ts
+++ b/packages/snowpack/src/commands/install.ts
@@ -146,7 +146,7 @@ function resolveWebDependency(dep: string): DependencyLoc {
         exportMapEntry?.require ||
         exportMapEntry;
       if (typeof exportMapValue !== 'string') {
-        logger.fatal(
+        logger.error(
           `Package "${packageName}" exists but package.json "exports" does not include entry for "./${packageEntrypoint}".`,
         );
         process.exit(1);
@@ -183,7 +183,7 @@ function resolveWebDependency(dep: string): DependencyLoc {
     depManifest.name &&
     (depManifest.name.startsWith('@reactesm') || depManifest.name.startsWith('@pika/react'))
   ) {
-    logger.fatal(
+    logger.error(
       `React workaround packages no longer needed! Revert back to the official React & React-DOM packages.`,
     );
     process.exit(1);
@@ -549,7 +549,7 @@ export async function run({
   let newLockfile: ImportMap | null = null;
   if (webDependencies && Object.keys(webDependencies).length > 0) {
     newLockfile = await resolveTargetsFromRemoteCDN(lockfile, config).catch((err) => {
-      logger.fatal('\n' + err.message || err);
+      logger.error('\n' + err.message || err);
       process.exit(1);
     });
   }
@@ -565,7 +565,7 @@ export async function run({
     if (err.url) {
       logger.error(colors.dim(`👉 ${err.url}`));
     }
-    logger.fatal(err.message || err);
+    logger.error(err.message || err);
     process.exit(1);
   });
 

--- a/packages/snowpack/src/commands/install.ts
+++ b/packages/snowpack/src/commands/install.ts
@@ -14,7 +14,7 @@ import {performance} from 'perf_hooks';
 import rimraf from 'rimraf';
 import {InputOptions, OutputOptions, rollup, RollupError} from 'rollup';
 import validatePackageName from 'validate-npm-package-name';
-import logger from '../logger';
+import {logger} from '../logger';
 import {resolveTargetsFromRemoteCDN} from '../resolve-remote.js';
 import {rollupPluginCatchUnresolved} from '../rollup-plugins/rollup-plugin-catch-unresolved.js';
 import {rollupPluginCatchFetch} from '../rollup-plugins/rollup-plugin-catch-fetch';

--- a/packages/snowpack/src/commands/install.ts
+++ b/packages/snowpack/src/commands/install.ts
@@ -10,12 +10,11 @@ import fs from 'fs';
 import * as colors from 'kleur/colors';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import pino from 'pino';
 import {performance} from 'perf_hooks';
 import rimraf from 'rimraf';
 import {InputOptions, OutputOptions, rollup, RollupError} from 'rollup';
 import validatePackageName from 'validate-npm-package-name';
-import createLogger from '../logger';
+import logger from '../logger';
 import {resolveTargetsFromRemoteCDN} from '../resolve-remote.js';
 import {rollupPluginCatchUnresolved} from '../rollup-plugins/rollup-plugin-catch-unresolved.js';
 import {rollupPluginCatchFetch} from '../rollup-plugins/rollup-plugin-catch-fetch';
@@ -44,8 +43,6 @@ import {
   isPackageAliasEntry,
   findMatchingAliasEntry,
 } from '../util.js';
-
-const logger = createLogger({name: 'snowpack'});
 
 type InstallResultCode = 'SUCCESS' | 'ASSET' | 'FAIL';
 
@@ -239,7 +236,6 @@ function resolveWebDependency(dep: string): DependencyLoc {
 interface InstallOptions {
   lockfile: ImportMap | null;
   config: SnowpackConfig;
-  logLevel?: pino.Level;
 }
 
 type InstallResult = {success: false; importMap: null} | {success: true; importMap: ImportMap};
@@ -491,10 +487,7 @@ export async function getInstallTargets(
 }
 
 export async function command(commandOptions: CommandOptions) {
-  const {cwd, config, logLevel = 'info'} = commandOptions;
-
-  // adjust logging level
-  logger.level = logLevel;
+  const {cwd, config} = commandOptions;
 
   const installTargets = await getInstallTargets(config);
   if (installTargets.length === 0) {
@@ -530,15 +523,11 @@ export async function run({
   config,
   lockfile,
   installTargets,
-  logLevel = 'info',
 }: InstallRunOptions): Promise<InstallRunResult> {
   const {
     installOptions: {dest},
     webDependencies,
   } = config;
-
-  // adjust logging level
-  logger.level = logLevel;
 
   // start
   const installStart = performance.now();
@@ -569,7 +558,6 @@ export async function run({
   const finalResult = await install(installTargets, {
     lockfile: newLockfile,
     config,
-    logLevel,
   }).catch((err) => {
     if (err.loc) {
       logger.error(colors.red(colors.bold(`✘ ${err.loc.file}`)));

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -35,7 +35,6 @@ function formatConsoleMessage(id: string, msg: string, color?: string) {
   }
   return consoleOutput;
 }
-
 /**
  * Get the actual port, based on the `defaultPort`.
  * If the default port was not available, then we'll prompt the user if its okay

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -35,6 +35,7 @@ function formatConsoleMessage(id: string, msg: string, color?: string) {
   }
   return consoleOutput;
 }
+
 /**
  * Get the actual port, based on the `defaultPort`.
  * If the default port was not available, then we'll prompt the user if its okay

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -3,6 +3,7 @@ import {EventEmitter} from 'events';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import readline from 'readline';
+
 const cwd = process.cwd();
 
 export const paintEvent = {

--- a/packages/snowpack/src/commands/paint.ts
+++ b/packages/snowpack/src/commands/paint.ts
@@ -3,7 +3,7 @@ import {EventEmitter} from 'events';
 import * as colors from 'kleur/colors';
 import path from 'path';
 import readline from 'readline';
-import logger from '../logger';
+import {logger} from '../logger';
 
 const cwd = process.cwd();
 
@@ -18,7 +18,6 @@ export const paintEvent = {
   WORKER_UPDATE: 'WORKER_UPDATE',
 };
 
-const MAX_CONSOLE_LENGTH = 500;
 /**
  * Get the actual port, based on the `defaultPort`.
  * If the default port was not available, then we'll prompt the user if its okay
@@ -111,13 +110,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
       process.stdout.write(colors.dim(`  Server starting…`) + '\n\n');
     }
     // Console Output
-    let history = logger.getHistory();
-    if (history.length > MAX_CONSOLE_LENGTH) {
-      history = [
-        colors.dim('<Previous messages trimmed>'),
-        ...history.slice(history.length - MAX_CONSOLE_LENGTH),
-      ];
-    }
+    const history = logger.getHistory();
     if (history.length) {
       process.stdout.write(`${colors.underline(colors.bold('▼ Console'))}\n\n`);
       process.stdout.write(history.join('\n'));
@@ -174,6 +167,7 @@ export function paint(bus: EventEmitter, plugins: string[]) {
     repaint();
   });
 
+  // replace logging behavior with repaint (note: messages are retrieved later, with logger.getHistory())
   logger.on('debug', () => {
     repaint();
   });

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -7,7 +7,7 @@ import http from 'http';
 import {validate, ValidatorResult} from 'jsonschema';
 import path from 'path';
 import yargs from 'yargs-parser';
-import createLogger from './logger';
+import logger from './logger';
 import srcFileExtensionMapping from './build/src-file-extension-mapping';
 import {esbuildPlugin} from './plugins/plugin-esbuild';
 import {
@@ -25,8 +25,6 @@ import {
 
 const CONFIG_NAME = 'snowpack';
 const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/.types/**/*'];
-
-const logger = createLogger({name: 'snowpack'});
 
 // default settings
 const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
@@ -85,6 +83,7 @@ const configSchema = {
       type: 'object',
       additionalProperties: {type: 'string'},
     },
+    logLevel: {type: 'string'},
     devOptions: {
       type: 'object',
       properties: {

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -83,7 +83,6 @@ const configSchema = {
       type: 'object',
       additionalProperties: {type: 'string'},
     },
-    logLevel: {type: 'string'},
     devOptions: {
       type: 'object',
       properties: {
@@ -162,7 +161,7 @@ function expandCliFlags(flags: CLIFlags): DeepPartial<SnowpackConfig> {
   };
   const {help, version, reload, config, ...relevantFlags} = flags;
 
-  const CLI_ONLY_FLAGS = ['debug', 'silent'];
+  const CLI_ONLY_FLAGS = ['logLevel', 'debug', 'silent'];
 
   for (const [flag, val] of Object.entries(relevantFlags)) {
     if (flag === '_' || flag.includes('-')) {
@@ -293,7 +292,7 @@ function loadPlugins(
           // Confirmed no plugins are using this now, so safe to use an empty array.
           jsFilePaths: [],
         }).catch((err) => {
-          logger.fatal(
+          logger.error(
             `[${plugin.name}] There was a problem running this older plugin. Please update the plugin to the latest version.`,
           );
           throw err;
@@ -547,19 +546,19 @@ function normalizeConfig(config: SnowpackConfig): SnowpackConfig {
 }
 
 function handleConfigError(msg: string) {
-  logger.fatal(msg);
+  logger.error(msg);
   process.exit(1);
 }
 
 function handleValidationErrors(filepath: string, errors: {toString: () => string}[]) {
-  logger.fatal(`! ${filepath || 'Configuration error'}
+  logger.error(`! ${filepath || 'Configuration error'}
 ${errors.map((err) => `    - ${err.toString()}`).join('\n')}
     See https://www.snowpack.dev/#configuration for more info.`);
   process.exit(1);
 }
 
 function handleDeprecatedConfigError(mainMsg: string, ...msgs: string[]) {
-  logger.fatal(`${mainMsg}
+  logger.error(`${mainMsg}
 ${msgs.join('\n')}
 See https://www.snowpack.dev/#configuration for more info.`);
   process.exit(1);

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -161,6 +161,9 @@ function expandCliFlags(flags: CLIFlags): DeepPartial<SnowpackConfig> {
     buildOptions: {} as any,
   };
   const {help, version, reload, config, ...relevantFlags} = flags;
+
+  const CLI_ONLY_FLAGS = ['debug', 'silent'];
+
   for (const [flag, val] of Object.entries(relevantFlags)) {
     if (flag === '_' || flag.includes('-')) {
       continue;
@@ -179,6 +182,9 @@ function expandCliFlags(flags: CLIFlags): DeepPartial<SnowpackConfig> {
     }
     if (configSchema.properties.buildOptions.properties[flag]) {
       result.buildOptions[flag] = val;
+      continue;
+    }
+    if (CLI_ONLY_FLAGS.includes(flag)) {
       continue;
     }
     logger.error(`Unknown CLI flag: "${flag}"`);

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -250,7 +250,7 @@ function loadPlugins(
       if (typeof plugin !== 'function') logger.error(`plugin ${name} doesn’t return function`);
       plugin = (plugin as any)(config, options);
     } catch (err) {
-      logger.error(err);
+      logger.error(err.toString() || err);
       throw err;
     }
     plugin.name = plugin.name || name;

--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -7,7 +7,7 @@ import http from 'http';
 import {validate, ValidatorResult} from 'jsonschema';
 import path from 'path';
 import yargs from 'yargs-parser';
-import logger from './logger';
+import {logger} from './logger';
 import srcFileExtensionMapping from './build/src-file-extension-mapping';
 import {esbuildPlugin} from './plugins/plugin-esbuild';
 import {
@@ -161,7 +161,7 @@ function expandCliFlags(flags: CLIFlags): DeepPartial<SnowpackConfig> {
   };
   const {help, version, reload, config, ...relevantFlags} = flags;
 
-  const CLI_ONLY_FLAGS = ['logLevel', 'debug', 'silent'];
+  const CLI_ONLY_FLAGS = ['quiet', 'verbose'];
 
   for (const [flag, val] of Object.entries(relevantFlags)) {
     if (flag === '_' || flag.includes('-')) {

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -6,7 +6,7 @@ import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
 import {loadAndValidateConfig} from './config.js';
-import createLogger from './logger';
+import logger from './logger';
 import {CLIFlags} from './types/snowpack';
 import {clearCache, readLockfile} from './util.js';
 
@@ -15,7 +15,6 @@ export {createConfiguration} from './config.js';
 export * from './types/snowpack';
 
 const cwd = process.cwd();
-const logger = createLogger({name: 'snowpack'});
 
 function printHelp() {
   logger.info(
@@ -83,7 +82,7 @@ export async function cli(args: string[]) {
     config: loadAndValidateConfig(cliFlags, pkgManifest),
     lockfile: await readLockfile(cwd),
     pkgManifest,
-    logLevel: cliFlags.logLevel || 'info',
+    logger,
   };
 
   logger.level = cliFlags.logLevel || 'info';

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -35,7 +35,7 @@ ${colors.bold('Flags:')}
   --help                Show this help message.
   --version             Show the current version.
   --reload              Clear Snowpack's local cache (troubleshooting).
-  --log-level=[level]   Adjust log level (default: info) (options: silent | error | warn | info | debug | trace)
+  --log-level=[level]   Adjust lowest level to log (default: info) (options: silent | error | warn | info | debug | trace)
   --debug               See normal logs + debug info. Alias for --log-level=debug.
   --silent              Don’t output anything (dev server will still log minimally). Alias for --log-level=silent.
     `.trim(),
@@ -65,7 +65,7 @@ export async function cli(args: string[]) {
   try {
     pkgManifest = require(path.join(cwd, 'package.json'));
   } catch (err) {
-    logger.fatal(`package.json not found in directory: ${cwd}. Run \`npm init -y\` to create one.`);
+    logger.error(`package.json not found in directory: ${cwd}. Run \`npm init -y\` to create one.`);
     process.exit(1);
   }
 
@@ -101,7 +101,7 @@ export async function cli(args: string[]) {
   }
 
   if (cliFlags['_'].length > 3) {
-    logger.fatal(`Unexpected multiple commands`);
+    logger.error(`Unexpected multiple commands`);
     process.exit(1);
   }
 
@@ -118,6 +118,6 @@ export async function cli(args: string[]) {
     return;
   }
 
-  logger.fatal(`Unrecognized command: ${cmd}`);
+  logger.error(`Unrecognized command: ${cmd}`);
   process.exit(1);
 }

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -35,7 +35,9 @@ ${colors.bold('Flags:')}
   --help                Show this help message.
   --version             Show the current version.
   --reload              Clear Snowpack's local cache (troubleshooting).
-  --log-level=[level]   Adjust log level (default: info) (options: trace | debug | info | warn | error | silent)
+  --log-level=[level]   Adjust log level (default: info) (options: silent | error | warn | info | debug | trace)
+  --debug               See normal logs + debug info. Alias for --log-level=debug.
+  --silent              Don’t output anything (dev server will still log minimally). Alias for --log-level=silent.
     `.trim(),
   );
 }
@@ -86,6 +88,8 @@ export async function cli(args: string[]) {
   };
 
   logger.level = cliFlags.logLevel || 'info';
+  if (cliFlags.debug) logger.level = 'debug';
+  if (cliFlags.silent) logger.level = 'silent';
 
   if (cmd === 'add') {
     await addCommand(cliFlags['_'][3], commandOptions);

--- a/packages/snowpack/src/index.ts
+++ b/packages/snowpack/src/index.ts
@@ -6,7 +6,7 @@ import {command as buildCommand} from './commands/build';
 import {command as devCommand} from './commands/dev';
 import {command as installCommand} from './commands/install';
 import {loadAndValidateConfig} from './config.js';
-import logger from './logger';
+import {logger} from './logger';
 import {CLIFlags} from './types/snowpack';
 import {clearCache, readLockfile} from './util.js';
 
@@ -35,9 +35,8 @@ ${colors.bold('Flags:')}
   --help                Show this help message.
   --version             Show the current version.
   --reload              Clear Snowpack's local cache (troubleshooting).
-  --log-level=[level]   Adjust lowest level to log (default: info) (options: silent | error | warn | info | debug | trace)
-  --debug               See normal logs + debug info. Alias for --log-level=debug.
-  --silent              Don’t output anything (dev server will still log minimally). Alias for --log-level=silent.
+  --verbose             View debug info (where available)
+  --quiet               Don’t output anything (dev server will still log minimally)
     `.trim(),
   );
 }
@@ -87,9 +86,8 @@ export async function cli(args: string[]) {
     logger,
   };
 
-  logger.level = cliFlags.logLevel || 'info';
-  if (cliFlags.debug) logger.level = 'debug';
-  if (cliFlags.silent) logger.level = 'silent';
+  if (cliFlags.verbose) logger.level = 'debug';
+  if (cliFlags.quiet) logger.level = 'silent';
 
   if (cmd === 'add') {
     await addCommand(cliFlags['_'][3], commandOptions);

--- a/packages/snowpack/src/logger.ts
+++ b/packages/snowpack/src/logger.ts
@@ -1,7 +1,7 @@
 import * as colors from 'kleur/colors';
 import pino from 'pino';
 
-const NAME_REGEX = /^\[[^\]]+\s*\]/; // select [somename] at beginning of line
+const NAME_REGEX = /^\[[^\]]+\]\s*/; // select [somename] at beginning of line
 
 const LEVEL = {
   TRACE: 10,

--- a/packages/snowpack/src/logger.ts
+++ b/packages/snowpack/src/logger.ts
@@ -1,35 +1,88 @@
 import * as colors from 'kleur/colors';
-import pino from 'pino';
+import {LoggerLevel, LoggerEvent, LoggerOptions} from './types/snowpack';
 
-const NAME_REGEX = /^\[[^\]]+\]\s*/; // select [somename] at beginning of line
-
-const LEVEL = {
-  TRACE: 10,
-  DEBUG: 20,
-  INFO: 30,
-  WARN: 40,
-  ERROR: 50,
-  FATAL: 60,
+const levels: Record<LoggerLevel, number> = {
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  silent: 90,
 };
 
-/** http://getpino.io/#/docs/pretty */
-function prettifier() {
-  return (inputData: pino.LogDescriptor) => {
-    // if the log starts with brackets, use that (e.g. [@snowpack/plugin-babel]); otherwise, use [snowpack]
-    const nameMatch = inputData.msg.match(NAME_REGEX);
-    let name = (nameMatch && nameMatch[0]) || '[snowpack]';
-    let msg = `${colors.dim(name.trim())} ${inputData.msg.replace(NAME_REGEX, '')}\n`; // add newline at end
+/** Custom logger heavily-inspired by https://github.com/pinojs/pino with extra features like log retentian */
+class SnowpackLogger {
+  /** set the log level (can be changed after init) */
+  public level: LoggerLevel = 'info';
 
-    if (inputData.level === LEVEL.ERROR || inputData.level === LEVEL.FATAL) msg = colors.red(msg);
-    if (inputData.level === LEVEL.WARN) msg = colors.yellow(msg);
-
-    return msg;
+  private history: string[] = []; // this is immutable; must be accessed with Logger.getHistory()
+  private callbacks: Record<LoggerEvent, (message: string) => void> = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
   };
+
+  private log({level, name, message}: {level: LoggerEvent; name: string; message: string}) {
+    // test if this level is enabled or not
+    if (levels[this.level] > levels[level]) {
+      return; // do nothing
+    }
+
+    // format
+    let text = message;
+    if (level === 'warn') text = colors.yellow(text);
+    if (level === 'error') text = colors.red(text);
+    const log = `${colors.dim(`[${name}]`)} ${text}`;
+
+    // add to log history
+    this.history = this.history.concat(log);
+
+    // log
+    let logFn = console.log;
+    if (level === 'warn') logFn = console.warn;
+    if (level === 'error') logFn = console.error;
+    logFn(log);
+
+    // fire callback, if any
+    if (typeof this.callbacks[level] === 'function') {
+      this.callbacks[level](log);
+    }
+  }
+
+  /** emit messages only visible when --debug is passed */
+  public debug(message: string, options?: LoggerOptions): void {
+    const name = (options && options.name) || 'snowpack';
+    this.log({level: 'debug', name, message});
+  }
+
+  /** emit general info */
+  public info(message: string, options?: LoggerOptions): void {
+    const name = (options && options.name) || 'snowpack';
+    this.log({level: 'info', name, message});
+  }
+
+  /** emit non-fatal warnings */
+  public warn(message: string, options?: LoggerOptions): void {
+    const name = (options && options.name) || 'snowpack';
+    this.log({level: 'warn', name, message});
+  }
+
+  /** emit critical error messages */
+  public error(message: string, options?: LoggerOptions): void {
+    const name = (options && options.name) || 'snowpack';
+    this.log({level: 'error', name, message});
+  }
+
+  /** get full logging history */
+  public getHistory() {
+    return [...this.history];
+  }
+
+  /** listen for events */
+  public on(event: LoggerEvent, callback: (message: string) => void) {
+    this.callbacks[event] = callback;
+  }
 }
 
-/** export one Pino logger to rest of app, a tiny logging library */
-export default pino({
-  name: 'snowpack',
-  prettyPrint: {suppressFlushSyncWarning: true},
-  prettifier,
-});
+/** export one logger to rest of app */
+export default new SnowpackLogger();

--- a/packages/snowpack/src/plugins/plugin-esbuild.ts
+++ b/packages/snowpack/src/plugins/plugin-esbuild.ts
@@ -3,6 +3,7 @@ import * as colors from 'kleur/colors';
 import path from 'path';
 import {promises as fs} from 'fs';
 import {SnowpackPlugin, SnowpackConfig} from '../types/snowpack';
+import logger from '../logger';
 
 let esbuildService: Service | null = null;
 
@@ -38,8 +39,8 @@ export function esbuildPlugin(config: SnowpackConfig, {input}: {input: string[]}
         sourcemap: config.buildOptions.sourceMaps,
       });
       for (const warning of warnings) {
-        console.error(colors.bold('! ') + filePath);
-        console.error('  ' + warning.text);
+        logger.error(`${colors.bold('!')} ${filePath}
+  ${warning.text}`);
       }
       return {
         '.js': {

--- a/packages/snowpack/src/plugins/plugin-esbuild.ts
+++ b/packages/snowpack/src/plugins/plugin-esbuild.ts
@@ -3,7 +3,7 @@ import * as colors from 'kleur/colors';
 import path from 'path';
 import {promises as fs} from 'fs';
 import {SnowpackPlugin, SnowpackConfig} from '../types/snowpack';
-import logger from '../logger';
+import {logger} from '../logger';
 
 let esbuildService: Service | null = null;
 

--- a/packages/snowpack/src/resolve-remote.ts
+++ b/packages/snowpack/src/resolve-remote.ts
@@ -4,9 +4,7 @@ import PQueue from 'p-queue';
 import validatePackageName from 'validate-npm-package-name';
 import {SnowpackConfig, ImportMap} from './types/snowpack';
 import {fetchCDNResource, PIKA_CDN, RESOURCE_CACHE} from './util.js';
-import createLogger from './logger';
-
-const logger = createLogger({name: 'snowpack'});
+import logger from './logger';
 
 /**
  * Given an install specifier, attempt to resolve it from the CDN.

--- a/packages/snowpack/src/resolve-remote.ts
+++ b/packages/snowpack/src/resolve-remote.ts
@@ -42,7 +42,7 @@ async function resolveDependency(
       );
     }
     if (packageSemver.startsWith('npm:@reactesm') || packageSemver.startsWith('npm:@pika/react')) {
-      logger.fatal(
+      logger.error(
         `React workaround packages no longer needed! Revert to the official React & React-DOM packages.`,
       );
       process.exit(1);
@@ -113,12 +113,12 @@ async function resolveDependency(
     ),
   );
   if (!importUrlPath) {
-    logger.fatal('X-Import-URL header expected, but none received.');
+    logger.error('X-Import-URL header expected, but none received.');
     process.exit(1);
   }
   const {statusCode: lookupStatusCode} = await fetchCDNResource(importUrlPath);
   if (lookupStatusCode !== 200) {
-    logger.fatal(`Unexpected response [${lookupStatusCode}]: ${PIKA_CDN}${importUrlPath}`);
+    logger.error(`Unexpected response [${lookupStatusCode}]: ${PIKA_CDN}${importUrlPath}`);
     process.exit(1);
   }
   return resolveDependency(installSpecifier, packageSemver, lockfile, false);

--- a/packages/snowpack/src/resolve-remote.ts
+++ b/packages/snowpack/src/resolve-remote.ts
@@ -4,7 +4,7 @@ import PQueue from 'p-queue';
 import validatePackageName from 'validate-npm-package-name';
 import {SnowpackConfig, ImportMap} from './types/snowpack';
 import {fetchCDNResource, PIKA_CDN, RESOURCE_CACHE} from './util.js';
-import logger from './logger';
+import {logger} from './logger';
 
 /**
  * Given an install specifier, attempt to resolve it from the CDN.

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -1,15 +1,15 @@
 import * as colors from 'kleur/colors';
 import path from 'path';
 import {Plugin} from 'rollup';
+import logger from '../logger';
 import {InstallTarget} from '../types/snowpack';
 
 function autoDetectExports(fileLoc: string): string[] | undefined {
   try {
     return Object.keys(require(fileLoc));
   } catch (err) {
-    console.error(
-      colors.red(`✘ Could not auto-detect exports for ${colors.bold(fileLoc)}\n${err.message}`),
-    );
+    logger.error(`✘ Could not auto-detect exports for ${colors.bold(fileLoc)}
+${err.message}`);
   }
 }
 

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -1,7 +1,7 @@
 import * as colors from 'kleur/colors';
 import path from 'path';
 import {Plugin} from 'rollup';
-import logger from '../logger';
+import {logger} from '../logger';
 import {InstallTarget} from '../types/snowpack';
 
 function autoDetectExports(fileLoc: string): string[] | undefined {

--- a/packages/snowpack/src/scan-imports.ts
+++ b/packages/snowpack/src/scan-imports.ts
@@ -7,13 +7,11 @@ import path from 'path';
 import stripComments from 'strip-comments';
 import validatePackageName from 'validate-npm-package-name';
 import {InstallTarget, SnowpackConfig, SnowpackSourceFile} from './types/snowpack';
-import createLogger from './logger';
+import logger from './logger';
 import {findMatchingAliasEntry, getExt, HTML_JS_REGEX, isTruthy, SVELTE_VUE_REGEX} from './util';
 
 const WEB_MODULES_TOKEN = 'web_modules/';
 const WEB_MODULES_TOKEN_LENGTH = WEB_MODULES_TOKEN.length;
-
-const logger = createLogger({name: 'snowpack'});
 
 // [@\w] - Match a word-character or @ (valid package name)
 // (?!.*(:\/\/)) - Ignore if previous match was a protocol (ex: http://)

--- a/packages/snowpack/src/scan-imports.ts
+++ b/packages/snowpack/src/scan-imports.ts
@@ -163,7 +163,7 @@ function parseCodeForInstallTargets({
       [imports] = parse(contents) || [];
     } catch (err) {
       // Another error! No hope left, just abort.
-      logger.fatal(`! ${locOnDisk}`);
+      logger.error(`! ${locOnDisk}`);
       throw err;
     }
   }

--- a/packages/snowpack/src/scan-imports.ts
+++ b/packages/snowpack/src/scan-imports.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import stripComments from 'strip-comments';
 import validatePackageName from 'validate-npm-package-name';
 import {InstallTarget, SnowpackConfig, SnowpackSourceFile} from './types/snowpack';
-import logger from './logger';
+import {logger} from './logger';
 import {findMatchingAliasEntry, getExt, HTML_JS_REGEX, isTruthy, SVELTE_VUE_REGEX} from './util';
 
 const WEB_MODULES_TOKEN = 'web_modules/';

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -1,5 +1,4 @@
 import type HttpProxy from 'http-proxy';
-import pino from 'pino';
 import {Plugin as RollupPlugin} from 'rollup';
 
 export type DeepPartial<T> = {
@@ -153,7 +152,7 @@ export interface CLIFlags extends Omit<Partial<SnowpackConfig['installOptions']>
   env?: string[]; // env vars
   open?: string[];
   secure?: boolean;
-  logLevel?: pino.Level;
+  logLevel?: LoggerLevel;
   debug?: boolean;
   silent?: boolean;
 }
@@ -197,3 +196,10 @@ export type DependencyStatsMap = {
 };
 
 export type DependencyStatsOutput = Record<DependencyType, DependencyStatsMap>;
+
+export type LoggerLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'; // same as Pino
+export type LoggerEvent = 'debug' | 'info' | 'warn' | 'error';
+export interface LoggerOptions {
+  /** (optional) change name at beginning of line */
+  name?: string;
+}

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -152,9 +152,8 @@ export interface CLIFlags extends Omit<Partial<SnowpackConfig['installOptions']>
   env?: string[]; // env vars
   open?: string[];
   secure?: boolean;
-  logLevel?: LoggerLevel;
-  debug?: boolean;
-  silent?: boolean;
+  verbose?: boolean;
+  quiet?: boolean;
 }
 
 export interface ImportMap {

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -165,7 +165,6 @@ export interface CommandOptions {
   config: SnowpackConfig;
   lockfile: ImportMap | null;
   pkgManifest: any;
-  logLevel?: pino.Level;
 }
 
 /**

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -154,6 +154,8 @@ export interface CLIFlags extends Omit<Partial<SnowpackConfig['installOptions']>
   open?: string[];
   secure?: boolean;
   logLevel?: pino.Level;
+  debug?: boolean;
+  silent?: boolean;
 }
 
 export interface ImportMap {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,22 +2958,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/pino-std-serializers@*":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz#f8bd52a209c8b3c97d1533b1ba27f57c816382bf"
-  integrity sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/pino@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@types/pino/-/pino-6.3.0.tgz#a4ad317278eca19becbc87f5ceafebb99d486604"
-  integrity sha512-AuZ32IbQlzW3XY9jA9X8iXkhMTtloKWHz1Ze23ClPx7L8ES69BNGfH308LsU2tHnDCLLCFoZvMn8+1njBx2EKg==
-  dependencies:
-    "@types/node" "*"
-    "@types/pino-std-serializers" "*"
-    "@types/sonic-boom" "*"
-
 "@types/prettier@*", "@types/prettier@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
@@ -3047,13 +3031,6 @@
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/snowpack-env/-/snowpack-env-2.3.0.tgz#a5cb4aeef86700df0245ad1a9c830ebe8cc8f752"
   integrity sha512-wC/zq9A0IhlNyO469UPCOr3XZNTOXeGWiOJig9yWUZ0DkUOVNJinfFqC3vRzmlid6+CSiPw8GLvW/03F2/1vyg==
-
-"@types/sonic-boom@*":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/sonic-boom/-/sonic-boom-0.7.0.tgz#38337036293992a1df65dd3161abddf8fb9b7176"
-  integrity sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==
-  dependencies:
-    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -3823,11 +3800,6 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-
-atomic-sleep@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
-  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -6690,16 +6662,6 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-redact@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.0.0.tgz#17bb8f5e1f56ecf4a38c8455985e5eab4c478431"
-  integrity sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==
-
-fast-safe-stringify@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -6841,11 +6803,6 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
-
-flatstr@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
-  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -11218,23 +11175,6 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pino-std-serializers@^2.4.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz#40ead781c65a0ce7ecd9c1c33f409d31fe712315"
-  integrity sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==
-
-pino@^6.5.0:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-6.5.1.tgz#a245adf960a1f3e88e61a339045d509bccbfb7cc"
-  integrity sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==
-  dependencies:
-    fast-redact "^2.0.0"
-    fast-safe-stringify "^2.0.7"
-    flatstr "^1.0.12"
-    pino-std-serializers "^2.4.2"
-    quick-format-unescaped "^4.0.1"
-    sonic-boom "^1.0.2"
-
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -12058,11 +11998,6 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-quick-format-unescaped@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
-  integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -13247,14 +13182,6 @@ solid-js@^0.16.7:
   version "0.16.14"
   resolved "https://registry.yarnpkg.com/solid-js/-/solid-js-0.16.14.tgz#098aea093d1f1660c3572eda5af085e5d0cc2f20"
   integrity sha512-fdkzrseYaileVAHJAmGRXBrq6Uyd7zwGK53T+QnKTlvd5hhPSh5i2W8vny1HycHTXZ3v8oms/2H2Gj3/cVfVqQ==
-
-sonic-boom@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.1.0.tgz#538c2de63aaca1b49254a7ed9d16e4931fab6ad3"
-  integrity sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==
-  dependencies:
-    atomic-sleep "^1.0.0"
-    flatstr "^1.0.12"
 
 sort-keys@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
## Changes

In our neverending quest for #648, we ran into a problem between `snowpack build` and `snowpack install` using Pino, a neat, minimal Node.js logger with super-clean formatting. And `snowpack dev`, which we wanted to do cool dashboard fullscreen paints.

Since we liked Pino, but couldn’t reconcile Pino with fullscreen paints, we built our own mini-logger with the same API. The result is we can have the best of both worlds: consistent logging formatting in a centralized place, and with a shared logging history we can keep track of for fullscreen terminal paints.

**Features**
- Dev server log/error history
- Fixed disappearing errors on startup
- Drastically improved Vue template error display (see screenshot)

### Screens

**Default build**

<img width="839" alt="Screen Shot 2020-08-14 at 5 32 47 PM" src="https://user-images.githubusercontent.com/1369770/90299665-2f46a700-de54-11ea-87b8-f08cdfb0cc70.png">

**Silent build**

<img width="847" alt="Screen Shot 2020-08-14 at 5 32 11 PM" src="https://user-images.githubusercontent.com/1369770/90299645-1d650400-de54-11ea-9c91-ba0376228622.png">

**Dev server (with new `install` output! 🎉 )**

<img width="841" alt="Screen Shot 2020-08-14 at 5 21 03 PM" src="https://user-images.githubusercontent.com/1369770/90299675-34a3f180-de54-11ea-93ee-8bdab6c4c923.png">

**Dev server (with plugin error)**

<img width="845" alt="Screen Shot 2020-08-14 at 5 43 01 PM" src="https://user-images.githubusercontent.com/1369770/90299995-a6c90600-de55-11ea-9a3a-3a45e32058a3.png">

**Vue template error**

![Screen Shot 2020-08-17 at 10 50 23 AM](https://user-images.githubusercontent.com/1369770/90422018-7bbdfc80-e077-11ea-91e7-04582bb3f7f6.png)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

The tests should take care of `install` output, however `snowpack dev` should be inspected carefully for:

- [ ] startup / shutdown
- [ ] build errors
- [ ] HMR refreshes

<!-- For someone unfamiliar with the issue, how should this be tested? -->
