### PR TITLE
fix string replacement problem

### DIFF
--- a/plugins/plugin-babel/plugin.js
+++ b/plugins/plugin-babel/plugin.js
@@ -1,6 +1,13 @@
 const workerpool = require('workerpool');
 let worker, pool;
 
+function wrapEnvDefine(code) {
+  if (!code.includes('process.env')) {
+    return code;
+  }
+  return `var process = {env: import.meta.env};\n${code}`
+}
+
 module.exports = function plugin(snowpackConfig, options = {}) {
   // options validation
   if (options) {
@@ -35,11 +42,7 @@ module.exports = function plugin(snowpackConfig, options = {}) {
       let {code, map} = JSON.parse(encodedResult);
 
       if (code) {
-        // Some Babel plugins assume process.env exists, but Snowpack
-        // uses import.meta.env instead. Handle this here since it
-        // seems to be pretty common.
-        // See: https://www.pika.dev/npm/snowpack/discuss/496
-        code = code.replace(/process\.env/g, 'import.meta.env');
+        code = wrapEnvDefine(code);
       }
       return {
         '.js': {


### PR DESCRIPTION
## Changes
> The replacement of global strings will tamper with our source code

```
// src
function getEnvLabel() {
 return 'process.env.NODE_ENV'
}
// dist
function getEnvLabel() {
 return 'import.meta.env'
}
```