### PR TITLE
add transpile target to plugin optimize

### DIFF
--- a/plugins/plugin-optimize/README.md
+++ b/plugins/plugin-optimize/README.md
@@ -2,6 +2,7 @@
 
 Optimize your unbundled Snowpack app:
 
+- ✅ Transpile JS
 - ✅ Minify JS
 - ✅ [Preload JS Modules][modulepreload]
 - (Coming soon) Minify HTML
@@ -38,5 +39,6 @@ Then add this plugin to your Snowpack config:
 | :--------------- | :-------: | :-------------------------------------------------------------- |
 | `minifyJS`       | `boolean` | Should JS be minified? (default: `true`)                        |
 | `preloadModules` | `boolean` | Should static `import`s be preloaded in HTML? (default: `true`) |
+| `target` | `string | string[]` | The language target(s) to transpile to. This can be a single string (ex: "es2018") or an array of strings (ex: ["chrome58","firefox57"]). If undefined, no transpilation will be done. See [esbuild documentation](https://github.com/evanw/esbuild) for more. |
 
 [modulepreload]: https://developers.google.com/web/updates/2017/12/modulepreload

--- a/plugins/plugin-optimize/plugin.js
+++ b/plugins/plugin-optimize/plugin.js
@@ -130,7 +130,7 @@ exports.default = function plugin(config, userDefinedOptions) {
     return code;
   }
 
-  async function optimizeFile({esbuildService, file, rootDir}) {
+  async function optimizeFile({esbuildService, file, target, rootDir}) {
     const baseExt = path.extname(file).toLowerCase();
 
     // optimize based on extension. if it’s not here, leave as-is
@@ -145,7 +145,7 @@ exports.default = function plugin(config, userDefinedOptions) {
         if (options.minifyJS) {
           try {
             let code = fs.readFileSync(file, 'utf-8');
-            const minified = await esbuildService.transform(code, {minify: true});
+            const minified = await esbuildService.transform(code, {minify: true, target});
             code = minified.js;
             fs.writeFileSync(file, code);
           } catch (err) {
@@ -187,7 +187,7 @@ exports.default = function plugin(config, userDefinedOptions) {
       // 2. optimize all files in parallel
       const parallelWorkQueue = new PQueue({concurrency: CONCURRENT_WORKERS});
       for (const file of allFiles) {
-        parallelWorkQueue.add(() => optimizeFile({file, esbuildService, rootDir: buildDirectory}));
+        parallelWorkQueue.add(() => optimizeFile({file, esbuildService, target: options.target, rootDir: buildDirectory}));
       }
       await parallelWorkQueue.onIdle();
 


### PR DESCRIPTION
## Changes

- Tackles part of https://github.com/pikapkg/snowpack/issues/838 to add transpilation for unbundled builds.

```
| `target` | `string | string[]` | The language target(s) to transpile to. This can be a single string (ex: "es2018") or an array of strings (ex: ["chrome58","firefox57"]). If undefined, no transpilation will be done. |
```

## Testing

- No plugin tests (yet).
