### PR TITLE
markdown cat now runs inside BEFOREWATCH event in docs

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -77,8 +77,9 @@ module.exports = function (eleventyConfig) {
   //   }
   // });
 
+
   eleventyConfig.on('beforeWatch', () => {
-    child_process.execSync('cat docs/* > index.md').toString('UTF-8')
+    child_process.execSync('cat docs/* > index.md', { encoding: 'utf8'} )
   });
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(pluginTOC, {

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const pluginTOC = require('eleventy-plugin-nesting-toc');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
+const child_process = require('child_process');
 
 const { DateTime } = require("luxon");
 // const pluginRss = require("@11ty/eleventy-plugin-rss");
@@ -76,6 +77,9 @@ module.exports = function (eleventyConfig) {
   //   }
   // });
 
+  eleventyConfig.on('beforeWatch', () => {
+    child_process.execSync('cat docs/* > index.md').toString('UTF-8')
+  });
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(pluginTOC, {
     tags: ['h2', 'h3'],

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.0",
   "scripts": {
     "docs:build": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js",
-    "docs:watch": "npx @11ty/eleventy --config .eleventy.js --serve"
+    "docs:watch": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js --serve"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.0",
   "scripts": {
     "docs:build": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js",
-    "docs:watch": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js --serve"
+    "docs:watch": "npx @11ty/eleventy --config .eleventy.js --serve"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",


### PR DESCRIPTION
## Changes

One of the steps to building the docs was `cat docs/* > index.md` which ran outside the watcher. Because of that if you changed anything in docs, it didn't show up because that ran only when you did the initial `docs:watch`.

I made it so that `cat docs/* > index.md` runs at the BEFOREWATCH event. It's a little awkward though (the implementation of running the command in the eleventy config file and the fact it triggers another watcher build) not sure how useful it is.

## Testing

There are no tests in the docs section. 