### PR TITLE
Ignore css files with no content

### DIFF
--- a/plugins/plugin-postcss/plugin.js
+++ b/plugins/plugin-postcss/plugin.js
@@ -5,7 +5,7 @@ module.exports = function postcssPlugin(_, options) {
     name: '@snowpack/postcss-transform',
     async transform({fileExt, contents}) {
       const {input = ['.css'], config} = options;
-      if (!input.includes(fileExt)) return;
+      if (!input.includes(fileExt) || !contents) return;
 
       const flags = [];
       if (config) flags.push(`--config ${config}`);


### PR DESCRIPTION
Postcss cli throws an exception when input stream is empty. We should probably avoid calling postcss when the css module content is empty.

## Changes

<!-- What does this change, in plain language? -->
Adds a content check for postcss plugins to avoid calling `postcss-cli` command with zero length input stream 

<!-- Before/after screenshots may be helpful.  -->
![2020-09-07_120902_scrot](https://user-images.githubusercontent.com/2857405/92405120-f6bc8500-f102-11ea-904b-67a0c1ec43b5.png)

## Testing

<!-- How was this change tested? -->
By adding an empty styles.css module under project src directory and running `snowpack build`

<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
