### PR TITLE
Add minimal test for plugin-babel

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  projects: ['<rootDir>'],
   modulePathIgnorePatterns: [
     '<rootDir>/create-snowpack-app/app-template-', // don’t run tests intended as user examples
     '<rootDir>/test/create-snowpack-app/test-install', // don’t run tests inside our mock create-snowpack-app install

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  projects: ['<rootDir>'],
   modulePathIgnorePatterns: [
     '<rootDir>/create-snowpack-app/app-template-', // don’t run tests intended as user examples
     '<rootDir>/test/create-snowpack-app/test-install', // don’t run tests inside our mock create-snowpack-app install

--- a/plugins/plugin-babel/test/plugin-babel.test.js
+++ b/plugins/plugin-babel/test/plugin-babel.test.js
@@ -1,0 +1,117 @@
+const plugin = require('../plugin.js');
+const babel = require('@babel/core');
+const workerpool = require('workerpool');
+
+jest.mock('@babel/core');
+babel.transformFileAsync = jest.fn(() => Promise.resolve({code: 'code', map: 'map'}));
+
+/** jest mock above in worker will not work */
+jest.mock('workerpool');
+workerpool.pool = jest.fn((path) => ({
+  proxy: jest.fn(() =>
+    Promise.resolve({
+      transformFileAsync: (...args) => babel.transformFileAsync(...args).then(JSON.stringify),
+    }),
+  ),
+}));
+
+beforeEach(() => {
+  babel.transformFileAsync.mockClear();
+});
+
+describe('plugin-babel', () => {
+  test('no options', async () => {
+    const p = plugin(
+      {
+        buildOptions: {},
+      },
+      {},
+    );
+    expect(p).toMatchInlineSnapshot(`
+      Object {
+        "cleanup": [Function],
+        "load": [Function],
+        "name": "@snowpack/plugin-babel",
+        "resolve": Object {
+          "input": Array [
+            ".js",
+            ".mjs",
+            ".jsx",
+            ".ts",
+            ".tsx",
+          ],
+          "output": Array [
+            ".js",
+          ],
+        },
+      }
+    `);
+    const result = await p.load({
+      filePath: 'test.js',
+    });
+    const [filePath, options] = babel.transformFileAsync.mock.calls[0];
+    expect(filePath).toMatchInlineSnapshot(`"test.js"`);
+    expect(options).toMatchObject({
+      cwd: process.cwd(),
+      ast: false,
+      compact: false,
+      sourceMaps: undefined,
+    });
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        ".js": Object {
+          "code": "code",
+          "map": "map",
+        },
+      }
+    `);
+  });
+  test('has transformOptions', async () => {
+    const transformOptions = {
+      ast: true,
+      plugins: ['jsx'],
+    };
+    const p = plugin(
+      {buildOptions: {}},
+      {
+        transformOptions,
+      },
+    );
+    await p.load({
+      filePath: 'test.js',
+    });
+    const [filePath, options] = babel.transformFileAsync.mock.calls[0];
+    expect(options).toMatchObject({
+      cwd: process.cwd(),
+      ast: false,
+      compact: false,
+      sourceMaps: undefined,
+      ...transformOptions,
+    });
+  });
+  test('sourceMaps option will be overwritte n', async () => {
+    const transformOptions = {
+      sourceMaps: 'inline',
+    };
+    const p = plugin(
+      {
+        buildOptions: {
+          sourceMaps: false,
+        },
+      },
+      {
+        transformOptions,
+      },
+    );
+    await p.load({
+      filePath: 'test.js',
+    });
+    const [filePath, options] = babel.transformFileAsync.mock.calls[0];
+    expect(options).toMatchObject({
+      cwd: process.cwd(),
+      ast: false,
+      compact: false,
+      ...transformOptions,
+    });
+  });
+});

--- a/plugins/plugin-babel/test/plugin-babel.test.js
+++ b/plugins/plugin-babel/test/plugin-babel.test.js
@@ -89,7 +89,7 @@ describe('plugin-babel', () => {
       ...transformOptions,
     });
   });
-  test('sourceMaps option will be overwritte n', async () => {
+  test('sourceMaps option will be overwritten', async () => {
     const transformOptions = {
       sourceMaps: 'inline',
     };

--- a/plugins/plugin-babel/test/plugin-babel.test.js
+++ b/plugins/plugin-babel/test/plugin-babel.test.js
@@ -1,12 +1,12 @@
 const plugin = require('../plugin.js');
-const babel = require('@babel/core');
-const workerpool = require('workerpool');
 
 jest.mock('@babel/core');
+const babel = require('@babel/core');
 babel.transformFileAsync = jest.fn(() => Promise.resolve({code: 'code', map: 'map'}));
 
 /** jest mock above in worker will not work */
 jest.mock('workerpool');
+const workerpool = require('workerpool');
 workerpool.pool = jest.fn((path) => ({
   proxy: jest.fn(() =>
     Promise.resolve({


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Add minimal test for plugin-babel.

Relates to #1019

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
Just make sure the plugin loading step will call `babel.transformFileAsync` with the desired options