### PR TITLE
use Yarn Workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "version": "independent",
   "packages": ["packages/@snowpack/*", "packages/*"],
-  "npmClient": "yarn"
+  "npmClient": "yarn",
+  "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "build": "cd packages/snowpack && yarn build",
-    "publish": "lerna publish",
+    "bootstrap": "lerna bootstrap",
+    "build": "lerna run build --scope=snowpack",
+    "publish": "lerna publish --no-private",
     "format": "prettier --write \"packages/*/src/**/*.ts\"",
     "test": "jest --test-timeout=30000",
     "update-snapshots": "node ./scripts/update-snapshots.js"


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Adds the `--no-private` flag to the `publish` command to prevent any churn on test packages and/or private packages. As far as I can tell, the yarn `workspaces` list is taking over the `packages` list. We need to bootstrap the test directory but we don't want to publish/version it.

![image](https://user-images.githubusercontent.com/855184/90433714-e1b77d80-e091-11ea-9401-becdf51e45ad.png)

Adds a convenience `bootstrap` command and utilizes `lerna run` to build the `snowpack` package.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->

Attempted a `yarn run publish` and observed that only the packages in the `packages/` directory were included.
