### PR TITLE
feat(csa): add `--no-install` option

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -1,7 +1,7 @@
 # Create Snowpack App (CSA)
 
 ```
-npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm]
+npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm | --no-install]
 ```
 
 ## Official App Templates

--- a/create-snowpack-app/cli/createSnowpackApp.js
+++ b/create-snowpack-app/cli/createSnowpackApp.js
@@ -24,7 +24,7 @@ function hasPmInstalled(packageManager) {
 
 function validateArgs(args) {
   const {template, useYarn, usePnpm, force, target, install, _} = yargs(args);
-  const toInstall = install == null || install && install !== 'false';
+  const toInstall = install !== undefined ? install : true;
   if (useYarn && usePnpm) {
     logError('You can not use Yarn and pnpm at the same time.');
   }

--- a/create-snowpack-app/cli/createSnowpackApp.js
+++ b/create-snowpack-app/cli/createSnowpackApp.js
@@ -23,7 +23,8 @@ function hasPmInstalled(packageManager) {
 }
 
 function validateArgs(args) {
-  const {template, useYarn, usePnpm, force, target, _} = yargs(args);
+  const {template, useYarn, usePnpm, force, target, install, _} = yargs(args);
+  const toInstall = install == null || install && install !== 'false';
   if (useYarn && usePnpm) {
     logError('You can not use Yarn and pnpm at the same time.');
   }
@@ -53,6 +54,7 @@ function validateArgs(args) {
     usePnpm,
     targetDirectoryRelative,
     targetDirectory,
+    toInstall,
   };
 }
 
@@ -116,7 +118,7 @@ async function cleanProject(dir) {
   );
 }
 
-const {template, useYarn, usePnpm, targetDirectoryRelative, targetDirectory} = validateArgs(
+const {template, useYarn, usePnpm, toInstall, targetDirectoryRelative, targetDirectory} = validateArgs(
   process.argv,
 );
 
@@ -156,29 +158,34 @@ const installedTemplate = isLocalTemplate
   await copy(installedTemplate, targetDirectory);
   await cleanProject(targetDirectory);
 
-  console.log(`  - Installing package dependencies. This might take a couple of minutes.\n`);
-  const npmInstallOptions = {
-    cwd: targetDirectory,
-    stdio: 'inherit',
-  };
+  if (toInstall) {
+    console.log(`  - Installing package dependencies. This might take a couple of minutes.\n`);
 
-  function installProcess(packageManager) {
-    switch (packageManager) {
-      case 'npm':
-        return execa('npm', ['install', '--loglevel', 'error'], npmInstallOptions);
-      case 'yarn':
-        return execa('yarn', ['--silent'], npmInstallOptions);
-      case 'pnpm':
-        return execa('pnpm', ['install', '--reporter=silent'], npmInstallOptions);
-      default:
-        throw new Error('Unspecified package installer.');
+    const npmInstallOptions = {
+      cwd: targetDirectory,
+      stdio: 'inherit',
+    };
+
+    function installProcess(packageManager) {
+      switch (packageManager) {
+        case 'npm':
+          return execa('npm', ['install', '--loglevel', 'error'], npmInstallOptions);
+        case 'yarn':
+          return execa('yarn', ['--silent'], npmInstallOptions);
+        case 'pnpm':
+          return execa('pnpm', ['install', '--reporter=silent'], npmInstallOptions);
+        default:
+          throw new Error('Unspecified package installer.');
+      }
     }
-  }
 
-  const npmInstallProcess = installProcess(installer);
-  npmInstallProcess.stdout && npmInstallProcess.stdout.pipe(process.stdout);
-  npmInstallProcess.stderr && npmInstallProcess.stderr.pipe(process.stderr);
-  await npmInstallProcess;
+    const npmInstallProcess = installProcess(installer);
+    npmInstallProcess.stdout && npmInstallProcess.stdout.pipe(process.stdout);
+    npmInstallProcess.stderr && npmInstallProcess.stderr.pipe(process.stderr);
+    await npmInstallProcess;
+  } else {
+    console.log(`  - Skipping "${installer} install" step\n`);
+  }
 
   console.log(`\n  - Initializing git repo.\n`);
   try {
@@ -207,7 +214,11 @@ const installedTemplate = isLocalTemplate
   console.log(
     formatCommand(
       `${installer} install`,
-      'Install your dependencies. (We already ran this one for you!)',
+      `Install your dependencies. ${
+        toInstall
+        ? '(We already ran this one for you!)'
+        : '(You asked us to skip this step!)'
+      }`
     ),
   );
   console.log(formatCommand(`${installer} start`, 'Start your development server.'));

--- a/test/create-snowpack-app/create-snowpack-app.test.js
+++ b/test/create-snowpack-app/create-snowpack-app.test.js
@@ -38,6 +38,41 @@ describe('create-snowpack-app', () => {
     // install, since it’s added at the end.
     const snowpackConfigExists = fs.existsSync(path.join(installDir, 'snowpack.config.json'));
     expect(snowpackConfigExists).toBe(true);
+
+    // install node_modules by default
+    const modulesExist = fs.existsSync(path.join(installDir, 'node_modules'));
+    expect(modulesExist).toBe(true);
+  });
+
+  // test `--no-install` option
+  it('npx create-snowpack-app --no-install', () => {
+    const template = 'app-template-preact'; // any template will do
+    const installDir = path.resolve(__dirname, 'test-install');
+
+    rimraf.sync(installDir);
+
+    // run the local create-snowpack-app bin
+    execa.sync(
+      'node',
+      [
+        './create-snowpack-app/cli',
+        `./test/create-snowpack-app/test-install`,
+        '--template',
+        `./create-snowpack-app/${template}`,
+        '--use-yarn', // we use Yarn for this repo
+        '--no-install'
+      ],
+      {cwd: path.resolve(__dirname, '..', '..')},
+    );
+
+    // snowpack.config.json is a file we can test for to assume successful
+    // install, since it’s added at the end.
+    const snowpackConfigExists = fs.existsSync(path.join(installDir, 'snowpack.config.json'));
+    expect(snowpackConfigExists).toBe(true);
+
+    // install node_modules by default
+    const modulesExist = fs.existsSync(path.join(installDir, 'node_modules'));
+    expect(modulesExist).toBe(false);
   });
 
   // template snapshots


### PR DESCRIPTION
## Changes

Adds `--no-install` flag to `create-snowpack-app` tool.

## Purpose

I'm using `volta` + `pnpm` and (currently) any `node` process can't lookup `volta-shim`'d binaries correctly (https://github.com/volta-cli/volta/issues/615#issuecomment-682206052). In other words, `--use-pnpm` failed since `execa/which` does not think the `pnpm` binary exists, even though it's there.

So I'd rather skip installation and run `pnpm install` myself. Plus, as seen with PreactCLI, PWA/CLI, etc, sometimes you just want to setup an empty scaffold without the intention of running it.

## Testing

* Modified existing test to ensure that packages are still installed by default
* Cloned existing test, but added `--no-install` to ensure installation was skipped
