### PR TITLE
fix(snowpack): exit process after success

### DIFF
--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -91,11 +91,11 @@ export async function cli(args: string[]) {
 
   if (cmd === 'add') {
     await addCommand(cliFlags['_'][3], commandOptions);
-    return;
+    return process.exit(0);
   }
   if (cmd === 'rm') {
     await rmCommand(cliFlags['_'][3], commandOptions);
-    return;
+    return process.exit(0);
   }
 
   if (cliFlags['_'].length > 3) {
@@ -105,15 +105,15 @@ export async function cli(args: string[]) {
 
   if (cmd === 'build') {
     await buildCommand(commandOptions);
-    return;
+    return process.exit(0);
   }
   if (cmd === 'dev') {
     await devCommand(commandOptions);
-    return;
+    return process.exit(0);
   }
   if (cmd === 'install' || !cmd) {
     await installCommand(commandOptions);
-    return;
+    return process.exit(0);
   }
 
   logger.error(`Unrecognized command: ${cmd}`);


### PR DESCRIPTION
## Changes

Ensures that the primary node process is exited, which cleans up any associated child processes spawned by it. Without this, `build` (specifically) can hang indefinitely even though it was successful and Snowpack knows it's complete.

## Screenshots

There's some additional logging in here -- remnants of my hunt to make sure it wasn't a fault of Snowpack elsewhere. For example, the `stopping` is at the cleanup stage of the esbuild plugin.

***Before***

> Snowpack prints "Build Complete" but the process never closes.

<img width="441" alt="Screen Shot 2020-08-28 at 11 23 17 AM" src="https://user-images.githubusercontent.com/5855893/91603087-345e2880-e921-11ea-8067-7d244b5f830e.png">

***After***

> The process exits successfully

<img width="353" alt="Screen Shot 2020-08-28 at 11 25 30 AM" src="https://user-images.githubusercontent.com/5855893/91603102-4049ea80-e921-11ea-868b-6b94b54f7638.png">

## Testing

Did not add tests since nothing should be altered by default. The `return` already implied a `0` exit code, preventing the final `process.exit(1)` from running. By adding `process.exit(0)` we're basically just redefining the defaults.