### PR TITLE
Add .avif format to static types in typescript templates

### DIFF
--- a/create-snowpack-app/app-template-blank-typescript/types/static.d.ts
+++ b/create-snowpack-app/app-template-blank-typescript/types/static.d.ts
@@ -30,3 +30,7 @@ declare module '*.webp' {
   const ref: string;
   export default ref;
 }
+declare module '*.avif' {
+  const ref: string;
+  export default ref;
+}

--- a/create-snowpack-app/app-template-lit-element-typescript/types/static.d.ts
+++ b/create-snowpack-app/app-template-lit-element-typescript/types/static.d.ts
@@ -30,3 +30,7 @@ declare module '*.webp' {
   const ref: string;
   export default ref;
 }
+declare module '*.avif' {
+  const ref: string;
+  export default ref;
+}

--- a/create-snowpack-app/app-template-react-typescript/types/static.d.ts
+++ b/create-snowpack-app/app-template-react-typescript/types/static.d.ts
@@ -30,3 +30,7 @@ declare module '*.webp' {
   const ref: string;
   export default ref;
 }
+declare module '*.avif' {
+  const ref: string;
+  export default ref;
+}

--- a/create-snowpack-app/app-template-svelte-typescript/types/static.d.ts
+++ b/create-snowpack-app/app-template-svelte-typescript/types/static.d.ts
@@ -30,3 +30,7 @@ declare module '*.webp' {
   const ref: string;
   export default ref;
 }
+declare module '*.avif' {
+  const ref: string;
+  export default ref;
+}


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Adds typing for `.avif` image format on Typescript templates. 

Jake wrote a good article about it here: https://twitter.com/jaffathecake/status/1303290847958573057

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->

No testing needed for typing update
