### PR TITLE
add manifest to webpack plugin

### DIFF
--- a/plugins/plugin-webpack/README.md
+++ b/plugins/plugin-webpack/README.md
@@ -26,6 +26,7 @@ npm install --save-dev @snowpack/plugin-webpack
 - `sourceMap: boolean` - Enable sourcemaps in the bundled output.
 - `outputPattern: {css: string, js: string, assets: string}` - Set the URL for your final bundled files. This is where they will be written to disk in the `build/` directory. See Webpack's [`output.filename`](https://webpack.js.org/configuration/output/#outputfilename) documentation for examples of valid values.
 - `extendConfig: (config: WebpackConfig) => WebpackConfig` - extend your webpack config, see below.
+- `manifest: boolean | string` - Enable generating a manifest file. The default value is `false`, the default file name is `./asset-manifest.json` if setting manifest to `true`. The relative path is resolved from the output directory.
 
 #### Extending The Default Webpack Config
 

--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -17,6 +17,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "terser-webpack-plugin": "^3.0.1",
-    "webpack": "^4.43.0"
+    "webpack": "^4.43.0",
+    "webpack-manifest-plugin": "^2.2.0"
   }
 }

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -6,6 +6,7 @@ const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const ManifestPlugin = require('webpack-manifest-plugin');
 const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 const cwd = process.cwd();
@@ -157,6 +158,8 @@ module.exports = function plugin(config, args) {
   if (!cssOutputPattern.endsWith(".css")) {
     throw new Error("Output Pattern for CSS must end in .css");
   }
+  const manifest = !args.manifest ? false :
+    args.manifest === true ? './asset-manifest.json' : `${args.manifest}`;
 
   // Webpack handles minification for us, so its safe to always
   // disable Snowpack's default minifier.
@@ -288,19 +291,24 @@ module.exports = function plugin(config, args) {
           splitChunks: getSplitChunksConfig({ numEntries: jsEntries.length }),
           minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
         },
-        plugins: [
-          //Extract a css file from imported css files
-          new MiniCssExtractPlugin({
-            filename: cssOutputPattern,
-          }),
-        ],
       };
+      const plugins = [	
+        //Extract a css file from imported css files	
+        new MiniCssExtractPlugin({	
+          filename: cssOutputPattern,	
+        }),	
+      ];
+      if (manifest) {
+        plugins.push(new ManifestPlugin({ fileName: manifest }))
+      }
+
       let entry = {};
       for (name in jsEntries) {
         entry[name] = jsEntries[name].path;
       }
       const extendedConfig = extendConfig({
         ...webpackConfig,
+        plugins,
         entry,
         output: {
           path: buildDirectory,

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -158,8 +158,13 @@ module.exports = function plugin(config, args) {
   if (!cssOutputPattern.endsWith(".css")) {
     throw new Error("Output Pattern for CSS must end in .css");
   }
-  const manifest = !args.manifest ? false :
-    args.manifest === true ? './asset-manifest.json' : `${args.manifest}`;
+  
+  const manifest =
+    typeof args.manifest === string
+      ? args.manifest
+      : !!args.manifest
+      ? './asset-manifest.json'
+      : undefined;
 
   // Webpack handles minification for us, so its safe to always
   // disable Snowpack's default minifier.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6873,6 +6873,15 @@ fs-extra@3.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -9371,7 +9380,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -10486,6 +10495,15 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.entries@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
+  integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    has "^1.0.3"
 
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
   version "2.1.0"
@@ -14737,6 +14755,16 @@ webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+
+webpack-manifest-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16"
+  integrity sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    object.entries "^1.1.0"
+    tapable "^1.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
solve the issue https://github.com/pikapkg/snowpack/issues/955.
I test it in a new `@snowpack/app-template-react` project by using `npm link`. And then the generating manifest is as below.
```
{
  "commons.js": "/js/commons.95f23ff96f7c2c05e3da.js",
  "index.js": "/js/index.c6bd3571682a9fa98854.js",
  "lib-0db4f475.js": "/js/lib-0db4f475.170551a15456bfb13a44.js",
  "webpack-runtime.js": "/js/webpack-runtime.164e3a9d86a338adba9d.js",
  "assets/logo-d264c5adf9650c78ea3f951b10fb965a.svg": "/assets/logo-d264c5adf9650c78ea3f951b10fb965a.svg",
  "js/commons.95f23ff96f7c2c05e3da.js.LICENSE.txt": "/js/commons.95f23ff96f7c2c05e3da.js.LICENSE.txt"
}
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
