### PR TITLE
enable native mjs for node v14

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -43,5 +43,9 @@
     "rollup": "^2.23.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "validate-npm-package-name": "^3.0.0"
+  },
+  "exports": {
+    "import": "./wrapper.mjs",
+    "require": "./dist-node/index.js"
   }
 }

--- a/esinstall/wrapper.mjs
+++ b/esinstall/wrapper.mjs
@@ -1,0 +1,4 @@
+import Pkg from './dist-node/index.js';
+
+export const printStats = Pkg.printStats;
+export const install = Pkg.install;


### PR DESCRIPTION
## Changes

before: `import { install } from 'esinstall'` would fail in .mjs or type: module node packages
now: it does not

## Testing

I ran it on a test repo manually