### PR TITLE
Update transform plugin to use id instead of filepath

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -110,7 +110,7 @@ For our first example, we’ll look at transforming a file.
 module.exports = function (snowpackConfig, pluginOptions) {
   return {
     name: 'my-commenter-plugin',
-    async transform({fileExt, filePath, contents, isDev}) {
+    async transform({id, contents, isDev}) {
       if (fileExt === '.js') {
         return `/* I’m a comment! */ ${contents}`;
       }

--- a/packages/@snowpack/plugin-react-refresh/plugin.js
+++ b/packages/@snowpack/plugin-react-refresh/plugin.js
@@ -29,14 +29,14 @@ function transformHtml(contents) {
   );
 }
 
-function transformJs(contents, filePath) {
+function transformJs(contents, id) {
   return `
 /** React Refresh: Setup **/
 if (import.meta.hot) {
   var prevRefreshReg = window.$RefreshReg$;
   var prevRefreshSig = window.$RefreshSig$;
   window.$RefreshReg$ = (type, id) => {
-    window.$RefreshRuntime$.register(type, ${JSON.stringify(filePath)} + " " + id);
+    window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
   }
   window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
 }
@@ -56,7 +56,7 @@ if (import.meta.hot) {
 module.exports = function reactRefreshTransform(snowpackConfig) {
   return {
     name: '@snowpack/plugin-react-refresh',
-    transform({contents, fileExt, filePath, isDev}) {
+    transform({contents, fileExt, id, isDev}) {
       // Use long-form "=== false" to handle older Snowpack versions
       if (snowpackConfig.devOptions.hmr === false) {
         return;
@@ -65,7 +65,7 @@ module.exports = function reactRefreshTransform(snowpackConfig) {
         return;
       }
       if (fileExt === '.js' && /\$RefreshReg\$\(/.test(contents)) {
-        return transformJs(contents, filePath);
+        return transformJs(contents, id);
       }
       if (fileExt === '.html') {
         return transformHtml(contents);

--- a/packages/snowpack/src/build/build-pipeline.ts
+++ b/packages/snowpack/src/build/build-pipeline.ts
@@ -112,7 +112,8 @@ async function runPipelineTransformStep(
   {isDev, plugins, sourceMaps}: BuildFileOptions,
 ): Promise<SnowpackBuildMap> {
   const srcExt = getExt(srcPath).baseExt;
-  const rootFileName = path.basename(srcPath).replace(srcExt, '');
+  const rootFilePath = srcPath.replace(srcExt, '');
+  const rootFileName = path.basename(rootFilePath);
   for (const step of plugins) {
     if (!step.transform) {
       continue;
@@ -122,14 +123,17 @@ async function runPipelineTransformStep(
       for (const destExt of Object.keys(output)) {
         const destBuildFile = output[destExt];
         const {code} = typeof destBuildFile === 'string' ? {code: destBuildFile} : destBuildFile;
-        const filePath = rootFileName + destExt;
+        const fileName = rootFileName + destExt;
+        const filePath = rootFilePath + destExt;
         const debugPath = path.relative(process.cwd(), filePath);
         logger.debug(`transform() starting… [${debugPath}]`, {name: step.name});
         const result = await step.transform({
           contents: code,
-          fileExt: destExt,
-          filePath,
           isDev,
+          fileExt: destExt,
+          id: filePath,
+          // @ts-ignore: Deprecated
+          filePath: fileName,
           // @ts-ignore: Deprecated
           urlPath: `./${path.basename(rootFileName + destExt)}`,
         });

--- a/packages/snowpack/src/types/snowpack.ts
+++ b/packages/snowpack/src/types/snowpack.ts
@@ -34,7 +34,7 @@ export interface PluginLoadOptions {
 }
 
 export interface PluginTransformOptions {
-  filePath: string;
+  id: string;
   fileExt: string;
   contents: string | Buffer;
   isDev: boolean;


### PR DESCRIPTION
## Changes

- Resolves #811
- `filePath` has been deprecated, `id` is the new full file path

## Testing

- Covered by existing tests.
