### PR TITLE
removing --config flag because it causes an issue with the config running twice

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,8 +2,8 @@
   "name": "snowpack-www",
   "version": "2.7.0",
   "scripts": {
-    "docs:build": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js",
-    "docs:watch": "cat docs/* > index.md && npx @11ty/eleventy --config .eleventy.js --serve"
+    "docs:build": "cat docs/* > index.md && npx @11ty/eleventy",
+    "docs:watch": "cat docs/* > index.md && npx @11ty/eleventy --serve"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",


### PR DESCRIPTION
Turns out it wasn't needed (it automatically recognizes the config flag) and caused a bug (see this issue https://github.com/11ty/eleventy/issues/1389)

## Changes

This removes the `--config` flag from commands in `package.json` because it doesn't need it

## Testing
No tests in docs (yet)