### PR TITLE
Remove the process polyfill's dependency on window, so it can run in web workers.

### DIFF
--- a/snowpack/src/rollup-plugins/generateProcessPolyfill.ts
+++ b/snowpack/src/rollup-plugins/generateProcessPolyfill.ts
@@ -23,6 +23,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/*
+THIS IS A MODIFIED VERSION OF https://github.com/calvinmetcalf/node-process-es6
+ORIGIANL ADDED IN COMMIT 6304406e065f356aeaa623a878d02be419b316d8 (good to know for diffing) 
+*/
+
+
 export function generateProcessPolyfill(env) {
   return `/* SNOWPACK PROCESS POLYFILL (based on https://github.com/calvinmetcalf/node-process-es6) */
 function defaultSetTimout() {

--- a/snowpack/src/rollup-plugins/generateProcessPolyfill.ts
+++ b/snowpack/src/rollup-plugins/generateProcessPolyfill.ts
@@ -33,10 +33,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 
@@ -185,7 +193,7 @@ function chdir (dir) {
 }function umask() { return 0; }
 
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -601,10 +601,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -738,7 +746,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -9512,10 +9512,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -9649,7 +9657,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance$1 = window.performance || {};
+var performance$1 = globalContext.performance || {};
 var performanceNow =
   performance$1.now        ||
   performance$1.mozNow     ||

--- a/test/integration/__snapshots__/install.test.js.snap
+++ b/test/integration/__snapshots__/install.test.js.snap
@@ -6392,10 +6392,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -6529,7 +6537,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||
@@ -11182,10 +11190,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -11319,7 +11335,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||
@@ -90551,10 +90567,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -90688,7 +90712,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||
@@ -95209,10 +95233,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -95346,7 +95378,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||
@@ -99866,10 +99898,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -100003,7 +100043,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||
@@ -104526,10 +104566,18 @@ function defaultClearTimeout () {
 }
 var cachedSetTimeout = defaultSetTimout;
 var cachedClearTimeout = defaultClearTimeout;
-if (typeof window.setTimeout === 'function') {
+var globalContext;
+if (typeof window !== 'undefined') {
+    globalContext = window;
+} else if (typeof self !== 'undefined') {
+    globalContext = self;
+} else {
+    globalContext = {};
+}
+if (typeof globalContext.setTimeout === 'function') {
     cachedSetTimeout = setTimeout;
 }
-if (typeof window.clearTimeout === 'function') {
+if (typeof globalContext.clearTimeout === 'function') {
     cachedClearTimeout = clearTimeout;
 }
 function runTimeout(fun) {
@@ -104663,7 +104711,7 @@ function chdir (dir) {
     throw new Error('process.chdir is not supported');
 }function umask() { return 0; }
 // from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
-var performance = window.performance || {};
+var performance = globalContext.performance || {};
 var performanceNow =
   performance.now        ||
   performance.mozNow     ||


### PR DESCRIPTION
## Changes

This makes the process polyfill safe for use in web workers, where `window` isn't defined (but `self` is).  For good measure, the fix also ensures that the polyfill will work (in a degraded fashion) in any other global environment.

## Testing

Tested by hand in my own project's build to confirm that the polyfill no longer raises an exception when loaded into a web worker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pikapkg/snowpack/994)
<!-- Reviewable:end -->
