### PR TITLE
fix `string` is undefined

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -160,7 +160,7 @@ module.exports = function plugin(config, args) {
   }
   
   const manifest =
-    typeof args.manifest === string
+    typeof args.manifest === 'string'
       ? args.manifest
       : !!args.manifest
       ? './asset-manifest.json'


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

plugin-webpack will throw a error because of undefined [`string`](https://github.com/pikapkg/snowpack/pull/983/commits/e97b99cd06a1bd575d4700a3c7945a27559e5fe3#diff-ef63a43117744b6074463ff5aa32028dR163).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
