### PR TITLE
configure hmr port part 1

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -315,7 +315,7 @@ export async function command(commandOptions: CommandOptions) {
       path.resolve(internalFilesBuildLoc, 'hmr-error-overlay.js'),
       HMR_OVERLAY_CODE,
     );
-    hmrEngine = new EsmHmrEngine();
+    hmrEngine = new EsmHmrEngine({ port: config.devOptions.hmrPort });
   }
 
   logger.info(colors.yellow('! building source…'));
@@ -431,7 +431,7 @@ export async function command(commandOptions: CommandOptions) {
 
   // "--watch --hmr" mode - Tell users about the HMR WebSocket URL
   if (hmrEngine) {
-    logger.info(`[HMR] WebSocket URL available at ${colors.cyan(`${hmrEngine.wsUrl}`)}`);
+    logger.info(`[HMR] WebSocket URL available at ${colors.cyan(`ws://localhost:${config.devOptions.hmrPort}`)}`);
   }
 
   // "--watch" mode - Start watching the file system.

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -48,6 +48,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
     out: 'build',
     fallback: 'index.html',
     hmrDelay: 0,
+    hmrPort: 12321,
   },
   buildOptions: {
     baseUrl: '/',
@@ -89,6 +90,8 @@ const configSchema = {
         bundle: {type: 'boolean'},
         open: {type: 'string'},
         hmr: {type: 'boolean'},
+        hmrDelay: {type: 'number'},
+        hmrPort: {type: 'number'},
       },
     },
     installOptions: {

--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -23,8 +23,17 @@ type HMRMessage =
       errorStackTrace?: string;
     };
 
-const DEFAULT_PORT = 12321;
 const DEFAULT_CONNECT_DELAY = 2000;
+
+interface EsmHmrEngineOptionsCommon {
+  delay?: number;
+}
+
+type EsmHmrEngineOptions = ({
+  server: http.Server | http2.Http2Server;  
+} | {
+  port: number;
+}) & EsmHmrEngineOptionsCommon;
 
 export class EsmHmrEngine {
   clients: Set<WebSocket> = new Set();
@@ -34,16 +43,16 @@ export class EsmHmrEngine {
   private currentBatch: HMRMessage[] = [];
   private currentBatchTimeout: NodeJS.Timer | null = null;
   private cachedConnectErrors: Set<HMRMessage> = new Set();
-  wsUrl = `ws://localhost:${DEFAULT_PORT}`;
 
-  constructor(options: {server?: http.Server | http2.Http2Server; delay?: number} = {}) {
-    const wss = options.server
+  constructor(options: EsmHmrEngineOptions) {
+    const wss = 'server' in options 
       ? new WebSocket.Server({noServer: true})
-      : new WebSocket.Server({port: DEFAULT_PORT});
+      : new WebSocket.Server({port: options.port});
     if (options.delay) {
       this.delay = options.delay;
     }
-    if (options.server) {
+
+    if ('server' in options) {
       options.server.on('upgrade', (req, socket, head) => {
         // Only handle upgrades to ESM-HMR requests, ignore others.
         if (req.headers['sec-websocket-protocol'] !== 'esm-hmr') {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -129,6 +129,7 @@ export interface SnowpackConfig {
     open: string;
     hmr?: boolean;
     hmrDelay: number;
+    hmrPort: number;
   };
   installOptions: InstallOptions;
   buildOptions: {


### PR DESCRIPTION
## Changes
Add a config value to customize the HMR port for https://github.com/pikapkg/snowpack/issues/1041.
Part 2 will be in another PR.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
manually test two cases:
1. run `yarn build --watch --hmr` and set `HMR_WEBSOCKET_URL` in html file.
2. run `yarn build --watch --hmr --hmrPort=15555` and set `HMR_WEBSOCKET_URL` in html file.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
