### PR TITLE
fixing unescaped code block in Troubleshooting section

### DIFF
--- a/docs/docs/09-troubleshooting.md
+++ b/docs/docs/09-troubleshooting.md
@@ -29,4 +29,5 @@ Snowpack follow's Node.js's CJS-ESM interoperability strategy, where Common.js p
     "namedExports": ["someModule"]
   }
 }
+```
 


### PR DESCRIPTION
## Changes

The final code block in the Troubleshooting section was not escaped which meant the Assets section was rendered in the block

## Testing

I didn't see any docs-related tests