### PR TITLE
Fix CSA document url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When you're ready to deploy your web application to users, you can add back a tr
 
 ## Create Snowpack App (CSA)
 
-For starter apps and templates, see [create-snowpack-app](./packages/create-snowpack-app).
+For starter apps and templates, see [create-snowpack-app](./create-snowpack-app).
 
 ## Official Snowpack Plugins
 

--- a/create-snowpack-app/README.md
+++ b/create-snowpack-app/README.md
@@ -1,1 +1,1 @@
-## 👉 [`create-snowpack-app`](./create-snowpack-app/cli)
+## 👉 [`create-snowpack-app`](./cli)

--- a/docs/docs/02-quickstart.md
+++ b/docs/docs/02-quickstart.md
@@ -14,7 +14,7 @@ Snowpack can also be installed globally via `npm install -g snowpack`. But, we r
 
 ### Create Snowpack App (CSA)
 
-The easiest way to get started with Snowpack is via [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
+The easiest way to get started with Snowpack is via [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
 
 If you've ever used Create React App, this is a lot like that!
 
@@ -34,7 +34,7 @@ npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
 - [@snowpack/app-template-lit-element](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
 - [@snowpack/app-template-lit-element-typescript](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element-typescript)
 - [@snowpack/app-template-11ty](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-11ty)
-- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app)**
+- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app)**
 
 <!--
 ### Tutorial: Starting from Scratch

--- a/docs/docs/04-features.md
+++ b/docs/docs/04-features.md
@@ -168,7 +168,7 @@ Snowpack supports full HMR out-of-the-box for the following served files:
 - CSS Modules
 - JSON
 
-Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/blob/master/packages/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
+Popular frameworks can also be set up for HMR. **[Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack/blob/master/create-snowpack-app) ships with HMR enabled by default for all of the following frameworks.** If you're not using CSA, you can setup HMR in your application with a simple plugin or a few lines of code:
 
 - Preact: [@prefresh/snowpack](https://www.npmjs.com/package/@prefresh/snowpack)
 - React: [@snowpack/plugin-react-refresh](https://www.npmjs.com/package/@snowpack/plugin-react-refresh)

--- a/docs/posts/2020-05-26-snowpack-2-0-release.md
+++ b/docs/posts/2020-05-26-snowpack-2-0-release.md
@@ -102,7 +102,7 @@ To be clear, Snowpack isn't against bundling for production. In fact, we recomme
 
 Snowpack treats bundling as a final, production-only build optimization. By bundling as the final step, you avoid mixing build logic and bundle logic in the same huge configuration file. Instead, your bundler gets already-built files and can focus solely on what it does best: bundling.
 
-Snowpack maintains official plugins for both Webpack & Parcel. Connect your favorite, and then run `snowpack build` to build your site for production. 
+Snowpack maintains official plugins for both Webpack & Parcel. Connect your favorite, and then run `snowpack build` to build your site for production.
 
 ```js
 // snowpack.config.json
@@ -129,7 +129,7 @@ If you already have an existing Snowpack application, Snowpack 2.0 will walk you
 
 #### Create Snowpack App
 
-The easiest way to get started with Snowpack is with [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment. 
+The easiest way to get started with Snowpack is with [Create Snowpack App (CSA)](https://github.com/pikapkg/snowpack). CSA automatically initializes a starter application for you with a pre-configured, Snowpack-powered dev environment.
 
 ``` bash
 npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
@@ -144,12 +144,12 @@ npx create-snowpack-app new-dir --template [SELECT FROM BELOW] [--use-yarn]
 - [@snowpack/app-template-vue](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-vue)
 - [@snowpack/app-template-lit-element](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-lit-element)
 - [@snowpack/app-template-11ty](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app/app-template-11ty)
-- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app)**
+- **[See all community templates](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app)**
 
 
 🐹 Happy hacking!
 
 ---
 
-*Thank you to all of our [80+ contributors](https://github.com/pikapkg/snowpack/graphs/contributors) for making this release possible.*  
+*Thank you to all of our [80+ contributors](https://github.com/pikapkg/snowpack/graphs/contributors) for making this release possible.*
 *Thanks to [Melissa McEwen](https://twitter.com/melissamcewen) & [@TheoOnTwitch](https://twitter.com/TheoOnTwitch) for helping to edit this post.*

--- a/docs/posts/2020-07-30-snowpack-2-7-release.md
+++ b/docs/posts/2020-07-30-snowpack-2-7-release.md
@@ -45,14 +45,14 @@ Snowpack v2.7 features an major rewrite of our internal build pipeline to suppo
 
 Snowpack 2.7 is fully backwards compatible with older plugins, so you can upgrade Snowpack without worrying about version mismatches.
 
-Every hook is documented in our new [Plugins Guide](/plugins) for plugin authors. The new API is heavily inspired by [Rollup](https://rollupjs.org/), so we hope it already feels familiar to many of you. 
+Every hook is documented in our new [Plugins Guide](/plugins) for plugin authors. The new API is heavily inspired by [Rollup](https://rollupjs.org/), so we hope it already feels familiar to many of you.
 
 
 ## Simplified Configuration
 
 ![snowpack screenshot](/img/snowpack-27-screenshot-3.png)
 
-Snowpack v2.0 originally introduced the concept of build `"scripts"` as a way to configure anything from file building to HTTP request proxying. Scripts were flexible, but hard to document and frustrating to debug. 
+Snowpack v2.0 originally introduced the concept of build `"scripts"` as a way to configure anything from file building to HTTP request proxying. Scripts were flexible, but hard to document and frustrating to debug.
 
 Our internal plugin rewrite presented an opportunity to improve the developer experience while keeping the flexibility of direct CLI tooling. You can now connect third-party tooling directly into Snowpack's build pipeline using one of two new utility plugins:
 
@@ -84,7 +84,7 @@ If you don't use a bundler in production, you'll still see a smaller build. That
 
 Last week, [Svelte announced official support for TypeScript](https://svelte.dev/blog/svelte-and-typescript). We're huge fans of both projects and couldn't pass up the chance to test the new support out in a brand new Svelte + TypeScript app template for Snowpack.
 
-Visit [Create Snowpack App](https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app) for a list of all of our new app templates.
+Visit [Create Snowpack App](https://github.com/pikapkg/snowpack/tree/master/create-snowpack-app) for a list of all of our new app templates.
 
 
 ## Thank You, Contributors!


### PR DESCRIPTION
## Changes

Fix CSA document urls in docs.

Before: `/packages/create-snowpack-app`

![image](https://user-images.githubusercontent.com/4298791/90970215-e1f5c400-e53c-11ea-8f15-cb7ffb07da65.png)

After: `/create-snowpack-app`

![image](https://user-images.githubusercontent.com/4298791/90970224-018cec80-e53d-11ea-9b1b-d92fd90e8db8.png)


## Testing

Check **Create Snowpack App** links in below links.

### Document

- https://snowpack-git-fork-ironhee-fix-csa-url.pikapkg.vercel.app/#official-app-templates
- https://snowpack-git-fork-ironhee-fix-csa-url.pikapkg.vercel.app/#hot-module-replacement

### Github

- https://github.com/ironhee/snowpack/blob/fix-csa-url/README.md#create-snowpack-app-csa
- https://github.com/ironhee/snowpack/blob/fix-csa-url/docs/docs/02-quickstart.md#create-snowpack-app-csa
- https://github.com/ironhee/snowpack/blob/fix-csa-url/docs/docs/04-features.md#hot-module-replacement
- https://github.com/ironhee/snowpack/blob/fix-csa-url/docs/posts/2020-07-30-snowpack-2-7-release.md#svelte--typescript-support
- https://github.com/ironhee/snowpack/blob/fix-csa-url/docs/posts/2020-05-26-snowpack-2-0-release.md
- https://github.com/ironhee/snowpack/blob/fix-csa-url/docs/posts/2020-05-26-snowpack-2-0-release.md#create-snowpack-app