### PR TITLE
Add cjs config support

### DIFF
--- a/docs/docs/05-configuration.md
+++ b/docs/docs/05-configuration.md
@@ -8,6 +8,7 @@ Snowpack supports configuration files in multiple formats, sorted by priority or
 
 1. `--config [path]`: If provided.
 1. `package.json`: A namespaced config object (`"snowpack": {...}`).
+1. `snowpack.config.cjs`: (`module.exports = {...}`) for projects using `"type": "module"`.
 1. `snowpack.config.js`: (`module.exports = {...}`).
 1. `snowpack.config.json`: (`{...}`).
 

--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -63,7 +63,7 @@
     "cachedir": "^2.3.0",
     "chokidar": "^3.4.0",
     "compressible": "^2.0.18",
-    "cosmiconfig": "^6.0.0",
+    "cosmiconfig": "^7.0.0",
     "css-modules-loader-core": "^1.1.0",
     "deepmerge": "^4.2.2",
     "detect-port": "^1.3.0",

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -761,8 +761,8 @@ export function createConfiguration(
 
 export function loadAndValidateConfig(flags: CLIFlags, pkgManifest: any): SnowpackConfig {
   const explorerSync = cosmiconfigSync(CONFIG_NAME, {
-    // only support these 3 types of config for now
-    searchPlaces: ['package.json', 'snowpack.config.js', 'snowpack.config.json'],
+    // only support these 4 types of config for now
+    searchPlaces: ['package.json', 'snowpack.config.cjs', 'snowpack.config.js', 'snowpack.config.json'],
     // don't support crawling up the folder tree:
     stopDir: path.dirname(process.cwd()),
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5255,6 +5255,17 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -7628,7 +7639,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.1.0:
+import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -15049,7 +15060,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
## Changes

This PR adds support for using `snowpack.config.cjs` in addition to all of the existing config formats. This was a blocker for me when trying to use snowpack in a project that had `"type": "module"` specified.

Turns out all that was required was upgrading `cosmiconfig` to v7 and 1 line of code change. 

One important consideration is that cosmiconfig v7 drops support for node 8, now requiring node 10+: https://github.com/davidtheclark/cosmiconfig/blob/master/CHANGELOG.md#700. Looks like snowpack already requires node version `>=10.19.0` in `engines`, so I imagine this might not need to be considered a breaking change, but calling it out just in case we might want to save this for a major version for whatever reason.

I've also updated the appropriate section in the docs to include the new format. Let me know if there's any other changes you'd like to see.

## Testing

I tested this manually by building locally and copy pasting the build to the project with `snowpack.config.cjs` config, and then manually bumping the version of cosmiconfig in that project. Seems to be working great.

Since this functionality is almost entirely handled by cosmiconfig, I didn't feel a new test here would add much value, but happy to add one if folks disagree.
