### PR TITLE
add demo with Vue & Capacitor v2 mobile framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ For starter apps and templates, see [create-snowpack-app](./create-snowpack-app)
 - [snowpack-plugin-svgr](https://github.com/jaredLunde/snowpack-plugin-svgr) Use [SVGR](https://github.com/gregberge/svgr) to transform `.svg` files into React components.
 - [snowpack-plugin-stylus](https://github.com/fansenze/snowpack-plugin-stylus) Use the [Stylus](https://github.com/stylus/stylus) compiler to build `.styl` files from source.
 - [snowpack-plugin-inliner](https://github.com/fansenze/snowpack-plugin-inliner) A plugin for snowpack which transforms files into base64 URIs.
+- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template
 - PRs that add a link to this list are welcome!

--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ For starter apps and templates, see [create-snowpack-app](./create-snowpack-app)
 - [snowpack-plugin-svgr](https://github.com/jaredLunde/snowpack-plugin-svgr) Use [SVGR](https://github.com/gregberge/svgr) to transform `.svg` files into React components.
 - [snowpack-plugin-stylus](https://github.com/fansenze/snowpack-plugin-stylus) Use the [Stylus](https://github.com/stylus/stylus) compiler to build `.styl` files from source.
 - [snowpack-plugin-inliner](https://github.com/fansenze/snowpack-plugin-inliner) A plugin for snowpack which transforms files into base64 URIs.
-- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template
+- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/pikapkg/snowpack/discussions/905)
 - PRs that add a link to this list are welcome!

--- a/README.md
+++ b/README.md
@@ -73,5 +73,4 @@ For starter apps and templates, see [create-snowpack-app](./create-snowpack-app)
 - [snowpack-plugin-svgr](https://github.com/jaredLunde/snowpack-plugin-svgr) Use [SVGR](https://github.com/gregberge/svgr) to transform `.svg` files into React components.
 - [snowpack-plugin-stylus](https://github.com/fansenze/snowpack-plugin-stylus) Use the [Stylus](https://github.com/stylus/stylus) compiler to build `.styl` files from source.
 - [snowpack-plugin-inliner](https://github.com/fansenze/snowpack-plugin-inliner) A plugin for snowpack which transforms files into base64 URIs.
-- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/pikapkg/snowpack/discussions/905)
 - PRs that add a link to this list are welcome!

--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -27,4 +27,5 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
 - [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
 - [hyperapp-snowpack](https://github.com/bmartel/hyperapp-snowpack) (Hyperapp + Snowpack + TailwindCSS)
+- [snowpack-vue-capacitor-2-demo](https://github.com/brodybits/snowpack-vue-capacitor-2-demo) Demo of Snowpack with Vue and [Capacitor mobile app framework](https://capacitorjs.com/) version 2, originally generated from `@snowpack/vue-template` template, see [discussion #905](https://github.com/pikapkg/snowpack/discussions/905)
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes

add https://github.com/brodybits/snowpack-vue-capacitor-2-demo - demo with Vue & [Capacitor](https://capacitorjs.com/) (v2) mobile framework, as discussed in #905

Note that multiple workarounds were needed to work on Android, and hot reload is not yet working. Further discussion should probably be in #905.

I think the title of the list needs to be updated, as I proposed in PR #925.

## Testing

Tested with Capacitor on Android & iOS

---

P.S. I am making this demo specific to Capacitor v2 since a large number of artifacts are needed to build on Android & iOS, and they would probably need to be regenerated when upgrading to upcoming Capacitor release 3. I hope to get this process improved in the future.