### PR TITLE
Add `@snowpack/plugin-react-refresh` to React scripts

### DIFF
--- a/packages/@snowpack/app-scripts-react/babel.config.json
+++ b/packages/@snowpack/app-scripts-react/babel.config.json
@@ -1,4 +1,11 @@
 {
   "presets": [["@babel/preset-react"], "@babel/preset-typescript"],
-  "plugins": ["@babel/plugin-syntax-import-meta"]
+  "plugins": ["@babel/plugin-syntax-import-meta"],
+  "env": {
+    "development": {
+      "plugins": [
+        "react-refresh/babel"
+      ]
+    }
+  }
 }

--- a/packages/@snowpack/app-scripts-react/package.json
+++ b/packages/@snowpack/app-scripts-react/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@snowpack/plugin-babel": "^2.0.3",
     "@snowpack/plugin-dotenv": "^2.0.0",
+    "@snowpack/plugin-react-refresh": "^2.0.2",
     "babel-jest": "^26.2.2",
     "babel-preset-react-app": "^9.1.2",
     "react-app-polyfill": "^1.0.6"

--- a/packages/@snowpack/app-scripts-react/snowpack.config.js
+++ b/packages/@snowpack/app-scripts-react/snowpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     public: '/',
     src: '/_dist_',
   },
-  plugins: ['@snowpack/plugin-babel', '@snowpack/plugin-dotenv'],
+  plugins: ['@snowpack/plugin-react-refresh', '@snowpack/plugin-babel', '@snowpack/plugin-dotenv'],
   devOptions: {},
   installOptions: {
     installTypes: isTS,

--- a/packages/@snowpack/plugin-react-refresh/package.json
+++ b/packages/@snowpack/plugin-react-refresh/package.json
@@ -10,8 +10,8 @@
     "react-refresh": "^0.8.3"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4"
 }

--- a/packages/@snowpack/plugin-react-refresh/package.json
+++ b/packages/@snowpack/plugin-react-refresh/package.json
@@ -10,8 +10,8 @@
     "react-refresh": "^0.8.3"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+    "react": ">=16.10.0",
+    "react-dom": ">=16.10.0"
   },
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4"
 }

--- a/packages/@snowpack/plugin-react-refresh/package.json
+++ b/packages/@snowpack/plugin-react-refresh/package.json
@@ -9,5 +9,9 @@
   "dependencies": {
     "react-refresh": "^0.8.3"
   },
+  "peerDependencies": {
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  },
   "gitHead": "a01616bb0787d56cd782f94cecf2daa12c7594e4"
 }


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Adds the `@snowpack/plugin-react-refresh` plugin back into the React scripts by default. The reasoning behind this is that:

- Next.js offers it by default (https://nextjs.org/docs/basic-features/fast-refresh)
- CRA offers it by default (https://github.com/facebook/create-react-app/pull/9350)

It is also, pretty easy for a user to remove this plugin if they don't want to use it.

Added a peer dependency of 16.9.0 to the `@snowpack/plugin-react-refresh` since it requires at least that to run. (https://github.com/facebook/react/issues/16604#issuecomment-528663101)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->

Tested in the `@snowpack/app-template-react` and `@snowpack/app-template-react-typescript` to ensure it was working.