### PR TITLE
fix: ignore `SNOWPACK_PUBLIC_` env variable when generating `__snowpack__/env.js`

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -235,7 +235,7 @@ export function generateEnvModule(mode: 'development' | 'production') {
   return `export default ${JSON.stringify(envObject)};`;
 }
 
-const PUBLIC_ENV_REGEX = /^SNOWPACK_PUBLIC_/;
+const PUBLIC_ENV_REGEX = /^SNOWPACK_PUBLIC_.+/;
 function getSnowpackPublicEnvVariables() {
   const envObject = {...process.env};
   for (const env of Object.keys(envObject)) {

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -563,7 +563,7 @@ exports[`snowpack build custom-modules-dir: my_modules/import-map.json 1`] = `
 }"
 `;
 
-exports[`snowpack build html-environment-variables: __snowpack__/env.js 1`] = `"export default {\\"SNOWPACK_PUBLIC_BUILD_TIME\\":\\"build-time-replacement-configured-in-package.json\\",\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\"};"`;
+exports[`snowpack build html-environment-variables: __snowpack__/env.js 1`] = `"export default {\\"SNOWPACK_PUBLIC_MY_ENV_VAR\\":\\"my-var-replacement-configured-in-package.json\\",\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\"};"`;
 
 exports[`snowpack build html-environment-variables: allFiles 1`] = `
 Array [
@@ -596,7 +596,7 @@ exports[`snowpack build html-environment-variables: index.html 1`] = `
   lang=\\"en\\"
   data-mode=\\"production\\"
   data-public-url=\\"/\\"
-  data-build-time=\\"build-time-replacement-configured-in-package.json\\"
+  data-my-env-var=\\"my-var-replacement-configured-in-package.json\\"
   data-undefined=\\"%SNOWPACK_PUBLIC_BUILD_UNDEFINED%\\"
 >
   <head>

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -597,6 +597,7 @@ exports[`snowpack build html-environment-variables: index.html 1`] = `
   data-mode=\\"production\\"
   data-public-url=\\"/\\"
   data-my-env-var=\\"my-var-replacement-configured-in-package.json\\"
+  data-edge-case-test=\\"%SNOWPACK_PUBLIC_%\\"
   data-undefined=\\"%SNOWPACK_PUBLIC_BUILD_UNDEFINED%\\"
 >
   <head>

--- a/test/build/html-environment-variables/package.json
+++ b/test/build/html-environment-variables/package.json
@@ -5,7 +5,7 @@
   "description": "This test makes sure that %SNOWPACK_PUBLIC_*% present in src/index.html are replaced correctly and removed if no value is set",
   "scripts": {
     "start": "snowpack dev",
-    "testbuild": "cross-env SNOWPACK_PUBLIC_MY_ENV_VAR='my-var-replacement-configured-in-package.json' snowpack build"
+    "testbuild": "cross-env SNOWPACK_PUBLIC_MY_ENV_VAR='my-var-replacement-configured-in-package.json' SNOWPACK_PUBLIC_='should be ignored' snowpack build"
   },
   "snowpack": {
     "mount": {

--- a/test/build/html-environment-variables/package.json
+++ b/test/build/html-environment-variables/package.json
@@ -5,7 +5,7 @@
   "description": "This test makes sure that %SNOWPACK_PUBLIC_*% present in src/index.html are replaced correctly and removed if no value is set",
   "scripts": {
     "start": "snowpack dev",
-    "testbuild": "cross-env SNOWPACK_PUBLIC_BUILD_TIME='build-time-replacement-configured-in-package.json' snowpack build"
+    "testbuild": "cross-env SNOWPACK_PUBLIC_MY_ENV_VAR='my-var-replacement-configured-in-package.json' snowpack build"
   },
   "snowpack": {
     "mount": {

--- a/test/build/html-environment-variables/package.json
+++ b/test/build/html-environment-variables/package.json
@@ -5,7 +5,7 @@
   "description": "This test makes sure that %SNOWPACK_PUBLIC_*% present in src/index.html are replaced correctly and removed if no value is set",
   "scripts": {
     "start": "snowpack dev",
-    "testbuild": "cross-env SNOWPACK_PUBLIC_MY_ENV_VAR='my-var-replacement-configured-in-package.json' SNOWPACK_PUBLIC_='should be ignored' snowpack build"
+    "testbuild": "cross-env SNOWPACK_PUBLIC_MY_ENV_VAR='my-var-replacement-configured-in-package.json' SNOWPACK_PUBLIC_='ignoreme' snowpack build"
   },
   "snowpack": {
     "mount": {

--- a/test/build/html-environment-variables/public/index.html
+++ b/test/build/html-environment-variables/public/index.html
@@ -4,6 +4,7 @@
   data-mode="%MODE%"
   data-public-url="%PUBLIC_URL%"
   data-my-env-var="%SNOWPACK_PUBLIC_MY_ENV_VAR%"
+  data-edge-case-test="%SNOWPACK_PUBLIC_%"
   data-undefined="%SNOWPACK_PUBLIC_BUILD_UNDEFINED%"
 >
   <head>

--- a/test/build/html-environment-variables/public/index.html
+++ b/test/build/html-environment-variables/public/index.html
@@ -3,7 +3,7 @@
   lang="en"
   data-mode="%MODE%"
   data-public-url="%PUBLIC_URL%"
-  data-build-time="%SNOWPACK_PUBLIC_BUILD_TIME%"
+  data-my-env-var="%SNOWPACK_PUBLIC_MY_ENV_VAR%"
   data-undefined="%SNOWPACK_PUBLIC_BUILD_UNDEFINED%"
 >
   <head>


### PR DESCRIPTION
Follow up to https://github.com/pikapkg/snowpack/pull/900\#discussion_r477058829 /cc @silverwind @FredKSchott