### PR TITLE
add back "tsc" to CSA react scripts

### DIFF
--- a/create-snowpack-app/app-scripts-react/snowpack.config.js
+++ b/create-snowpack-app/app-scripts-react/snowpack.config.js
@@ -9,7 +9,12 @@ module.exports = {
     public: '/',
     src: '/_dist_',
   },
-  plugins: ['@snowpack/plugin-react-refresh', '@snowpack/plugin-babel', '@snowpack/plugin-dotenv'],
+  plugins: [
+    '@snowpack/plugin-react-refresh',
+    '@snowpack/plugin-babel',
+    '@snowpack/plugin-dotenv',
+    ...(isTS ? [['@snowpack/plugin-run-script', {cmd: 'tsc --noEmit', watch: '$1 --watch'}]] : []),
+  ],
   devOptions: {},
   installOptions: {
     installTypes: isTS,


### PR DESCRIPTION
## Changes

- Adds back the automatic TypeScript runner for React + TypeScript CSA apps
- Not sure when or why this got removed, but it shouldn't have
- Related: I think this overall "app-scripts" system could be simplified, starting to think this "app-scripts" concept does more harm than good (confusing)

## Testing
 
- Covered by existing csa build test.