### PR TITLE
test: explain how to delete left-over test folders

### DIFF
--- a/test/build/build.test.js
+++ b/test/build/build.test.js
@@ -24,8 +24,15 @@ describe('snowpack build', () => {
 
     it(testName, () => {
       const cwd = path.join(__dirname, testName);
+      const relativePath = cwd.replace(process.cwd() + '/', '');
+
       if (!existsSync(path.join(cwd, 'package.json'))) {
-        console.error(testName, 'no longer exists, skipping...');
+        console.warn(
+          '%s folder has no package.json file, it is likely a leftover folder from a deleted test. You can remove the folder with `git clean -xdf %s`',
+          relativePath,
+          relativePath,
+        );
+
         return;
       }
 

--- a/test/integration/install.test.js
+++ b/test/integration/install.test.js
@@ -68,8 +68,15 @@ describe('snowpack install', () => {
       }
 
       const cwd = path.join(__dirname, testName);
+      const relativePath = cwd.replace(process.cwd() + '/', '');
+
       if (!existsSync(path.join(cwd, 'package.json'))) {
-        console.error(testName, 'no longer exists, skipping...');
+        console.warn(
+          '%s folder has no package.json file, it is likely a leftover folder from a deleted test. You can remove the folder with `git clean -xdf %s`',
+          relativePath,
+          relativePath,
+        );
+
         return;
       }
 


### PR DESCRIPTION
This is a follow up to https://github.com/pikapkg/snowpack/pull/992 /cc @FredKSchott

I've run into this again and thought it might help others to understand the problem better and to resolve it quicker.

To see the warnings, you can check out this pull request and run

```
mkdir test/build/test-log-warning test/integration/test-log-warning
npm test
```

## Changes

- Make message more helpful in case of left-over test folders

## Testing

see steps above