### PR TITLE
Improve HMR script loading, Chrome blocking dev server start on Mac

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -827,7 +827,9 @@ ${err}`);
   });
 
   // Open the user's browser
-  if (open !== 'none') await openInBrowser(protocol, hostname, port, open);
+  if (open !== 'none') {
+    await openInBrowser(protocol, hostname, port, open);
+  }
 
   // Start watching the file system.
   // Defer "chokidar" loading to here, to reduce impact on overall startup time


### PR DESCRIPTION
## Changes

In testing the dev server’s HMR, I noticed 2 things:

1. If Chrome wasn’t responding, then Snowpack dev server wouldn’t start (which seemed broken)
2. We were loading the `hmr.js` script _after_ the closing `</body>` tag

#2 probably won’t affect anything because HTML is very forgiving, but better to err or the side of safety. #1 actually was a blocker, because I was confused why I could load the site in Firefox but nothing was working, and didn’t realize on my machine a failed Chrome process was running and Snowpack had stopped everything to try and talk to it. I imagine more people have had that problem than we realized (or in general, Chrome is slower than anticipated). 

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Try out all the CSA templates, make sure HMR is working

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
