### PR TITLE
add typescript env package for TS users

### DIFF
--- a/packages/@snowpack/app-template-blank-typescript/package.json
+++ b/packages/@snowpack/app-template-blank-typescript/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@snowpack/plugin-run-script": "^2.0.4",
     "@types/canvas-confetti": "^1.0.0",
+    "@types/snowpack-env": "^2.3.0",
     "prettier": "^2.0.5",
     "snowpack": "^2.7.7",
     "typescript": "^3.9.7"

--- a/packages/@snowpack/app-template-blank-typescript/types/import.d.ts
+++ b/packages/@snowpack/app-template-blank-typescript/types/import.d.ts
@@ -1,8 +1,0 @@
-// ESM-HMR Interface: `import.meta.hot`
-
-interface ImportMeta {
-  // TODO: Import the exact .d.ts files from "esm-hmr"
-  // https://github.com/pikapkg/esm-hmr
-  hot: any;
-  env: Record<string, any>;
-}

--- a/packages/@snowpack/app-template-lit-element-typescript/package.json
+++ b/packages/@snowpack/app-template-lit-element-typescript/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-proposal-decorators": "^7.10.5",
     "@babel/preset-typescript": "^7.10.4",
     "@snowpack/app-scripts-lit-element": "^1.8.2",
+    "@types/snowpack-env": "^2.3.0",
     "prettier": "^2.0.5",
     "snowpack": "^2.7.7",
     "typescript": "^3.9.7"

--- a/packages/@snowpack/app-template-lit-element-typescript/types/import.d.ts
+++ b/packages/@snowpack/app-template-lit-element-typescript/types/import.d.ts
@@ -1,8 +1,0 @@
-// ESM-HMR Interface: `import.meta.hot`
-
-interface ImportMeta {
-  // TODO: Import the exact .d.ts files from "esm-hmr"
-  // https://github.com/pikapkg/esm-hmr
-  hot: any;
-  env: Record<string, any>;
-}

--- a/packages/@snowpack/app-template-react-typescript/package.json
+++ b/packages/@snowpack/app-template-react-typescript/package.json
@@ -25,6 +25,7 @@
     "@testing-library/react": "^10.0.3",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
+    "@types/snowpack-env": "^2.3.0",
     "jest": "^26.2.2",
     "prettier": "^2.0.5",
     "snowpack": "^2.7.7",

--- a/packages/@snowpack/app-template-react-typescript/types/import.d.ts
+++ b/packages/@snowpack/app-template-react-typescript/types/import.d.ts
@@ -1,8 +1,0 @@
-// ESM-HMR Interface: `import.meta.hot`
-
-interface ImportMeta {
-  // TODO: Import the exact .d.ts files from "esm-hmr"
-  // https://github.com/pikapkg/esm-hmr
-  hot: any;
-  env: Record<string, any>;
-}

--- a/packages/@snowpack/app-template-svelte-typescript/package.json
+++ b/packages/@snowpack/app-template-svelte-typescript/package.json
@@ -23,6 +23,7 @@
     "@testing-library/svelte": "^3.0.0",
     "@tsconfig/svelte": "^1.0.3",
     "@types/jest": "^26.0.4",
+    "@types/snowpack-env": "^2.3.0",
     "jest": "^26.2.2",
     "snowpack": "^2.7.7",
     "svelte-check": "^1.0.0",

--- a/packages/@snowpack/app-template-svelte-typescript/types/import.d.ts
+++ b/packages/@snowpack/app-template-svelte-typescript/types/import.d.ts
@@ -1,8 +1,0 @@
-// ESM-HMR Interface: `import.meta.hot`
-
-interface ImportMeta {
-  // TODO: Import the exact .d.ts files from "esm-hmr"
-  // https://github.com/pikapkg/esm-hmr
-  hot: any;
-  env: Record<string, any>;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,6 +3043,11 @@
   resolved "https://registry.yarnpkg.com/@types/signal-exit/-/signal-exit-3.0.0.tgz#75e3b17660cf1f6c6cb8557675b4e680e43bbf36"
   integrity sha512-MaJ+16SOXz0Z27EMf3d88+B6UDglq1sn140a+5X/ROLkIcEfRq0CPg+1B2efF1GXQn4n+aKH4ti2hHG4Ya+Dzg==
 
+"@types/snowpack-env@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/snowpack-env/-/snowpack-env-2.3.0.tgz#a5cb4aeef86700df0245ad1a9c830ebe8cc8f752"
+  integrity sha512-wC/zq9A0IhlNyO469UPCOr3XZNTOXeGWiOJig9yWUZ0DkUOVNJinfFqC3vRzmlid6+CSiPw8GLvW/03F2/1vyg==
+
 "@types/sonic-boom@*":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@types/sonic-boom/-/sonic-boom-0.7.0.tgz#38337036293992a1df65dd3161abddf8fb9b7176"


### PR DESCRIPTION
## Changes

We were able to get a DefinitelyTyped package merged for Snowpack projects, automatically adding typed definition for `import.meta.hot` and `import.meta.env`. This PR adds that to our TS templates.

## Testing

N/A
