### PR TITLE
remove bad vue template compiler option

### DIFF
--- a/plugins/plugin-vue/plugin.js
+++ b/plugins/plugin-vue/plugin.js
@@ -96,7 +96,6 @@ module.exports = function plugin(snowpackConfig) {
           preprocessLang: descriptor.template.lang,
           compilerOptions: {
             scopeId: descriptor.styles.some((s) => s.scoped) ? `data-v-${id}` : null,
-            runtimeModuleName: '/web_modules/vue.js',
           },
         });
         if (js.errors && js.errors.length > 0) {

--- a/plugins/plugin-vue/test/__snapshots__/plugin-vue-ts-tsx-jsx.test.js.snap
+++ b/plugins/plugin-vue/test/__snapshots__/plugin-vue-ts-tsx-jsx.test.js.snap
@@ -43,7 +43,7 @@ const defaultExport = defineComponent({
     const name = \\"VueContentTs\\";
   }
 });
-import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"/web_modules/vue.js\\"
+import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(\\"h1\\", null, \\"Vue Content Ts\\"))

--- a/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
@@ -47,7 +47,7 @@ const defaultExport = {
   }
 };
 
-import { createVNode as _createVNode, createTextVNode as _createTextVNode, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock } from \\"/web_modules/vue.js\\"
+import { createVNode as _createVNode, createTextVNode as _createTextVNode, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 const _hoisted_1 = { class: \\"App\\" }
 const _hoisted_2 = { class: \\"App-header\\" }
@@ -93,7 +93,7 @@ Object {
   },
   ".js": Object {
     "code": "const defaultExport = {};
-import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"/web_modules/vue.js\\"
+import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(\\"h1\\", null, \\"Vue Content Only Tpl\\"))
@@ -153,7 +153,7 @@ const defaultExport = {
   }
 };
 
-import { createVNode as _createVNode, createTextVNode as _createTextVNode, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock } from \\"/web_modules/vue.js\\"
+import { createVNode as _createVNode, createTextVNode as _createTextVNode, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"
 
 const _hoisted_1 = { class: \\"App\\" }
 const _hoisted_2 = { class: \\"App-header\\" }

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -9512,6 +9512,36 @@ function normalizeClass(value) {
     }
     return res.trim();
 }
+/**
+ * For converting {{ interpolation }} values to displayed strings.
+ * @private
+ */
+const toDisplayString = (val) => {
+    return val == null
+        ? ''
+        : isObject(val)
+            ? JSON.stringify(val, replacer, 2)
+            : String(val);
+};
+const replacer = (_key, val) => {
+    if (val instanceof Map) {
+        return {
+            [\`Map(\${val.size})\`]: [...val.entries()].reduce((entries, [key, val]) => {
+                entries[\`\${key} =>\`] = val;
+                return entries;
+            }, {})
+        };
+    }
+    else if (val instanceof Set) {
+        return {
+            [\`Set(\${val.size})\`]: [...val.values()]
+        };
+    }
+    else if (isObject(val) && !isArray(val) && !isPlainObject(val)) {
+        return String(val);
+    }
+    return val;
+};
 const EMPTY_OBJ =  {};
 const EMPTY_ARR = [];
 const NOOP = () => { };
@@ -9544,6 +9574,7 @@ const toTypeString = (value) => objectToString.call(value);
 const toRawType = (value) => {
     return toTypeString(value).slice(8, -1);
 };
+const isPlainObject = (val) => toTypeString(val) === '[object Object]';
 const isIntegerKey = (key) => isString(key) && key[0] !== '-' && '' + parseInt(key, 10) === key;
 const isReservedProp = /*#__PURE__*/ makeMap('key,ref,' +
     'onVnodeBeforeMount,onVnodeMounted,' +
@@ -10880,6 +10911,26 @@ function openBlock(disableTracking = false) {
 function closeBlock() {
     blockStack.pop();
     currentBlock = blockStack[blockStack.length - 1] || null;
+}
+/**
+ * Create a block root vnode. Takes the same exact arguments as \`createVNode\`.
+ * A block root keeps track of dynamic nodes within the block in the
+ * \`dynamicChildren\` array.
+ *
+ * @private
+ */
+function createBlock(type, props, children, patchFlag, dynamicProps) {
+    const vnode = createVNode(type, props, children, patchFlag, dynamicProps, true /* isBlock: prevent a block from tracking itself */);
+    // save current block children on the block vnode
+    vnode.dynamicChildren = currentBlock || EMPTY_ARR;
+    // close block
+    closeBlock();
+    // a block is always going to be patched, so track it as a child of its
+    // parent block
+    if ( currentBlock) {
+        currentBlock.push(vnode);
+    }
+    return vnode;
 }
 function isVNode(value) {
     return value ? value.__v_isVNode === true : false;
@@ -14186,5 +14237,5 @@ function normalizeContainer(container) {
     }
     return container;
 }
-export { createApp };"
+export { createApp, createBlock, createTextVNode, createVNode, openBlock, toDisplayString };"
 `;


### PR DESCRIPTION
fix https://github.com/pikapkg/snowpack/discussions/1100

## Changes

Remove `runtimeModuleName` compiler option to use default value, i.e. `vue` instead of `/web_modules/vue.js`.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
Snapshots updated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
