### PR TITLE
[react-refresh] add plugin error message if setup script not run

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -33,12 +33,16 @@ function transformJs(contents, id) {
   return `
 /** React Refresh: Setup **/
 if (import.meta.hot) {
-  var prevRefreshReg = window.$RefreshReg$;
-  var prevRefreshSig = window.$RefreshSig$;
-  window.$RefreshReg$ = (type, id) => {
-    window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
+  if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
+    console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You many want to remove this plugin.');
+  } else {
+    var prevRefreshReg = window.$RefreshReg$;
+    var prevRefreshSig = window.$RefreshSig$;
+    window.$RefreshReg$ = (type, id) => {
+      window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
+    }
+    window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
   }
-  window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
 }
 
 ${contents}


### PR DESCRIPTION
## Changes

- Resolves https://github.com/pikapkg/snowpack/issues/1082
- Adds handling & better logging for incomplete React Refresh setup

## Testing

- Tested manually
