### PR TITLE
fix exporting multiple default

### DIFF
--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -82,6 +82,9 @@ export function rollupPluginWrapInstallTargets(
       const normalizedFileLoc = fileLoc.split(path.win32.sep).join(path.posix.sep);
       if (!isTreeshake && isAutoDetect(normalizedFileLoc)) {
         uniqueNamedImports = autoDetectExports(fileLoc) || uniqueNamedImports;
+        if (uniqueNamedImports.includes('default')) {
+          uniqueNamedImports.splice(uniqueNamedImports.indexOf('default'), 1);
+        }
         treeshakeSummary.default = true;
       }
       const result = `

--- a/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
+++ b/packages/snowpack/src/rollup-plugins/rollup-plugin-wrap-install-targets.ts
@@ -6,7 +6,7 @@ import {InstallTarget} from '../types/snowpack';
 
 function autoDetectExports(fileLoc: string): string[] | undefined {
   try {
-    return Object.keys(require(fileLoc));
+    return Object.keys(require(fileLoc)).filter((imp) => imp !== 'default');
   } catch (err) {
     logger.error(`✘ Could not auto-detect exports for ${colors.bold(fileLoc)}
 ${err.message}`);
@@ -82,9 +82,6 @@ export function rollupPluginWrapInstallTargets(
       const normalizedFileLoc = fileLoc.split(path.win32.sep).join(path.posix.sep);
       if (!isTreeshake && isAutoDetect(normalizedFileLoc)) {
         uniqueNamedImports = autoDetectExports(fileLoc) || uniqueNamedImports;
-        if (uniqueNamedImports.includes('default')) {
-          uniqueNamedImports.splice(uniqueNamedImports.indexOf('default'), 1);
-        }
         treeshakeSummary.default = true;
       }
       const result = `


### PR DESCRIPTION
## Steps to Reproduce
1. `npx create-snowpack-app snowpack-react --template @snowpack/app-template-react --use-yarn`
2. `cd snowpack-react`
3. `yarn add react-redux redux redux-undo`
4. add `src/reducer.js`. [see code](https://github.com/MoonBall/snowpack/blob/discussions/758/packages/%40snowpack/app-template-react/src/reducer.js).
5. add `src/store.js`. [see code](https://github.com/MoonBall/snowpack/blob/discussions/758/packages/%40snowpack/app-template-react/src/store.js).
6. modify `src/index.jsx` to use redux. [see code](https://github.com/MoonBall/snowpack/blob/discussions/758/packages/%40snowpack/app-template-react/src/index.jsx).
7. modify `src/App.jsx`. [see code](https://github.com/MoonBall/snowpack/blob/discussions/758/packages/%40snowpack/app-template-react/src/App.jsx).
8. modify `snowpack.config.json`. [see code](https://github.com/MoonBall/snowpack/blob/discussions/758/packages/%40snowpack/app-template-react/snowpack.config.json).
9. `yarn start`

There would be an error in console.
```
Duplicate export 'default' (4:139) in snowpack-wrap:.../node_modules/redux-undo/lib/index.js
```

## Cause
The return value of `autoDetectExports()` could  include `default`. So error occur.

## Changes
if the return value of `autoDetectExports()` includes `default`, we remove `default` from array.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
