### PR TITLE
Ensure that the import resolver respects installOptions.externalPackage.

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -56,7 +56,7 @@ export function createImportResolver({
   config,
 }: ImportResolverOptions) {
   return function importResolver(spec: string): string | false {
-    if (URL_HAS_PROTOCOL_REGEX.test(spec)) {
+    if (URL_HAS_PROTOCOL_REGEX.test(spec) || config.installOptions.externalPackage?.includes(spec)) {
       return spec;
     }
     if (spec.startsWith('/') || spec.startsWith('./') || spec.startsWith('../')) {

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -195,7 +195,8 @@ class FileBuilder {
           return spec;
         }
         // Ignore "http://*" imports
-        if (url.parse(resolvedImportUrl).protocol) {
+        if (url.parse(resolvedImportUrl).protocol ||
+            this.config.installOptions.externalPackage?.includes(resolvedImportUrl)) {
           return spec;
         }
         // Handle normal "./" & "../" import specifiers

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -195,8 +195,11 @@ class FileBuilder {
           return spec;
         }
         // Ignore "http://*" imports
-        if (url.parse(resolvedImportUrl).protocol ||
-            this.config.installOptions.externalPackage?.includes(resolvedImportUrl)) {
+        if (url.parse(resolvedImportUrl).protocol) {
+          return spec;
+        }
+        // Ignore packages marked as external
+        if (this.config.installOptions.externalPackage?.includes(resolvedImportUrl)) {
           return spec;
         }
         // Handle normal "./" & "../" import specifiers

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -35,8 +35,6 @@ export const HTML_JS_REGEX = /(<script[^>]*?type="module".*?>)(.*?)<\/script>/gi
 export const CSS_REGEX = /@import\s*['"](.*?)['"];/gs;
 export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gims;
 
-export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
-
 /** Read file from disk; return a string if it’s a code file */
 export async function readFile(filepath: string): Promise<string | Buffer> {
   const data = await fs.promises.readFile(filepath);

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -509,6 +509,56 @@ exports[`snowpack build config-extends-plugins: index.html 1`] = `
 </html>"
 `;
 
+exports[`snowpack build config-external-package: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\"};"`;
+
+exports[`snowpack build config-external-package: _dist_/index.js 1`] = `
+"import 'fs';
+import '../web_modules/array-flatten.js';"
+`;
+
+exports[`snowpack build config-external-package: allFiles 1`] = `
+Array [
+  "__snowpack__/env.js",
+  "_dist_/index.js",
+  "web_modules/array-flatten.js",
+  "web_modules/import-map.json",
+]
+`;
+
+exports[`snowpack build config-external-package: web_modules/array-flatten.js 1`] = `
+"/**
+ * Flatten an array indefinitely.
+ */
+function flatten(array) {
+    var result = [];
+    $flatten(array, result);
+    return result;
+}
+/**
+ * Internal flatten function recursively passes \`result\`.
+ */
+function $flatten(array, result) {
+    for (var i = 0; i < array.length; i++) {
+        var value = array[i];
+        if (Array.isArray(value)) {
+            $flatten(value, result);
+        }
+        else {
+            result.push(value);
+        }
+    }
+}
+export { flatten };"
+`;
+
+exports[`snowpack build config-external-package: web_modules/import-map.json 1`] = `
+"{
+  \\"imports\\": {
+    \\"array-flatten\\": \\"./array-flatten.js\\"
+  }
+}"
+`;
+
 exports[`snowpack build config-out: __snowpack__/env.js 1`] = `"export default {\\"MODE\\":\\"production\\",\\"NODE_ENV\\":\\"production\\"};"`;
 
 exports[`snowpack build config-out: allFiles 1`] = `

--- a/test/build/config-external-package/package.json
+++ b/test/build/config-external-package/package.json
@@ -1,0 +1,28 @@
+{
+  "private": true,
+  "version": "1.0.0",
+  "name": "@snowpack/test-config-external-package",
+  "description": "Test for installOptions.externalPackage as it applies to building.",
+  "scripts": {
+    "testbuild": "snowpack build"
+  },
+  "snowpack": {
+    "buildOptions": {
+      "minify": false
+    },
+    "mount": {
+      "./src": "/_dist_"
+    },
+    "installOptions": {
+      "externalPackage": [
+        "fs"
+      ]
+    }
+  },
+  "devDependencies": {
+    "snowpack": "^2.7.0"
+  },
+  "dependencies": {
+    "array-flatten": "^3.0.0"
+  }
+}

--- a/test/build/config-external-package/src/index.js
+++ b/test/build/config-external-package/src/index.js
@@ -1,0 +1,2 @@
+import 'fs';
+import 'array-flatten';


### PR DESCRIPTION
This makes the dev import resolver pass through any imported packages that are on the `installOptions.externalPackage` list.  Fixes #1067.

## Testing

I added a test to ensure that building respects external packages.  The option also affects the output of dev mode but I'm not sure how to test that -- could you point me to an example?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pikapkg/snowpack/1070)
<!-- Reviewable:end -->
