### PR TITLE
Ignore buildOptions.baseUrl configuration for %BASE_URL% replacement in dev server

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -46,16 +46,18 @@ export function wrapImportMeta({
 export function wrapHtmlResponse({
   code,
   hmr,
+  isDev,
   config,
   mode,
 }: {
   code: string;
   hmr: boolean;
+  isDev: boolean;
   config: SnowpackConfig;
   mode: 'development' | 'production';
 }) {
   // replace %PUBLIC_URL% (along with surrounding slashes, if any)
-  code = code.replace(/\/?%PUBLIC_URL%\/?/g, config.buildOptions.baseUrl);
+  code = code.replace(/\/?%PUBLIC_URL%\/?/g, isDev ? '/' : config.buildOptions.baseUrl);
 
   // replace %MODE%
   code = code.replace(/%MODE%/g, mode);

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -134,6 +134,7 @@ class FileBuilder {
             code = wrapHtmlResponse({
               code,
               hmr: false,
+              isDev: false,
               config: this.config,
               mode: 'production',
             });

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -499,7 +499,13 @@ export async function command(commandOptions: CommandOptions) {
     ) {
       // transform special requests
       if (isRoute) {
-        code = wrapHtmlResponse({code: code as string, hmr: isHmr, config, mode: 'development'});
+        code = wrapHtmlResponse({
+          code: code as string,
+          hmr: isHmr,
+          isDev: true,
+          config,
+          mode: 'development',
+        });
       } else if (isProxyModule) {
         responseFileExt = '.js';
       } else if (isSourceMap && sourceMap) {


### PR DESCRIPTION
## Changes

- During dev, we want to host the entire app on our dev server at `/`
- This fixes the bug reported here: https://github.com/pikapkg/snowpack/discussions/848#discussioncomment-58728

## Testing

- No dev tests.
