### PR TITLE
fix: display command name in config error

### DIFF
--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -321,7 +321,7 @@ function loadPlugins(
     const {scriptType, input, output} = parseScript(target);
     if ((config.plugins as any).some((p) => (Array.isArray(p) ? p[0] : p) === cmd)) {
       handleConfigError(
-        `[${name}]: loaded in both \`scripts\` and \`plugins\`. Please choose one (preferably \`plugins\`).`,
+        `[${cmd}]: loaded in both \`scripts\` and \`plugins\`. Please choose one (preferably \`plugins\`).`,
       );
     }
 


### PR DESCRIPTION
## Changes

Fixes `ReferenceError: name is not defined` because `name` is not in scope. I believe this is meant to display the `cmd` name instead.

## Testing

No functionality change and there seems to be no existing test for similar configuration errors. As there is also a comment above this code section declaring it as deprecated I decided not to write a test for this.