### PR TITLE
Fix dev server hanging on binary files

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -77,6 +77,7 @@
     "got": "^11.1.4",
     "http-proxy": "^1.18.1",
     "is-builtin-module": "^3.0.0",
+    "isbinaryfile": "^4.0.6",
     "jsonschema": "^1.2.5",
     "kleur": "^4.1.1",
     "mime-types": "^2.1.26",

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -1,9 +1,8 @@
-import {promises as fs} from 'fs';
 import path from 'path';
 import {validatePluginLoadResult} from '../config';
 import {logger} from '../logger';
 import {SnowpackBuildMap, SnowpackConfig, SnowpackPlugin} from '../types/snowpack';
-import {getEncodingType, getExt, replaceExt} from '../util';
+import {getExt, readFile, replaceExt} from '../util';
 
 export interface BuildFileOptions {
   isDev: boolean;
@@ -97,7 +96,7 @@ async function runPipelineLoadStep(
 
   return {
     [srcExt]: {
-      code: await fs.readFile(srcPath, getEncodingType(srcExt)),
+      code: await readFile(srcPath),
     },
   };
 }

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -184,7 +184,7 @@ class FileBuilder {
         // Until supported, just exit here.
         if (!resolvedImportUrl) {
           isSuccess = false;
-          logger.error(`${file.locOnDisk} - Could not resolve unkonwn import "${spec}".`);
+          logger.error(`${file.locOnDisk} - Could not resolve unknown import "${spec}".`);
           return spec;
         }
         // Ignore "http://*" imports

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -207,23 +207,23 @@ class FileBuilder {
           } else {
             this.filesToProxy.push(path.resolve(path.dirname(outLoc), resolvedImportPath));
           }
+        }
 
-          if (isProxyImport) {
-            resolvedImportPath = resolvedImportPath + '.proxy.js';
-            resolvedImportUrl = resolvedImportUrl + '.proxy.js';
-          }
+        if (isProxyImport) {
+          resolvedImportPath = resolvedImportPath + '.proxy.js';
+          resolvedImportUrl = resolvedImportUrl + '.proxy.js';
+        }
 
-          // When dealing with an absolute import path, we need to honor the baseUrl
-          if (isAbsoluteUrlPath) {
-            resolvedImportUrl = relativeURL(
-              path.dirname(outLoc),
-              path.resolve(this.config.devOptions.out, resolvedImportPath),
-            );
-          }
-          // Make sure that a relative URL always starts with "./"
-          if (!resolvedImportUrl.startsWith('.') && !resolvedImportUrl.startsWith('/')) {
-            resolvedImportUrl = './' + resolvedImportUrl;
-          }
+        // When dealing with an absolute import path, we need to honor the baseUrl
+        if (isAbsoluteUrlPath) {
+          resolvedImportUrl = relativeURL(
+            path.dirname(outLoc),
+            path.resolve(this.config.devOptions.out, resolvedImportPath),
+          );
+        }
+        // Make sure that a relative URL always starts with "./"
+        if (!resolvedImportUrl.startsWith('.') && !resolvedImportUrl.startsWith('/')) {
+          resolvedImportUrl = './' + resolvedImportUrl;
         }
         return resolvedImportUrl;
       });

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -242,6 +242,7 @@ export async function command(commandOptions: CommandOptions) {
 
   // Set the proper install options, in case an install is needed.
   const dependencyImportMapLoc = path.join(DEV_DEPENDENCIES_DIR, 'import-map.json');
+  logger.debug(`Using cache folder: ${path.relative(cwd, DEV_DEPENDENCIES_DIR)}`);
   const installCommandOptions = merge(commandOptions, {
     config: {
       installOptions: {
@@ -254,9 +255,12 @@ export async function command(commandOptions: CommandOptions) {
 
   // Start with a fresh install of your dependencies, if needed.
   if (!(await checkLockfileHash(DEV_DEPENDENCIES_DIR)) || !existsSync(dependencyImportMapLoc)) {
+    logger.debug('Cache out of date or missing. Updating…');
     logger.info(colors.yellow('! updating dependencies...'));
     await installCommand(installCommandOptions);
     await updateLockfileHash(DEV_DEPENDENCIES_DIR);
+  } else {
+    logger.debug(`Cache up-to-date. Using existing cache`);
   }
 
   let dependencyImportMap: ImportMap = {imports: {}};

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -68,11 +68,11 @@ import {
   checkLockfileHash,
   cssSourceMappingURL,
   DEV_DEPENDENCIES_DIR,
-  getEncodingType,
   getExt,
   jsSourceMappingURL,
   openInBrowser,
   parsePackageImportSpecifier,
+  readFile,
   replaceExt,
   resolveDependencyManifest,
   updateLockfileHash,
@@ -166,7 +166,7 @@ const sendFile = (
   }
 
   res.writeHead(200, headers);
-  res.write(body, getEncodingType(ext) as BufferEncoding);
+  res.write(body);
   res.end();
 };
 
@@ -682,7 +682,7 @@ If Snowpack is having trouble detecting the import, add ${colors.bold(
     }
 
     // 2. Load the file from disk. We'll need it to check the cold cache or build from scratch.
-    const fileContents = await fs.readFile(fileLoc, getEncodingType(requestedFileExt));
+    const fileContents = await readFile(fileLoc);
 
     // 3. Send dependencies directly, since they were already build & resolved at install time.
     if (reqPath.startsWith(config.buildOptions.webModulesUrl) && !isProxyModule) {

--- a/snowpack/src/commands/install.ts
+++ b/snowpack/src/commands/install.ts
@@ -446,6 +446,7 @@ export async function getInstallTargets(
   if (webDependencies) {
     installTargets.push(...scanDepList(Object.keys(webDependencies), cwd));
   }
+  // TODO: remove this if block; move logic inside scanImports
   if (scannedFiles) {
     installTargets.push(...(await scanImportsFromFiles(scannedFiles, config)));
   } else {
@@ -457,17 +458,23 @@ export async function getInstallTargets(
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config} = commandOptions;
 
+  logger.debug('Starting install');
   const installTargets = await getInstallTargets(config);
+  logger.debug('Received install targets');
   if (installTargets.length === 0) {
     logger.error('Nothing to install.');
     return;
   }
+  logger.debug('Running install command');
   const finalResult = await run({...commandOptions, installTargets});
+  logger.debug('Install command successfully ran');
   if (finalResult.newLockfile) {
     await writeLockfile(path.join(cwd, 'snowpack.lock.json'), finalResult.newLockfile);
+    logger.debug('Successfully wrote lockfile');
   }
   if (finalResult.stats) {
     logger.info(printStats(finalResult.stats));
+    logger.debug('Stats printed');
   }
 
   if (!finalResult.success || finalResult.hasError) {

--- a/snowpack/src/commands/install.ts
+++ b/snowpack/src/commands/install.ts
@@ -474,7 +474,6 @@ export async function command(commandOptions: CommandOptions) {
   }
   if (finalResult.stats) {
     logger.info(printStats(finalResult.stats));
-    logger.debug('Stats printed');
   }
 
   if (!finalResult.success || finalResult.hasError) {

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -2,7 +2,6 @@ import buildScriptPlugin from '@snowpack/plugin-build-script';
 import runScriptPlugin from '@snowpack/plugin-run-script';
 import {cosmiconfigSync} from 'cosmiconfig';
 import {all as merge} from 'deepmerge';
-import fs from 'fs';
 import http from 'http';
 import {validate, ValidatorResult} from 'jsonschema';
 import path from 'path';
@@ -22,7 +21,13 @@ import {
   LegacySnowpackPlugin,
   PluginLoadResult,
 } from './types/snowpack';
-import {addLeadingSlash, addTrailingSlash, removeLeadingSlash, removeTrailingSlash} from './util';
+import {
+  addLeadingSlash,
+  addTrailingSlash,
+  readFile,
+  removeLeadingSlash,
+  removeTrailingSlash,
+} from './util';
 
 const CONFIG_NAME = 'snowpack';
 const ALWAYS_EXCLUDE = ['**/node_modules/**/*', '**/.types/**/*'];
@@ -268,7 +273,7 @@ function loadPlugins(
       plugin.load = async (options: PluginLoadOptions) => {
         const result = await build({
           ...options,
-          contents: fs.readFileSync(options.filePath, 'utf-8'),
+          contents: await readFile(options.filePath),
         }).catch((err) => {
           logger.error(
             `[${plugin.name}] There was a problem running this older plugin. Please update the plugin to the latest version.`,

--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -81,7 +81,7 @@ async function transformCssImports(code: string, replaceImport: (specifier: stri
 }
 
 export async function transformFileImports(
-  {baseExt, contents}: SnowpackSourceFile,
+  {baseExt, contents}: SnowpackSourceFile<string>,
   replaceImport: (specifier: string) => string,
 ) {
   if (baseExt === '.js') {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -15,11 +15,11 @@ export type SnowpackBuiltFile = {code: string | Buffer; map?: string};
 export type SnowpackBuildMap = Record<string, SnowpackBuiltFile>;
 
 /** Standard file interface */
-export interface SnowpackSourceFile {
+export interface SnowpackSourceFile<Type = string | Buffer> {
   /** base extension (e.g. `.js`) */
   baseExt: string;
   /** file contents */
-  contents: string;
+  contents: Type;
   /** expanded extension (e.g. `.proxy.js` or `.module.css`) */
   expandedExt: string;
   /** if no location on disk, assume this exists in memory */

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -81,7 +81,7 @@ export interface SnowpackPlugin {
 
 export interface LegacySnowpackPlugin {
   defaultBuildScript: string;
-  build?(options: PluginLoadOptions & {contents: string}): Promise<any>;
+  build?(options: PluginLoadOptions & {contents: string | Buffer}): Promise<any>;
   bundle?(options: {
     srcDirectory: string;
     destDirectory: string;

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -6,6 +6,7 @@ import projectCacheDir from 'find-cache-dir';
 import findUp from 'find-up';
 import fs from 'fs';
 import got, {CancelableRequest, Response} from 'got';
+import {isBinaryFile} from 'isbinaryfile';
 import mkdirp from 'mkdirp';
 import open from 'open';
 import path from 'path';
@@ -36,9 +37,11 @@ export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gims;
 
 export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
 
-const UTF8_FORMATS = ['.css', '.html', '.js', '.map', '.mjs', '.json', '.svg', '.txt', '.xml'];
-export function getEncodingType(ext: string): 'utf-8' | undefined {
-  return UTF8_FORMATS.includes(ext) ? 'utf-8' : undefined;
+/** Read file from disk; return a string if it’s a code file */
+export async function readFile(filepath: string): Promise<string | Buffer> {
+  const data = await fs.promises.readFile(filepath);
+  const isBinary = await isBinaryFile(data);
+  return isBinary ? data : data.toString('utf-8');
 }
 
 export async function readLockfile(cwd: string): Promise<ImportMap | null> {

--- a/test/integration/error-include-ignore-unsupported-files/expected-output.txt
+++ b/test/integration/error-include-ignore-unsupported-files/expected-output.txt
@@ -1,2 +1,1 @@
-[snowpack] ignoring unsupported file "src/c.abcdefg"
 [snowpack] Nothing to install.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8335,6 +8335,11 @@ isarray@^2.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
+isbinaryfile@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.6.tgz#edcb62b224e2b4710830b67498c8e4e5a4d2610b"
+  integrity sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"


### PR DESCRIPTION
Discussion: https://github.com/pikapkg/snowpack/discussions/1016

## Changes

We were silently processing binary files, trying to scan them for imports, when we shouldn’t.

This PR makes a change where **extensions are no longer used to determine if something is a binary file or not.** That was error-prone, and we likely get it wrong. We now use [isbinaryfile](https://www.npmjs.com/package/isbinaryfile) which should be more reliable.

To be clear, our entire build pipeline & plugin workflow still operates by extensions, as it should remain. But us reading files is completely unrelated, and I think relying on extensions too much there have bitten us before. This change should simplify things and make it more automatic.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

- [x] dev server now working with repro: https://github.com/ralphtheninja/snowpack-dev-problem
- [x] all create-snowpack-app templates tested
- [x] all tests passing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
