### PR TITLE
fix no web_modules proxy file

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -290,7 +290,6 @@ export async function command(commandOptions: CommandOptions) {
       process.exit(1);
     }
     const allFiles = glob.sync(`**/*`, {
-      ignore: config.exclude,
       cwd: installDest,
       absolute: true,
       nodir: true,


### PR DESCRIPTION
## Changes
fix https://github.com/pikapkg/snowpack/issues/902.
The `allFiles` is always empty because of [the commit](https://github.com/pikapkg/snowpack/commit/8a3fc8ef3c0828fb7c54ae3a7b3b982f8f97a9b0#diff-217403b4d478514cf9e93c8efcaa48c1R550)
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
adding test later
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
