### PR TITLE
Adding some debug messages for rollup install

### DIFF
--- a/snowpack/src/commands/install.ts
+++ b/snowpack/src/commands/install.ts
@@ -398,6 +398,7 @@ ${colors.dim(
   };
   if (Object.keys(installEntrypoints).length > 0) {
     try {
+      logger.debug(`building Rollup with options:\n    ${JSON.stringify(inputOptions)}`);
       const packageBundle = await rollup(inputOptions);
       logger.debug(
         `installing npm packages:\n    ${Object.keys(installEntrypoints).join('\n    ')}`,
@@ -405,6 +406,7 @@ ${colors.dim(
       if (isFatalWarningFound) {
         throw new Error(FAILED_INSTALL_MESSAGE);
       }
+      logger.debug(`writing Rollup bundle with options:\n    ${JSON.stringify(outputOptions)}`);
       await packageBundle.write(outputOptions);
     } catch (_err) {
       const err: RollupError = _err;


### PR DESCRIPTION
## Changes

Adds debug messages during install when running Rollup
<img width="501" alt="Screen Shot 2020-09-11 at 3 43 01 PM" src="https://user-images.githubusercontent.com/1251094/92971130-820c8200-f445-11ea-900f-d02df0fb3eb3.png">

## Testing

Debug messages don't have tests yet

