### PR TITLE
Fix community plugins header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ When you're ready to deploy your web application to users, you can add back a tr
 
 ## Create Snowpack App (CSA)
 
-### Starter Templates
-
 For starter apps and templates, see [create-snowpack-app](./create-snowpack-app).
 
 ## Official Snowpack Plugins

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ When you're ready to deploy your web application to users, you can add back a tr
 
 ## Create Snowpack App (CSA)
 
+### Starter Templates
+
 For starter apps and templates, see [create-snowpack-app](./create-snowpack-app).
 
 ## Official Snowpack Plugins
@@ -61,7 +63,7 @@ For starter apps and templates, see [create-snowpack-app](./create-snowpack-app)
 - [@snowpack/plugin-build-script](./plugins/plugin-build-script)
 - [@snowpack/plugin-run-script](./plugins/plugin-run-script)
 
-### Featured Community Plugins
+## Featured Community Plugins
 
 - [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
 - [snowpack-plugin-imagemin](https://github.com/jaredLunde/snowpack-plugin-imagemin) Use [imagemin](https://github.com/imagemin/imagemin) to optimize your build images.


### PR DESCRIPTION
## Changes

- add explicit header before link to the starter list in the CLI package, which I missed when raising PRs #925 & #926
- change the community plugins header to H2 (`##`) since I think it should not be a subsection of "official" plugins - similar to closed PR #925

## Testing

Preview of Markdown on GitHub

## Other

I will completely understand if this is not the right way. I was hoping to solve a couple problems:

- It was evidently not obvious enough to me that I had to go to another page to see the list of starter apps & templates.
- I think the community list of plugins are not "officially" supported by pikapkg.