### PR TITLE
fix outdated test conflicts

### DIFF
--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -22,7 +22,11 @@ describe('snowpack build', () => {
     }
 
     it(testName, () => {
-      let cwd = path.join(__dirname, testName);
+      const cwd = path.join(__dirname, testName);
+      if (!existsSync(path.join(cwd, 'package.json'))) {
+        console.error(testName, 'no longer exists, skipping...');
+        return;
+      }
 
       // build test
       execa.sync('yarn', ['testbuild'], {cwd});

--- a/test/integration/install.test.js
+++ b/test/integration/install.test.js
@@ -67,9 +67,15 @@ describe('snowpack install', () => {
         removeLockfile(testName);
       }
 
+      const cwd = path.join(__dirname, testName);
+      if (!existsSync(path.join(cwd, 'package.json'))) {
+        console.error(testName, 'no longer exists, skipping...');
+        return;
+      }
+
       // Run Test
       const {all} = await execa('yarn', ['--silent', 'run', 'testinstall'], {
-        cwd: path.join(__dirname, testName),
+        cwd,
         reject: false,
         all: true,
       });
@@ -126,7 +132,7 @@ describe('snowpack install', () => {
         throw new Error('Empty build directory!');
       }
 
-      expect(allFiles.map(f => f.replace(/\\/g, '/'))).toMatchSnapshot('allFiles');
+      expect(allFiles.map((f) => f.replace(/\\/g, '/'))).toMatchSnapshot('allFiles');
 
       // If any diffs are detected, we'll assert the difference so that we get nice output.
       for (const entry of allFiles) {


### PR DESCRIPTION
## Changes

- Fixed an issue affecting https://github.com/pikapkg/snowpack/pull/976
- When a test is renamed/removed, our .gitignore'd files hang around, causing broken tests until they're cleaned out manually
- Now, we'll ignore these with an error console log telling you to cleanup whenever you can

## Testing

- N/A