### PR TITLE
Allow omitting options to plugin-webpack

### DIFF
--- a/plugins/plugin-webpack/README.md
+++ b/plugins/plugin-webpack/README.md
@@ -2,20 +2,35 @@
 
 Use Webpack to bundle your application for production.
 
+### Install
+
 ```
 npm install --save-dev @snowpack/plugin-webpack
 ```
 
-```js
-// snowpack.config.json
+### Usage
+
+Add `@snowpack/plugin-webpack` to `snowpack.config.json`:
+
+```json
 {
-  "plugins": [["@snowpack/plugin-webpack", { /* see "Plugin Options" below */}]]
+  "plugins": [["@snowpack/plugin-webpack", { /* see "Plugin Options" below */ }]]
 }
 ```
 
-#### Default Build Script
+or to `snowpack.config.js`:
 
 ```js
+module.exports = {
+  plugins: [["@snowpack/plugin-webpack", { /* see "Plugin Options" below */ }]]
+}
+```
+
+The options object is optional.
+
+### Default Build Script
+
+```json
 {
   "scripts": {"bundle:*": "@snowpack/plugin-webpack"}
 }

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -154,7 +154,7 @@ function getSplitChunksConfig({ numEntries }) {
   };
 }
 
-module.exports = function plugin(config, args) {
+module.exports = function plugin(config, args = {}) {
   // Deprecated: args.mode
   if (args.mode && args.mode !== "production") {
     throw new Error("args.mode support has been removed.");


### PR DESCRIPTION
## Changes

It allows the developer to omit the options object. Maybe they forgot to add the object or simply just want to use the plugin default values. Either way, they need to pass an empty object to avoid `TypeError: Cannot read property 'mode' of undefined`

Also tweaked the docs a bit, explaining that the options object _is_ optional.

Before:

![Screenshot from 2020-09-12 13-37-26](https://user-images.githubusercontent.com/308049/92995102-89449600-f500-11ea-9fa4-ed67ab67aac8.png)


## Testing

No plugin tests (yet).
