### PR TITLE
Output basic HMR messages to log

### DIFF
--- a/packages/snowpack/assets/hmr.js
+++ b/packages/snowpack/assets/hmr.js
@@ -3,8 +3,9 @@
  * A client-side implementation of the ESM-HMR spec, for reference.
  */
 
+ const ESM_PREFIX = '[ESM-HMR]'
 function debug(...args) {
-  console.debug('[ESM-HMR]', ...args);
+  console.debug(ESM_PREFIX, ...args);
 }
 function reload() {
   location.reload(true);
@@ -138,6 +139,7 @@ socket.addEventListener('message', ({data: _data}) => {
   if (data.type === 'reload') {
     debug('message: reload');
     reload();
+    console.log(`${ESM_PREFIX} Reloaded`);
     return;
   }
   if (data.type !== 'update') {
@@ -146,6 +148,7 @@ socket.addEventListener('message', ({data: _data}) => {
   }
   debug('message: update', data);
   debug(data.url, Object.keys(REGISTERED_MODULES));
+  console.log(`${ESM_PREFIX} Updated`);
   runModuleAccept(data.url)
     .then((ok) => {
       if (!ok) {

--- a/packages/snowpack/assets/hmr.js
+++ b/packages/snowpack/assets/hmr.js
@@ -3,9 +3,8 @@
  * A client-side implementation of the ESM-HMR spec, for reference.
  */
 
- const ESM_PREFIX = '[ESM-HMR]'
-function debug(...args) {
-  console.debug(ESM_PREFIX, ...args);
+function log(...args) {
+  console.log('[ESM-HMR]', ...args);
 }
 function reload() {
   location.reload(true);
@@ -136,17 +135,15 @@ socket.addEventListener('message', ({data: _data}) => {
   }
   const data = JSON.parse(_data);
   if (data.type === 'reload') {
-    debug('message: reload');
+    log('message: reload');
     reload();
-    console.log(`${ESM_PREFIX} Reloaded`);
     return;
   }
   if (data.type !== 'update') {
-    debug('message: unknown', data);
+    log('message: unknown', data);
     return;
   }
-  debug('message: update', data);
-  console.log(`${ESM_PREFIX} Updated`);
+  log('message: update', data);
   runModuleAccept(data.url)
     .then((ok) => {
       if (!ok) {
@@ -158,4 +155,4 @@ socket.addEventListener('message', ({data: _data}) => {
       reload();
     });
 });
-debug('listening for file changes...');
+log('listening for file changes...');

--- a/packages/snowpack/assets/hmr.js
+++ b/packages/snowpack/assets/hmr.js
@@ -135,7 +135,6 @@ socket.addEventListener('message', ({data: _data}) => {
     return;
   }
   const data = JSON.parse(_data);
-  debug('message', data);
   if (data.type === 'reload') {
     debug('message: reload');
     reload();
@@ -147,7 +146,6 @@ socket.addEventListener('message', ({data: _data}) => {
     return;
   }
   debug('message: update', data);
-  debug(data.url, Object.keys(REGISTERED_MODULES));
   console.log(`${ESM_PREFIX} Updated`);
   runModuleAccept(data.url)
     .then((ok) => {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->



Before:

Output 3 lines per "update" and 2 lines minimum per message. All output on `console.debug` (Not visible by default log levels)

With default logging:
![image](https://user-images.githubusercontent.com/855184/90450011-454fa400-e0ae-11ea-9e88-30d0f67522f9.png)

With debug/verbose enabled:
![image](https://user-images.githubusercontent.com/855184/90450022-4b458500-e0ae-11ea-94ea-613780d72fda.png)

After:

Output 1 line per message. All output on `console.log` (Visible by default log levels)

With default logging:
![image](https://user-images.githubusercontent.com/855184/90452458-d07f6880-e0b3-11ea-977b-348c124817be.png)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->

Manually tested using `@snowpack/app-template-react` with Fast Refresh enabled.