### PR TITLE
Added CSS modules configuration for webpack plugin

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -240,12 +240,27 @@ module.exports = function plugin(config, args) {
             },
             {
               test: /\.css$/,
+              exclude: /\.module\.css$/,
               use: [
                 {
                   loader: MiniCssExtractPlugin.loader,
                 },
                 {
                   loader: "css-loader",
+                },
+              ],
+            },
+            {
+              test: /\.module\.css$/,
+              use: [
+                {
+                  loader: MiniCssExtractPlugin.loader,
+                },
+                {
+                  loader: "css-loader",
+                  options: {
+                    modules: true
+                  }
                 },
               ],
             },


### PR DESCRIPTION
## Changes

Fixes issue #963 by adding separate rule to webpack config for CSS modules.

> CSS modules work in development, but not when built with webpack plugin.
> 
> Repro repository: https://github.com/toneb/snowpack-webpack-bug
> 
> Repro code:
> ![image](https://user-images.githubusercontent.com/616279/91636174-e6b7ed80-e9fe-11ea-9e0f-efa5a1fbff45.png)
> 
> Result in development:
> ![image](https://user-images.githubusercontent.com/616279/91636181-fb948100-e9fe-11ea-8e43-8b9cc75dfe26.png)
> 
> Result in release:
> ![image](https://user-images.githubusercontent.com/616279/91636194-0a7b3380-e9ff-11ea-8732-bfdab386ca1b.png)




## Testing

Copied the modified webpack plugin to repro repository, and manually tested in dev/build. Repro repository, with modified plugin: https://github.com/toneb/snowpack-webpack-bug/commit/3bc1cb23d886ccf7b4210eed71ae5d3f90d1ccc3