### PR TITLE
fix wrong logic when extendConfig's plugin has options

### DIFF
--- a/packages/snowpack/src/config.ts
+++ b/packages/snowpack/src/config.ts
@@ -793,13 +793,17 @@ export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): Snowpa
       process.exit(1);
     }
     if (extendConfig.plugins) {
-      const extendConfgDir = path.dirname(extendConfigLoc);
+      const extendConfigDir = path.dirname(extendConfigLoc);
       extendConfig.plugins = extendConfig.plugins.map((plugin) => {
         const name = Array.isArray(plugin) ? plugin[0] : plugin;
         const absName = path.isAbsolute(name)
           ? name
-          : require.resolve(name, {paths: [extendConfgDir]});
-        return Array.isArray(plugin) ? plugin.splice(0, 1, absName) : absName;
+          : require.resolve(name, {paths: [extendConfigDir]});
+        if (Array.isArray(plugin)) {
+          plugin.splice(0, 1, absName);
+          return plugin;
+        }
+        return absName;
       });
     }
   }


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The return value of `splice()` is [a new array containing the extracted elements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice). 
Our code should return a array. it's `array[0]` is `absName`.


## Testing


<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
