### PR TITLE
feature enhanced hmr

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -510,29 +510,6 @@ export async function command(commandOptions: CommandOptions) {
             code =
               `import './${path.basename(reqPath).replace(/.js$/, '.css.proxy.js')}';\n` + code;
 
-          if (reqUrlHmrParam)
-            code = await transformEsmImports(code as string, (imp) => {
-              const importUrl = path.posix.resolve(path.posix.dirname(reqPath), imp);
-              const node = hmrEngine.getEntry(importUrl);
-              if (node && node.needsReplacement) {
-                hmrEngine.markEntryForReplacement(node, false);
-                return `${imp}?${reqUrlHmrParam}`;
-              }
-              return imp;
-            });
-
-          // hmr
-          const isHmrEnabled = code.includes('import.meta.hot');
-          const rawImports = await scanCodeImportsExports(code);
-          const resolvedImports = rawImports.map((imp) => {
-            let spec = code.substring(imp.s, imp.e);
-            if (imp.d > -1) {
-              spec = matchImportSpecifier(spec) || '';
-            }
-            return path.posix.resolve(path.posix.dirname(reqPath), spec);
-          });
-          hmrEngine.setEntry(originalReqPath, resolvedImports, isHmrEnabled);
-
           // source mapping
           if (sourceMap) code = jsSourceMappingURL(code, sourceMappingURL);
 
@@ -587,6 +564,34 @@ export async function command(commandOptions: CommandOptions) {
           return spec;
         },
       );
+
+      let code = wrappedResponse;
+      if (responseFileExt === '.js' && reqUrlHmrParam)
+        code = await transformEsmImports(code as string, (imp) => {
+          const importUrl = path.posix.resolve(path.posix.dirname(reqPath), imp);
+          const node = hmrEngine.getEntry(importUrl);
+          if (node && node.needsReplacement) {
+            hmrEngine.markEntryForReplacement(node, false);
+            return `${imp}?${reqUrlHmrParam}`;
+          }
+          return imp;
+        });
+
+      if (responseFileExt === '.js') {
+        const isHmrEnabled = code.includes('import.meta.hot');
+        const rawImports = await scanCodeImportsExports(code);
+        const resolvedImports = rawImports.map((imp) => {
+          let spec = code.substring(imp.s, imp.e);
+          if (imp.d > -1) {
+            spec = matchImportSpecifier(spec) || '';
+          }
+          spec = spec.replace(/\?mtime=[0-9]+$/, '');
+          return path.posix.resolve(path.posix.dirname(reqPath), spec);
+        });
+        hmrEngine.setEntry(originalReqPath, resolvedImports, isHmrEnabled);
+      }
+
+      wrappedResponse = code;
       return wrappedResponse;
     }
 
