### PR TITLE
fix: wrong proxy path of package assets

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -310,7 +310,7 @@ export async function command(commandOptions: CommandOptions) {
       ) {
         const proxiedCode = await fs.readFile(installedFileLoc, {encoding: 'utf-8'});
         const importProxyFileLoc = installedFileLoc + '.proxy.js';
-        const proxiedUrl = installedFileLoc.substr(installDest.length).replace(/\\/g, '/');
+        const proxiedUrl = installedFileLoc.substr(buildDirectoryLoc.length).replace(/\\/g, '/');
         const proxyCode = await wrapImportProxy({
           url: proxiedUrl,
           code: proxiedCode,

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -3921,7 +3921,9 @@ console.log(
 // Importing something that isn't JS
 import styles from './components/style.css.proxy.js'; // relative import
 import styles_ from './components/style.css.proxy.js'; // relative import
-console.log(styles, styles_);"
+console.log(styles, styles_);
+import adSvg from '../TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js';
+console.log(adSvg);"
 `;
 
 exports[`snowpack build resolve-imports: _dist_/sort.js 1`] = `"export default (arr) => arr.sort();"`;
@@ -3930,6 +3932,8 @@ exports[`snowpack build resolve-imports: _dist_/test-mjs.js 1`] = `
 "import {flatten} from \\"../TEST_WMU/array-flatten.js\\";
 console.log(flatten);"
 `;
+
+exports[`snowpack build resolve-imports: TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js 1`] = `"export default \\"/TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg\\";"`;
 
 exports[`snowpack build resolve-imports: TEST_WMU/array-flatten.js 1`] = `
 "/**
@@ -3960,6 +3964,7 @@ export { flatten };"
 exports[`snowpack build resolve-imports: TEST_WMU/import-map.json 1`] = `
 "{
   \\"imports\\": {
+    \\"@fortawesome/fontawesome-free/svgs/solid/ad.svg\\": \\"./@fortawesome/fontawesome-free/svgs/solid/ad.svg\\",
     \\"aliased-dep\\": \\"./array-flatten.js\\",
     \\"array-flatten\\": \\"./array-flatten.js\\"
   }
@@ -3976,6 +3981,8 @@ Array [
   "_dist_/index.js",
   "_dist_/sort.js",
   "_dist_/test-mjs.js",
+  "TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg",
+  "TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg.proxy.js",
   "TEST_WMU/array-flatten.js",
   "TEST_WMU/import-map.json",
 ]

--- a/test/build/resolve-imports/package.json
+++ b/test/build/resolve-imports/package.json
@@ -26,6 +26,7 @@
     }
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "array-flatten": "^3.0.0",
     "snowpack": "^2.7.0"
   }

--- a/test/build/resolve-imports/src/index.js
+++ b/test/build/resolve-imports/src/index.js
@@ -34,3 +34,6 @@ console.log(
 import styles from './components/style.css'; // relative import
 import styles_ from '@app/components/style.css'; // relative import
 console.log(styles, styles_);
+
+import adSvg from '@fortawesome/fontawesome-free/svgs/solid/ad.svg';
+console.log(adSvg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fortawesome/fontawesome-free@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
+  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
+
 "@iarna/toml@^2.2.0":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
From [test example](https://github.com/MoonBall/snowpack/blob/fix/wrong-proxy-path-of-package-assets/test/build/resolve-imports/src/index.js#L38), the directory structure of build output is as below.
```
├── TEST_WMU
│   ├── @fortawesome
│   │   └── fontawesome-free
│   │       └── svgs
│   │           └── solid
│   │               ├── ad.svg
│   │               └── ad.svg.proxy.js
│   ├── array-flatten.js
│   └── import-map.json
├── __snowpack__
│   └── env.js
└── _dist_
    ├── components
    │   ├── index.js
    │   ├── style.css
    │   └── style.css.proxy.js
    ├── index.html
    ├── index.js
    ├── sort.js
    └── test-mjs.js
```

the content of ad.svg.proxy.js is `export default "@fortawesome/fontawesome-free/svgs/solid/ad.svg";` before this pr modification.

the content of ad.svg.proxy.js is `export default "/TEST_WMU/@fortawesome/fontawesome-free/svgs/solid/ad.svg";` after this pr modification.


## Testing

Test added.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
