### PR TITLE
Change HTML glob pattern to include subdirectories

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -16,7 +16,7 @@ function insertBefore(newNode, existingNode) {
 
 function parseHTMLFiles({ buildDirectory }) {
   // Get all html files from the output folder
-  const pattern = buildDirectory + "/**/*.html";
+  const pattern = buildDirectory + "/**/**.html";
   const htmlFiles = glob
     .sync(pattern)
     .map((htmlPath) => path.relative(buildDirectory, htmlPath));


### PR DESCRIPTION
# Purpose

Currently, the glob pattern for HTML searches 1 level deep for HTML files. If somebody has nested HTML files the `<script>` tags will not be rewritten.

Current glob pattern: `**/*.html`

```bash
build:
    subdir:
      index.html
```

Will not pick up HTML files.


## Changes

With the proposed change:

`**/**.html`

HTML files in subdirectories like above will have their script tags rewritten.

## Testing

I'm making my own custom plugin for snowpack and was using this as a reference and noticed the issue with the glob pattern.

I did not add tests because I simply found it in the repo and wasnt sure if you all felt the change was necessary.
