### PR TITLE
Improve encoding

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -184,23 +184,25 @@ export async function wrapImportProxy({
   config,
 }: {
   url: string;
-  code: string;
+  code: string | Buffer;
   isDev: boolean;
   hmr: boolean;
   config: SnowpackConfig;
 }) {
   const {baseExt, expandedExt} = getExt(url);
 
-  if (baseExt === '.json') {
-    return generateJsonImportProxy({code, hmr, isDev, config});
-  }
+  if (typeof code === 'string') {
+    if (baseExt === '.json') {
+      return generateJsonImportProxy({code, hmr, isDev, config});
+    }
 
-  if (baseExt === '.css') {
-    // if proxying a CSS file, remove its source map (the path no longer applies)
-    const sanitized = code.replace(/\/\*#\s*sourceMappingURL=[^/]+\//gm, '');
-    return expandedExt.endsWith('.module.css')
-      ? generateCssModuleImportProxy({url, code: sanitized, isDev, hmr, config})
-      : generateCssImportProxy({code: sanitized, hmr, isDev, config});
+    if (baseExt === '.css') {
+      // if proxying a CSS file, remove its source map (the path no longer applies)
+      const sanitized = code.replace(/\/\*#\s*sourceMappingURL=[^/]+\//gm, '');
+      return expandedExt.endsWith('.module.css')
+        ? generateCssModuleImportProxy({url, code: sanitized, isDev, hmr, config})
+        : generateCssImportProxy({code: sanitized, hmr, isDev, config});
+    }
   }
 
   return generateDefaultImportProxy(url);

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -143,7 +143,7 @@ const sendFile = (
   }
 
   res.writeHead(200, headers);
-  res.write(body, getEncodingType(ext));
+  res.write(body, getEncodingType(ext) as BufferEncoding);
   res.end();
 };
 
@@ -596,13 +596,15 @@ If Snowpack is having trouble detecting the import, add ${colors.bold(
       fileLoc: string,
       requestedFileExt: string,
       output: SnowpackBuildMap,
-    ): Promise<string | null> {
+    ): Promise<string | Buffer | null> {
       // Verify that the requested file exists in the build output map.
       if (!output[requestedFileExt] || !Object.keys(output)) {
         return null;
       }
       // Wrap the response.
       const {code, map} = output[requestedFileExt];
+      if (typeof code !== 'string') return code; // return binary files as-is
+
       const hasAttachedCss = requestedFileExt === '.js' && !!output['.css'];
       let wrappedResponse = await wrapResponse(code, {
         hasCssResource: hasAttachedCss,
@@ -688,7 +690,7 @@ If Snowpack is having trouble detecting the import, add ${colors.bold(
     }
 
     // 5. Final option: build the file, serve it, and cache it.
-    let responseContent: string | null;
+    let responseContent: string | Buffer | null;
     let responseOutput: SnowpackBuildMap;
     try {
       responseOutput = await buildFile(fileLoc);

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -11,7 +11,7 @@ export type DeepPartial<T> = {
 
 export type EnvVarReplacements = Record<string, string | number | true>;
 
-export type SnowpackBuiltFile = {code: string; map?: string};
+export type SnowpackBuiltFile = {code: string | Buffer; map?: string};
 export type SnowpackBuildMap = Record<string, SnowpackBuiltFile>;
 
 /** Standard file interface */

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -35,8 +35,8 @@ export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gms;
 export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
 
 const UTF8_FORMATS = ['.css', '.html', '.js', '.map', '.mjs', '.json', '.svg', '.txt', '.xml'];
-export function getEncodingType(ext: string): 'utf-8' | 'binary' {
-  return UTF8_FORMATS.includes(ext) ? 'utf-8' : 'binary';
+export function getEncodingType(ext: string): 'utf-8' | undefined {
+  return UTF8_FORMATS.includes(ext) ? 'utf-8' : undefined;
 }
 
 export async function readLockfile(cwd: string): Promise<ImportMap | null> {


### PR DESCRIPTION
## Changes

Snowpack used `'binary'` as the encoding for binary files, but apparently that’s not what it means! It’s actually [an alias for `latin1`](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) meant for text files. For binary files, there’s no encoding, so nothing should be returned instead. This PR allows Snowpack to work with Buffers (binary files) more directly both in `build` and `dev`.

Credit to @stramel for the find/suggestion!

Hopefully this will fix reported weirdness with binary files, such as https://www.pika.dev/npm/snowpack/discuss/505 and problems with video files @stramel noted.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Binary files work just fine in the build & dev server.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
