### PR TITLE
configure run jobs to run in watch mode on build --watch

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -265,6 +265,7 @@ class FileBuilder {
 
 export async function command(commandOptions: CommandOptions) {
   const {cwd, config} = commandOptions;
+  const isWatch = !!config.buildOptions.watch;
 
   const buildDirectoryLoc = config.devOptions.out;
   const internalFilesBuildLoc = path.join(buildDirectoryLoc, config.buildOptions.metaDir);
@@ -285,10 +286,10 @@ export async function command(commandOptions: CommandOptions) {
 
   for (const runPlugin of config.plugins) {
     if (runPlugin.run) {
-      await runPlugin
+      const runJob = runPlugin
         .run({
-          isDev: false,
-          isHmrEnabled: false,
+          isDev: isWatch,
+          isHmrEnabled: getIsHmrEnabled(config),
           // @ts-ignore: internal API only
           log: (msg, data: {msg: string} = {}) => {
             if (msg === 'WORKER_MSG') {
@@ -298,8 +299,14 @@ export async function command(commandOptions: CommandOptions) {
         })
         .catch((err) => {
           logger.error(err.toString(), {name: runPlugin.name});
-          process.exit(1);
+          if (!isWatch) {
+            process.exit(1);
+          }
         });
+      // Wait for the job to complete before continuing (unless in watch mode)
+      if (!isWatch) {
+        await runJob;
+      }
     }
   }
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/pikapkg/snowpack/discussions/1089
- If building in watch mode, plugin `run()` jobs should also run in watch mode

## Testing

- Non-watch mode covered by tests
- watch mode tested manually 