### PR TITLE
Ensure that child build processes started when running on Windows exit properly.

### DIFF
--- a/plugins/plugin-build-script/plugin.js
+++ b/plugins/plugin-build-script/plugin.js
@@ -21,6 +21,7 @@ function buildScriptPlugin(_, {input, output, cmd}) {
         env: npmRunPath.env(),
         extendEnv: true,
         shell: true,
+        windowsHide: false,
         input: contents,
         cwd,
       });

--- a/plugins/plugin-run-script/plugin.js
+++ b/plugins/plugin-run-script/plugin.js
@@ -13,6 +13,7 @@ function runScriptPlugin(_, {cmd, watch, output}) {
         env: npmRunPath.env(),
         extendEnv: true,
         shell: true,
+        windowsHide: false,
         cwd,
       });
       const {stdout, stderr} = workerPromise;


### PR DESCRIPTION
## Changes

plugin-run-script and plugin-build script use execa.command with the shell: true option set to execute the user's command.  On Windows, this causes the child process to remain running after Snowpack exits: https://github.com/sindresorhus/execa/issues/433. The fix is to override the default windowsHide option -- as Snowpack always runs from a console we don't actually need execa to hide any extra console windows for us.

## Testing

Tested on my project's build with a few `plugin-run-script` instances by keeping an eye on the process list before/after running Snowpack.  I don't immediately see how to automate testing the issue...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pikapkg/snowpack/1022)
<!-- Reviewable:end -->
