### PR TITLE
Lookup with ".html" extension in dev server

### DIFF
--- a/packages/snowpack/src/commands/dev.ts
+++ b/packages/snowpack/src/commands/dev.ts
@@ -397,6 +397,7 @@ export async function command(commandOptions: CommandOptions) {
         }
         if (isRoute) {
           let fileLoc =
+            (await attemptLoadFile(requestedFile)) ||
             (await attemptLoadFile(requestedFile + '.html')) ||
             (await attemptLoadFile(requestedFile + 'index.html')) ||
             (await attemptLoadFile(requestedFile + '/index.html'));


### PR DESCRIPTION
## Changes

- Our resolution logic wasn't finding HTML files properly when the extension already existed.
- Now it is!

## Testing

- Tested the dev server manually.