@@ -779,11 +784,18 @@ export async function command(commandOptions: CommandOptions) {
     if (node && node.isHmrEnabled) {
       hmrEngine.broadcastMessage({type: 'update', url});
     }
-    if (node && node.isHmrAccepted) {
+    if (
+      node &&
+      node.isHmrAccepted &&
+      // width isHmrAccepted but also need bubble
+      !(url.endsWith('.json.proxy.js') || url.endsWith('.module.css.proxy.js'))
+    ) {
       // Found a boundary, no bubbling needed
     } else if (node && node.dependents.size > 0) {
-      hmrEngine.markEntryForReplacement(node, true);
-      node.dependents.forEach((dep) => updateOrBubble(dep, visited));
+      node.dependents.forEach((dep) => {
+        hmrEngine.markEntryForReplacement(node, true);
+        updateOrBubble(dep, visited);
+      });
     } else {
       // We've reached the top, trigger a full page refresh
       hmrEngine.broadcastMessage({type: 'reload'});
@@ -799,7 +811,7 @@ export async function command(commandOptions: CommandOptions) {
     }
 
     // Append ".proxy.js" to Non-JS files to match their registered URL in the client app.
-    if (!updateUrl.endsWith('.js') && !updateUrl.endsWith('.module.css')) {
+    if (!updateUrl.endsWith('.js')) {
       updateUrl += '.proxy.js';
     }
     // Check if a virtual file exists in the resource cache (ex: CSS from a Svelte file)

--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -784,12 +784,7 @@ export async function command(commandOptions: CommandOptions) {
     if (node && node.isHmrEnabled) {
       hmrEngine.broadcastMessage({type: 'update', url});
     }
-    if (
-      node &&
-      node.isHmrAccepted &&
-      // width isHmrAccepted but also need bubble
-      !(url.endsWith('.json.proxy.js') || url.endsWith('.module.css.proxy.js'))
-    ) {
+    if (node && node.isHmrAccepted) {
       // Found a boundary, no bubbling needed
     } else if (node && node.dependents.size > 0) {
       node.dependents.forEach((dep) => {

--- a/packages/snowpack/src/hmr-server-engine.ts
+++ b/packages/snowpack/src/hmr-server-engine.ts
@@ -8,6 +8,7 @@ interface Dependency {
   isHmrEnabled: boolean;
   isHmrAccepted: boolean;
   needsReplacement: boolean;
+  needsReplacementCount: number;
 }
 
 export class EsmHmrEngine {
@@ -51,6 +52,7 @@ export class EsmHmrEngine {
       dependencies: new Set(),
       dependents: new Set(),
       needsReplacement: false,
+      needsReplacementCount: 0,
       isHmrEnabled: false,
       isHmrAccepted: false,
     };
@@ -99,7 +101,12 @@ export class EsmHmrEngine {
   }
 
   markEntryForReplacement(entry: Dependency, state: boolean) {
-    entry.needsReplacement = state;
+    if (state) {
+      entry.needsReplacementCount++;
+    } else {
+      entry.needsReplacementCount--;
+    }
+    entry.needsReplacement = !!entry.needsReplacementCount;
   }
 
   broadcastMessage(data: object) {


### PR DESCRIPTION
This PR is a way to enhanced hmr for current snowpack.

## Changes

### 1. Make correct hmr dependencyTree

In current version, we call `hmrEngine.setEntry` in `wrapResponse` function.  

> https://github.com/pikapkg/snowpack/blob/master/packages/snowpack/src/commands/dev.ts#L523

In this stage, `import resolve` is not finished. the `hmr dependencyTree` may be incorrect in some situation. such as:

> https://github.com/Akimyou/snowpack/blob/test%2Fhmr/packages/%40snowpack/app-template-vue/src/test-hmr/SubComponent.vue

```js
import foo from './foo';
import bar from './bar';
```
These import statement depend on `import resolve` to import the correct file `./foo` > `./foo.js`, `./bar` > `./bar/index.js`.
If we call `hmrEngine.setEntry` in `wrapResponse` function the `SubComponent.vue`'s `hmr dependencyTree` is incorrect as: 

```shell
[snowpack] /_dist_/test-hmr/SubComponent.js
[snowpack] /_dist_/test-hmr/SubComponent.css.proxy.js, /_dist_/test-hmr/foo, /_dist_/test-hmr/bar
```
The correct result should be:
```shell
[snowpack] /_dist_/test-hmr/SubComponent.js
[snowpack] /_dist_/test-hmr/SubComponent.css.proxy.js, /_dist_/test-hmr/foo.js, /_dist_/test-hmr/bar/index.js
```

So, we need make sure `import resolve` is finished when we do some about hmr.
We can move hmr codes from `wrapResponse` function to `resolveResponseImports` function.

Code changes:
- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03L513
- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03R569

#### 1.1 Remove useless `mtime query` before set `hmr dependencyTree`
- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03R588

### 2. Make hmr updateOrBubble in suitable way

#### 2.1 `json` and `module.css` should bubble to the top

Because of the `esm` export feature. The `json` hmr accept callback change the json module address in memory. This change can't not be notice by other module. The `module.css` have same issue with `json` if we change `module.css`'s exportTokens.

> https://github.com/pikapkg/snowpack/blob/master/packages/snowpack/src/build/build-import-proxy.ts#L99
> https://github.com/pikapkg/snowpack/blob/master/packages/snowpack/src/build/build-import-proxy.ts#L161

So, in my opinion, we should make it bubble to the top.

Code changes:
- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03R790

#### 2.2 Treat `module.css` as normal proxy file

- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03R814

### 3. Support multiple parents hmr bubble

Current `EsmHmrEngine.needsReplacement` is a bool flag. If a module have multiple parents to bubble, it will only bubble the first one.

```
App.vue
>>> foo.js
>>> SubComponent.vue
         >>> foo.js
```
Only one parent node can be hmr update.

To support multiple parents hmr bubble. We can change to use `EsmHmrEngine.needsReplacementCount`.

Code changes:
- https://github.com/pikapkg/snowpack/pull/827/files#diff-727d7d0aceb2230c58ee736e6f7cd9f6R103
- https://github.com/pikapkg/snowpack/pull/827/files#diff-a9a5e1182c58895d1721309294326f03R795

## Testing

Please try this repo for test current snowpack hmr behaviour.

- https://github.com/Akimyou/snowpack/tree/test/hmr/packages/%40snowpack/app-template-vue

```shell
npm run start
```

And you can run new snowpack with this PR in the same test project,  make a comparison.

- https://github.com/Akimyou/snowpack/tree/feature/enhancedHmr

## Thanks

Thanks for read this PR and hard work on snowpack. Hope we change make snowpack better.
