### PR TITLE
Fix build watch errors, including v2.10.0 regression

### DIFF
--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -8,6 +8,7 @@ import {getEncodingType, getExt, replaceExt} from '../util';
 export interface BuildFileOptions {
   isDev: boolean;
   isHmrEnabled: boolean;
+  isExitOnBuild: boolean;
   plugins: SnowpackPlugin[];
   sourceMaps: boolean;
 }
@@ -38,7 +39,7 @@ export function getInputsFromOutput(fileLoc: string, plugins: SnowpackPlugin[]) 
  */
 async function runPipelineLoadStep(
   srcPath: string,
-  {isDev, isHmrEnabled, plugins, sourceMaps}: BuildFileOptions,
+  {isDev, isHmrEnabled, isExitOnBuild, plugins, sourceMaps}: BuildFileOptions,
 ): Promise<SnowpackBuildMap> {
   const srcExt = getExt(srcPath).baseExt;
   for (const step of plugins) {
@@ -88,7 +89,9 @@ async function runPipelineLoadStep(
     } catch (err) {
       // note: for many plugins like Babel, `err.toString()` is needed to display full output
       logger.error(err.toString() || err, {name: step.name});
-      if (!isDev) process.exit(1); // exit in build
+      if (isExitOnBuild) {
+        process.exit(1);
+      }
     }
   }
 
@@ -109,7 +112,7 @@ async function runPipelineLoadStep(
 async function runPipelineTransformStep(
   output: SnowpackBuildMap,
   srcPath: string,
-  {isDev, plugins, sourceMaps}: BuildFileOptions,
+  {isDev, isExitOnBuild, plugins, sourceMaps}: BuildFileOptions,
 ): Promise<SnowpackBuildMap> {
   const srcExt = getExt(srcPath).baseExt;
   const rootFilePath = srcPath.replace(srcExt, '');
@@ -153,7 +156,9 @@ async function runPipelineTransformStep(
     } catch (err) {
       // note: for many plugins like Babel, `err.toString()` is needed to display full output
       logger.error(err.toString() || err, {name: step.name});
-      if (!isDev) process.exit(1); // exit in build
+      if (isExitOnBuild) {
+        process.exit(1);
+      }
     }
   }
 

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -468,6 +468,7 @@ export async function command(commandOptions: CommandOptions) {
         const builtFileOutput = await _buildFile(fileLoc, {
           plugins: config.plugins,
           isDev: true,
+          isExitOnBuild: false,
           isHmrEnabled: isHmr,
           sourceMaps: config.buildOptions.sourceMaps,
         });


### PR DESCRIPTION
- Resolves #975 

## Changes

- Fix issue where any build --watch error killed the watcher
- Fix issue where broken `run` scripts wouldn't break the build
- Fix 2.10.0 regression where build --watch exited instead of watching

## Testing

- Tested manually (like dev, no testing for `build --watch`)