### PR TITLE
Update title for featured community packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For starter apps and templates, see [create-snowpack-app](./create-snowpack-app)
 - [@snowpack/plugin-build-script](./plugins/plugin-build-script)
 - [@snowpack/plugin-run-script](./plugins/plugin-run-script)
 
-### Featured Community Plugins
+## Featured Community Packages
 
 - [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
 - [snowpack-plugin-imagemin](https://github.com/jaredLunde/snowpack-plugin-imagemin) Use [imagemin](https://github.com/imagemin/imagemin) to optimize your build images.


### PR DESCRIPTION
## Changes

- change title since I think not all featured community packages will strictly be plugins, my demo with Vue & CapacitorJS (see #905) would be an example
- change to H2 (`##`), since I think it does not belong as part of the list of official plugins

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
