### PR TITLE
fix: open tab twice when `openChrome` occurs error

### DIFF
--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -200,17 +200,17 @@ export async function openInBrowser(
       // if Chrome doesn’t respond within 3s, fall back to opening new tab in default browser
       let isChromeStalled = setTimeout(() => {
         openChrome.cancel();
-        console.warn(`Chrome not responding to Snowpack after 3s. Opening dev server in new tab.`);
-        open(url);
       }, 3000);
 
       try {
         await openChrome;
       } catch (err) {
-        if (!err.isCanceled) {
+        if (err.isCanceled) {
+          console.warn(`Chrome not responding to Snowpack after 3s. Opening dev server in new tab.`);
+        } else {
           console.error(err.toString() || err);
-          open(url);
-        }
+        } 
+        open(url);
       } finally {
         clearTimeout(isChromeStalled);
       }

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -206,10 +206,13 @@ export async function openInBrowser(
 
       try {
         await openChrome;
-        clearTimeout(isChromeStalled);
       } catch (err) {
-        console.error(err.toString() || err);
-        open(url);
+        if (!err.isCanceled) {
+          console.error(err.toString() || err);
+          open(url);
+        }
+      } finally {
+        clearTimeout(isChromeStalled);
       }
       return true;
     } catch (err) {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Before modify: the `open(url)` in catch block and the `open(url)` in setTimeout callback will execute  if `openChrome` promise rejected.

After modify: 
1. Only open once by `osascript` if `openChrome` successes.
2. Only `open(url)` in setTimeout callback executes if timeout.
3. Only `open(url)` in catch executes if `openChrome` rejects and is not canceled.

## Testing
no test
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
