### PR TITLE
Add note on yarn --force

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,14 @@ Note: you will see warnings about `__dirname` and `require()` not being "a valid
 
 ```bash
 yarn build
-yarn --force
+yarn --force # only needed after very first build; afterward can be skipped
 ```
+
+#### Why is `yarn --force` needed?
+
+The advantages of using Lerna in a monorepo setup means when we run our tests (and even the [create-snowpack-app templates](./create-snowpack-app)), we’re using our local build of Snowpack and not npm’s published version. After all, if we had to publish to npm in order to test anything, that would be a bad experience for everyone!
+
+When we run `yarn build`, a binstub is built at `./snowpack/pkg/node-dist/index.bin.js`. This is what runs when you run `snowpack` in your CLI, as well as the thing that runs for all our tests. But say you ran `yarn build && yarn test` (no `yarn --force`), you’d get an error message: `/bin/sh: snowpack: command not found`. That’s because in all our tests and sub-projects it’s not enough for that to exist; that has to be symlinked inside every sub-project to `node_modules/.bin/snowpack` (again, because we want to use a local build and not npm’s version). `yarn` is the quickest way to symlink everything, however, `yarn --force` is required at this stage when dependencies are already installed. Without that flag Yarn (incorrectly) thinks there’s nothing to do. In other words, `yarn --force` is only needed **one time** as a one-line command to symlink everything for local development, after which only `yarn build` is needed for subsequent changes and rebuilds.
 
 ## Run tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,7 @@ yarn --force # only needed after very first build; afterward can be skipped
 
 #### Why is `yarn --force` needed?
 
-The advantages of using Lerna in a monorepo setup means when we run our tests (and even the [create-snowpack-app templates](./create-snowpack-app)), we’re using our local build of Snowpack and not npm’s published version. After all, if we had to publish to npm in order to test anything, that would be a bad experience for everyone!
-
-When we run `yarn build`, a binstub is built at `./snowpack/pkg/node-dist/index.bin.js`. This is what runs when you run `snowpack` in your CLI, as well as the thing that runs for all our tests. But say you ran `yarn build && yarn test` (no `yarn --force`), you’d get an error message: `/bin/sh: snowpack: command not found`. That’s because in all our tests and sub-projects it’s not enough for that to exist; that has to be symlinked inside every sub-project to `node_modules/.bin/snowpack` (again, because we want to use a local build and not npm’s version). `yarn` is the quickest way to symlink everything, however, `yarn --force` is required at this stage when dependencies are already installed. Without that flag Yarn (incorrectly) thinks there’s nothing to do. In other words, `yarn --force` is only needed **one time** as a one-line command to symlink everything for local development, after which only `yarn build` is needed for subsequent changes and rebuilds.
+Lerna allows us to use our local build of Snowpack which is key for testing any changes we make. Thanks to Lerna, when we run `yarn build`, the `snowpack` [executable script](https://docs.npmjs.com/files/package.json#bin) is built at `./snowpack/pkg/node-dist/index.bin.js`. The `--force` command generates the symlinks needed so that this new executable script gets used by all parts of the project. Now when you run tests in [create-snowpack-app templates](./create-snowpack-app), it knows to use the locally built symlinked version. This solves two major problems: it means you don't have tons of `node_modules` in subdirectories and also means you don’t need to publish Snowpack to npm to test your changes.
 
 ## Run tests
 


### PR DESCRIPTION
Satisfies #1056

## Changes

Read #1056 for more context, but explains the mysterious `yarn --force` required for local development/testing.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

👀 Review here: https://github.com/pikapkg/snowpack/blob/drwpow/yarn-force/CONTRIBUTING.md

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
