### PR TITLE
Add @babel/preset-typescript to lit-element TS

### DIFF
--- a/packages/@snowpack/app-template-lit-element-typescript/package.json
+++ b/packages/@snowpack/app-template-lit-element-typescript/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-decorators": "^7.10.5",
+    "@babel/preset-typescript": "^7.10.4",
     "@snowpack/app-scripts-lit-element": "^1.8.2",
     "prettier": "^2.0.5",
     "snowpack": "^2.7.7",


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

It adds a missing dependency to @snowpack/app-template-lit-element-typescript. Without it, Babel is unable to process Typescript code.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Just compile after generating the project.
