### PR TITLE
Skypack SDK

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "version": "independent",
-  "packages": ["snowpack", "create-snowpack-app/*", "plugins/*"],
+  "packages": ["snowpack", "skypack", "create-snowpack-app/*", "plugins/*"],
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "lerna run build --scope=esinstall --scope=snowpack",
-    "build:watch": "lerna run build:watch --parallel --scope=esinstall --scope=snowpack",
+    "build": "lerna run build --scope=esinstall --scope=snowpack --scope=skypack",
+    "build:watch": "lerna run build:watch --parallel --scope=esinstall --scope=snowpack --scope=skypack",
     "build:docs": "cd www && yarn build",
-    "lint": "lerna run lint --parallel --scope=esinstall --scope=snowpack",
+    "lint": "lerna run lint --parallel --scope=esinstall --scope=snowpack --scope=skypack",
     "publish": "npm run build && lerna publish --no-private",
     "format": "prettier --write '{snowpack,esinstall}/src/**/*.{ts,js}' '{test,plugins}/**/*.{ts,js}' '*.{js,json,md}' '**/*.{json,md}' '.github/**/*.{md,yml}' '!**/{_dist_,build,packages,pkg,TEST_BUILD_OUT,web_modules}/**' !test/create-snowpack-app/test-install",
     "test": "jest /test/ --test-timeout=30000",
@@ -18,6 +18,7 @@
     "plugins/*",
     "esinstall",
     "snowpack",
+    "skypack",
     "test/build/*",
     "test/esinstall/*"
   ],

--- a/skypack/.gitignore
+++ b/skypack/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lib

--- a/skypack/.prettierrc
+++ b/skypack/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": false,
+  "printWidth": 100
+}

--- a/skypack/README.md
+++ b/skypack/README.md
@@ -1,0 +1,9 @@
+# Skypack
+
+This is an experimental SDK for interacting with the Skypack Package CDN. It is not yet ready for public use, and may change without notice. Use at your own risk!
+
+More documentation will be written as this gets closer to a public release! Until then, you can browse the package code to get a better idea of the interface.
+
+```
+npm install skypack
+```

--- a/skypack/index.esm.mjs
+++ b/skypack/index.esm.mjs
@@ -1,0 +1,9 @@
+import Pkg from './lib/index.js';
+
+export const rollupPluginSkypack = Pkg.rollupPluginSkypack;
+export const generateImportMap = Pkg.generateImportMap;
+export const fetchCDN = Pkg.fetchCDN;
+export const buildNewPackage = Pkg.buildNewPackage;
+export const lookupBySpecifier = Pkg.lookupBySpecifier;
+export const clearCache = Pkg.clearCache;
+export const SKYPACK_ORIGIN = Pkg.SKYPACK_ORIGIN;

--- a/skypack/package.json
+++ b/skypack/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "skypack",
+  "version": "0.0.1",
+  "description": "Install packages from Skypack",
+  "keywords": [
+    "skypack",
+    "esm",
+    "cdn",
+    "sdk"
+  ],
+  "private": true,
+  "author": "Fred K. Schott <fkschott@gmail.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "pkg"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/snowpackjs/snowpack.git",
+    "directory": "skypack"
+  },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "lint": "tsc --noEmit --noUnusedLocals true --noUnusedParameters true && package-check"
+  },
+  "engines": {
+    "node": ">=10.19.0"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.esm.mjs",
+      "require": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "index.bin.js",
+    "index.esm.mjs"
+  ],
+  "dependencies": {
+    "cacache": "^15.0.0",
+    "cachedir": "^2.3.0",
+    "got": "^11.1.4",
+    "kleur": "^4.1.0",
+    "p-queue": "^6.2.1",
+    "rimraf": "^3.0.0",
+    "rollup": "^2.23.0",
+    "validate-npm-package-name": "^3.0.0"
+  }
+}

--- a/skypack/src/index.ts
+++ b/skypack/src/index.ts
@@ -1,0 +1,217 @@
+import cacache from 'cacache';
+import got, {Response} from 'got';
+import {IncomingHttpHeaders} from 'http';
+import {ImportMap, RESOURCE_CACHE, SKYPACK_ORIGIN, HAS_CDN_HASH_REGEX} from './util';
+
+export {rollupPluginSkypack} from './rollup-plugin-remote-cdn';
+export {SKYPACK_ORIGIN} from './util';
+
+function parseRawPackageImport(spec: string): [string, string | null] {
+  const impParts = spec.split('/');
+  if (spec.startsWith('@')) {
+    const [scope, name, ...rest] = impParts;
+    return [`${scope}/${name}`, rest.join('/') || null];
+  }
+  const [name, ...rest] = impParts;
+  return [name, rest.join('/') || null];
+}
+
+export async function generateImportMap(
+  webDependencies: Record<string, string>,
+  inheritFromImportMap?: ImportMap,
+): Promise<ImportMap> {
+  const newLockfile: ImportMap = {imports: {}};
+  await Promise.all(
+    Object.entries(webDependencies).map(async ([packageName, packageSemver]) => {
+      if (inheritFromImportMap && inheritFromImportMap.imports[packageName]) {
+        newLockfile.imports[packageName] = inheritFromImportMap.imports[packageName];
+        newLockfile.imports[packageName + '/'] = inheritFromImportMap.imports[packageName + '/'];
+        return;
+      }
+      const lookupResponse = await lookupBySpecifier(packageName, packageSemver);
+      if (lookupResponse.error) {
+        throw lookupResponse.error;
+      }
+      if (lookupResponse.pinnedUrl) {
+        let keepGoing = true;
+        const deepPinnedUrlParts = lookupResponse.pinnedUrl.split('/');
+        // TODO: Get ?meta support to get this info via JSON instead of header manipulation
+        deepPinnedUrlParts.shift(); // remove ""
+        deepPinnedUrlParts.shift(); // remove "pin"
+
+        while (keepGoing) {
+          const investigate = deepPinnedUrlParts.pop()!;
+          if (HAS_CDN_HASH_REGEX.test(investigate)) {
+            keepGoing = false;
+            deepPinnedUrlParts.push(investigate);
+          }
+        }
+        newLockfile.imports[packageName] = '/' + deepPinnedUrlParts.join('/');
+        newLockfile.imports[packageName + '/'] = '/' + deepPinnedUrlParts.join('/') + '/';
+      }
+    }),
+  );
+  const newLockfileSorted = Object.keys(newLockfile.imports).sort((a, b) => {
+    // We want 'xxx/' to come after 'xxx', so we convert it to a space (the character with the highest sort order)
+    // See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
+    return a.replace(/\/$/, ' ').localeCompare(b.replace(/\/$/, ' '));
+  });
+  return {
+    imports: newLockfileSorted.reduce((prev, k) => {
+      prev[k] = newLockfile.imports[k];
+      return prev;
+    }, {}),
+  };
+}
+
+interface ResourceCacheMetadata {
+  headers: IncomingHttpHeaders;
+  statusCode: number;
+  freshUntil: string;
+}
+
+export async function fetchCDN(
+  resourceUrl: string,
+  userAgent?: string,
+): Promise<{
+  body: string;
+  headers: IncomingHttpHeaders;
+  statusCode: number;
+  isCached: boolean;
+  isStale: boolean;
+}> {
+  if (!resourceUrl.startsWith(SKYPACK_ORIGIN)) {
+    resourceUrl = SKYPACK_ORIGIN + resourceUrl;
+  }
+
+  const cachedResult = await cacache.get(RESOURCE_CACHE, resourceUrl).catch(() => null);
+  if (cachedResult) {
+    const cachedResultMetadata = cachedResult.metadata as ResourceCacheMetadata;
+    const freshUntil = new Date(cachedResult.metadata.freshUntil);
+    if (freshUntil >= new Date()) {
+      return {
+        isCached: true,
+        isStale: false,
+        body: cachedResult.data.toString(),
+        headers: cachedResultMetadata.headers,
+        statusCode: cachedResultMetadata.statusCode,
+      };
+    }
+  }
+
+  let freshResult: Response<string>;
+  try {
+    freshResult = await got(resourceUrl, {
+      headers: {'user-agent': userAgent || `snowpack/v3.0 (https://www.snowpack.dev)`},
+      throwHttpErrors: false,
+    });
+  } catch (err) {
+    if (cachedResult) {
+      const cachedResultMetadata = cachedResult.metadata as ResourceCacheMetadata;
+      return {
+        isCached: true,
+        isStale: true,
+        body: cachedResult.data.toString(),
+        headers: cachedResultMetadata.headers,
+        statusCode: cachedResultMetadata.statusCode,
+      };
+    }
+    throw err;
+  }
+
+  const cacheUntilMatch = freshResult.headers['cache-control']?.match(/max-age=(\d+)/);
+  if (cacheUntilMatch) {
+    var freshUntil = new Date();
+    freshUntil.setSeconds(freshUntil.getSeconds() + parseInt(cacheUntilMatch[1]));
+    // no need to await, since we `.catch()` to swallow any errors.
+    cacache
+      .put(RESOURCE_CACHE, resourceUrl, freshResult.body, {
+        metadata: {
+          headers: freshResult.headers,
+          statusCode: freshResult.statusCode,
+          freshUntil: freshUntil.toUTCString(),
+        } as ResourceCacheMetadata,
+      })
+      .catch(() => null);
+  }
+
+  return {
+    body: freshResult.body as string,
+    headers: freshResult.headers,
+    statusCode: freshResult.statusCode,
+    isCached: false,
+    isStale: false,
+  };
+}
+
+export type BuildNewPackageResponse =
+  | {error: Error; success: false}
+  | {
+      error: null;
+      success: boolean;
+    };
+
+export async function buildNewPackage(
+  spec: string,
+  semverString?: string,
+  userAgent?: string,
+): Promise<BuildNewPackageResponse> {
+  const [packageName, packagePath] = parseRawPackageImport(spec);
+  const lookupUrl =
+    `/new/${packageName}` +
+    (semverString ? `@${semverString}` : ``) +
+    (packagePath ? `/${packagePath}` : ``);
+  try {
+    const {statusCode} = await fetchCDN(lookupUrl, userAgent);
+    return {
+      error: null,
+      success: statusCode !== 500,
+    };
+  } catch (err) {
+    return {error: err, success: false};
+  }
+}
+
+export type LookupBySpecifierResponse =
+  | {error: Error}
+  | {
+      error: null;
+      body: string;
+      isCached: boolean;
+      isStale: boolean;
+      importStatus: string;
+      importUrl: string;
+      pinnedUrl: string | undefined;
+      typesUrl: string | undefined;
+    };
+
+export async function lookupBySpecifier(
+  spec: string,
+  semverString?: string,
+  userAgent?: string,
+): Promise<LookupBySpecifierResponse> {
+  const [packageName, packagePath] = parseRawPackageImport(spec);
+  const lookupUrl =
+    `/${packageName}` +
+    (semverString ? `@${semverString}` : ``) +
+    (packagePath ? `/${packagePath}` : ``);
+  try {
+    const {body, headers, isCached, isStale} = await fetchCDN(lookupUrl, userAgent);
+    return {
+      error: null,
+      body,
+      isCached,
+      isStale,
+      importStatus: headers['x-import-status'] as string,
+      importUrl: headers['x-import-url'] as string,
+      pinnedUrl: headers['x-pinned-url'] as string | undefined,
+      typesUrl: headers['x-typescript-types'] as string | undefined,
+    };
+  } catch (err) {
+    return {error: err};
+  }
+}
+
+export async function clearCache() {
+  return Promise.all([cacache.rm.all(RESOURCE_CACHE)]);
+}

--- a/skypack/src/rollup-plugin-remote-cdn.ts
+++ b/skypack/src/rollup-plugin-remote-cdn.ts
@@ -1,0 +1,124 @@
+import cacache from 'cacache';
+import {OutputOptions, Plugin, ResolvedId} from 'rollup';
+import {fetchCDN} from './index';
+import {SKYPACK_ORIGIN, HAS_CDN_HASH_REGEX, RESOURCE_CACHE} from './util';
+
+const CACHED_FILE_ID_PREFIX = 'snowpack-pkg-cache:';
+const PIKA_CDN_TRIM_LENGTH = SKYPACK_ORIGIN.length;
+
+/**
+ * rollup-plugin-remote-cdn
+ *
+ * Load import URLs from a remote CDN, sitting behind a local cache. The local
+ * cache acts as a go-between for the resolve & load step: when we get back a
+ * successful CDN resolution, we save the file to the local cache and then tell
+ * rollup that it's safe to load from the cache in the `load()` hook.
+ */
+export function rollupPluginSkypack({
+  installTypes,
+}: {
+  installTypes: boolean;
+}) {
+  // const allTypesToInstall = new Set<string>();
+  return {
+    name: 'snowpack:rollup-plugin-remote-cdn',
+    async resolveId(source: string, importer) {
+      let cacheKey: string;
+      if (source.startsWith(SKYPACK_ORIGIN)) {
+        cacheKey = source;
+      } else if (source.startsWith('/-/')) {
+        cacheKey = SKYPACK_ORIGIN + source;
+      } else if (source.startsWith('/pin/')) {
+        cacheKey = SKYPACK_ORIGIN + source;
+      } else {
+        return null;
+      }
+
+      // If the source path is a CDN path including a hash, it's assumed the
+      // file will never change and it is safe to pull from our local cache
+      // without a network request.
+      console.debug(`resolve ${cacheKey}`, {name: 'install:remote'});
+      if (HAS_CDN_HASH_REGEX.test(cacheKey)) {
+        const cachedResult = await cacache.get
+          .info(RESOURCE_CACHE, cacheKey)
+          .catch((/* ignore */) => null);
+        if (cachedResult) {
+          return CACHED_FILE_ID_PREFIX + cacheKey;
+        }
+      }
+
+      // Otherwise, make the remote request and cache the file on success.
+      const {statusCode} = await fetchCDN(cacheKey);
+      if (statusCode === 200) {
+        return CACHED_FILE_ID_PREFIX + cacheKey;
+      }
+
+      // If lookup failed, skip this plugin and resolve the import locally instead.
+      // TODO: Log that this has happened (if some sort of verbose mode is enabled).
+      const packageName = cacheKey
+        .substring(PIKA_CDN_TRIM_LENGTH)
+        .replace('/-/', '')
+        .replace('/pin/', '')
+        .split('@')[0];
+      return this.resolve(packageName, importer!, {skipSelf: true}).then((resolved) => {
+        let finalResult = resolved;
+        if (!finalResult) {
+          finalResult = ({id: packageName} as any) as ResolvedId;
+        }
+        return finalResult;
+      });
+    },
+    async load(id: string) {
+      if (!id.startsWith(CACHED_FILE_ID_PREFIX)) {
+        return null;
+      }
+      const cacheKey = id.substring(CACHED_FILE_ID_PREFIX.length);
+      console.debug(`load ${cacheKey}`, {name: 'install:remote'});
+      // const typesUrl: string | undefined = cachedResult.metadata?.typesUrl;
+      // if (typesUrl && installTypes) {
+      //   const typesTarballUrl = typesUrl.replace(/(mode=types.*?)\/.*/, '$1/all.tgz');
+      //   allTypesToInstall.add(typesTarballUrl);
+      // }
+      const {body} = await fetchCDN(cacheKey);
+      return body;
+    },
+    async writeBundle(_: OutputOptions) {
+      if (!installTypes) {
+        return;
+      }
+      // await mkdirp(path.join(options.dir!, '.types'));
+      // const tempDir = await cacache.tmp.mkdir(RESOURCE_CACHE);
+      // for (const typesTarballUrl of allTypesToInstall) {
+      //   let tarballContents: Buffer;
+      //   const cachedTarball = await cacache
+      //     .get(RESOURCE_CACHE, typesTarballUrl)
+      //     .catch((/* ignore */) => null);
+      //   if (cachedTarball) {
+      //     tarballContents = cachedTarball.data;
+      //   } else {
+      //     const tarballResponse = await fetchCDN(typesTarballUrl, 'buffer');
+      //     if (tarballResponse.statusCode !== 200) {
+      //       continue;
+      //     }
+      //     tarballContents = (tarballResponse.body as any) as Buffer;
+      //     await cacache.put(RESOURCE_CACHE, typesTarballUrl, tarballContents);
+      //   }
+      //   const typesUrlParts = url.parse(typesTarballUrl).pathname!.split('/');
+      //   const typesPackageName = url.parse(typesTarballUrl).pathname!.startsWith('/-/@')
+      //     ? typesUrlParts[2] + '/' + typesUrlParts[3].split('@')[0]
+      //     : typesUrlParts[2].split('@')[0];
+      //   const typesPackageTarLoc = path.join(tempDir, `${typesPackageName}.tgz`);
+      //   if (typesPackageName.includes('/')) {
+      //     await mkdirp(path.dirname(typesPackageTarLoc));
+      //   }
+      //   fs.writeFileSync(typesPackageTarLoc, tarballContents);
+      //   const typesPackageLoc = path.join(options.dir!, `.types/${typesPackageName}`);
+      //   await mkdirp(typesPackageLoc);
+      //   await tar.x({
+      //     file: typesPackageTarLoc,
+      //     cwd: typesPackageLoc,
+      //   });
+      // }
+    },
+  } as Plugin;
+}

--- a/skypack/src/util.ts
+++ b/skypack/src/util.ts
@@ -1,0 +1,250 @@
+import globalCacheDir from 'cachedir';
+import etag from 'etag';
+import findUp from 'find-up';
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+import path from 'path';
+
+export interface ImportMap {
+  imports: {[packageName: string]: string};
+}
+
+export const GLOBAL_CACHE_DIR = globalCacheDir('skypack');
+export const RESOURCE_CACHE = path.join(GLOBAL_CACHE_DIR, 'pkg-cache-3.0');
+export const SKYPACK_ORIGIN = `https://cdn.skypack.dev`;
+export const HAS_CDN_HASH_REGEX = /\-[a-zA-Z0-9]{16,}/;
+
+// A note on cache naming/versioning: We currently version our global caches
+// with the version of the last breaking change. This allows us to re-use the
+// same cache across versions until something in the data structure changes.
+// At that point, bump the version in the cache name to create a new unique
+// cache name.
+export const BUILD_CACHE = path.join(GLOBAL_CACHE_DIR, 'build-cache-2.7');
+
+const LOCKFILE_HASH_FILE = '.hash';
+
+// NOTE(fks): Must match empty script elements to work properly.
+export const HTML_JS_REGEX = /(<script.*?type="?module"?.*?>)(.*?)<\/script>/gms;
+export const CSS_REGEX = /@import\s*['"](.*)['"];/gs;
+export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gms;
+
+export const URL_HAS_PROTOCOL_REGEX = /^(\w+:)?\/\//;
+
+const UTF8_FORMATS = ['.css', '.html', '.js', '.map', '.mjs', '.json', '.svg', '.txt', '.xml'];
+export function getEncodingType(ext: string): 'utf-8' | undefined {
+  return UTF8_FORMATS.includes(ext) ? 'utf-8' : undefined;
+}
+
+export async function readLockfile(cwd: string): Promise<ImportMap | null> {
+  try {
+    var lockfileContents = fs.readFileSync(path.join(cwd, 'snowpack.lock.json'), {
+      encoding: 'utf-8',
+    });
+  } catch (err) {
+    // no lockfile found, ignore and continue
+    return null;
+  }
+  // If this fails, we actually do want to alert the user by throwing
+  return JSON.parse(lockfileContents);
+}
+
+export async function writeLockfile(loc: string, importMap: ImportMap): Promise<void> {
+  const sortedImportMap: ImportMap = {imports: {}};
+  for (const key of Object.keys(importMap.imports).sort()) {
+    sortedImportMap.imports[key] = importMap.imports[key];
+  }
+  fs.writeFileSync(loc, JSON.stringify(sortedImportMap, undefined, 2), {encoding: 'utf-8'});
+}
+
+export function isTruthy<T>(item: T | false | null | undefined): item is T {
+  return Boolean(item);
+}
+
+/** Get the package name + an entrypoint within that package (if given). */
+export function parsePackageImportSpecifier(imp: string): [string, string | null] {
+  const impParts = imp.split('/');
+  if (imp.startsWith('@')) {
+    const [scope, name, ...rest] = impParts;
+    return [`${scope}/${name}`, rest.join('/') || null];
+  }
+  const [name, ...rest] = impParts;
+  return [name, rest.join('/') || null];
+}
+
+/**
+ * Given a package name, look for that package's package.json manifest.
+ * Return both the manifest location (if believed to exist) and the
+ * manifest itself (if found).
+ *
+ * NOTE: You used to be able to require() a package.json file directly,
+ * but now with export map support in Node v13 that's no longer possible.
+ */
+export function resolveDependencyManifest(dep: string, cwd: string): [string | null, any | null] {
+  // Attempt #1: Resolve the dependency manifest normally. This works for most
+  // packages, but fails when the package defines an export map that doesn't
+  // include a package.json. If we detect that to be the reason for failure,
+  // move on to our custom implementation.
+  try {
+    const depManifest = require.resolve(`${dep}/package.json`, {paths: [cwd]});
+    return [depManifest, require(depManifest)];
+  } catch (err) {
+    // if its an export map issue, move on to our manual resolver.
+    if (err.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      return [null, null];
+    }
+  }
+
+  // Attempt #2: Resolve the dependency manifest manually. This involves resolving
+  // the dep itself to find the entrypoint file, and then haphazardly replacing the
+  // file path within the package with a "./package.json" instead. It's not as
+  // thorough as Attempt #1, but it should work well until export maps become more
+  // established & move out of experimental mode.
+  let result = [null, null] as [string | null, any | null];
+  try {
+    const fullPath = require.resolve(dep, {paths: [cwd]});
+    // Strip everything after the package name to get the package root path
+    // NOTE: This find-replace is very gross, replace with something like upath.
+    const searchPath = `${path.sep}node_modules${path.sep}${dep.replace('/', path.sep)}`;
+    const indexOfSearch = fullPath.lastIndexOf(searchPath);
+    if (indexOfSearch >= 0) {
+      const manifestPath =
+        fullPath.substring(0, indexOfSearch + searchPath.length + 1) + 'package.json';
+      result[0] = manifestPath;
+      const manifestStr = fs.readFileSync(manifestPath, {encoding: 'utf-8'});
+      result[1] = JSON.parse(manifestStr);
+    }
+  } catch (err) {
+    // ignore
+  } finally {
+    return result;
+  }
+}
+
+/**
+ * If Rollup erred parsing a particular file, show suggestions based on its
+ * file extension (note: lowercase is fine).
+ */
+export const MISSING_PLUGIN_SUGGESTIONS: {[ext: string]: string} = {
+  '.svelte':
+    'Try installing rollup-plugin-svelte and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+  '.vue':
+    'Try installing rollup-plugin-vue and adding it to Snowpack (https://www.snowpack.dev/#custom-rollup-plugins)',
+};
+
+export async function checkLockfileHash(dir: string) {
+  const lockfileLoc = await findUp(['package-lock.json', 'yarn.lock']);
+  if (!lockfileLoc) {
+    return true;
+  }
+  const hashLoc = path.join(dir, LOCKFILE_HASH_FILE);
+  const newLockHash = etag(await fs.promises.readFile(lockfileLoc, 'utf-8'));
+  const oldLockHash = await fs.promises.readFile(hashLoc, 'utf-8').catch(() => '');
+  return newLockHash === oldLockHash;
+}
+
+export async function updateLockfileHash(dir: string) {
+  const lockfileLoc = await findUp(['package-lock.json', 'yarn.lock']);
+  if (!lockfileLoc) {
+    return;
+  }
+  const hashLoc = path.join(dir, LOCKFILE_HASH_FILE);
+  const newLockHash = etag(await fs.promises.readFile(lockfileLoc));
+  await mkdirp(path.dirname(hashLoc));
+  await fs.promises.writeFile(hashLoc, newLockHash);
+}
+
+/**
+ * For the given import specifier, return an alias entry if one is matched.
+ */
+export function findMatchingAliasEntry(
+  alias: Record<string, string>,
+  spec: string,
+): {from: string; to: string; type: 'package' | 'path'} | undefined {
+  // Only match bare module specifiers. relative and absolute imports should not match
+  if (
+    spec === '.' ||
+    spec === '..' ||
+    spec.startsWith('./') ||
+    spec.startsWith('../') ||
+    spec.startsWith('/') ||
+    spec.startsWith('http://') ||
+    spec.startsWith('https://')
+  ) {
+    return undefined;
+  }
+
+  for (const [from, to] of Object.entries(alias)) {
+    let foundType: 'package' | 'path' = isPackageAliasEntry(to) ? 'package' : 'path';
+    const isExactMatch = spec === removeTrailingSlash(from);
+    const isDeepMatch = spec.startsWith(addTrailingSlash(from));
+    if (isExactMatch || isDeepMatch) {
+      return {
+        from,
+        to,
+        type: foundType,
+      };
+    }
+  }
+}
+
+/**
+ * For the given import specifier, return an alias entry if one is matched.
+ */
+export function isPackageAliasEntry(val: string): boolean {
+  return !path.isAbsolute(val);
+}
+
+/** Get full extensions of files */
+export function getExt(fileName: string) {
+  return {
+    /** base extension (e.g. `.js`) */
+    baseExt: path.extname(fileName).toLocaleLowerCase(),
+    /** full extension, if applicable (e.g. `.proxy.js`) */
+    expandedExt: path.basename(fileName).replace(/[^.]+/, '').toLocaleLowerCase(),
+  };
+}
+
+/** Replace file extensions */
+export function replaceExt(fileName: string, oldExt: string, newExt: string): string {
+  const extToReplace = new RegExp(`\\${oldExt}$`, 'i');
+  return fileName.replace(extToReplace, newExt);
+}
+
+/**
+ * Sanitizes npm packages that end in .js (e.g `tippy.js` -> `tippyjs`).
+ * This is necessary because Snowpack can’t create both a file and directory
+ * that end in .js.
+ */
+export function sanitizePackageName(filepath: string): string {
+  const dirs = filepath.split('/');
+  const file = dirs.pop() as string;
+  return [...dirs.map((path) => path.replace(/\.js$/i, 'js')), file].join('/');
+}
+
+// Source Map spec v3: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.lmz475t4mvbx
+
+/** CSS sourceMappingURL */
+export function cssSourceMappingURL(code: string, sourceMappingURL: string) {
+  return code + `/*# sourceMappingURL=${sourceMappingURL} */`;
+}
+
+/** JS sourceMappingURL */
+export function jsSourceMappingURL(code: string, sourceMappingURL: string) {
+  return code.replace(/\n*$/, '') + `\n//# sourceMappingURL=${sourceMappingURL}\n`; // strip ending lines & append source map (with linebreaks for safety)
+}
+
+export function removeLeadingSlash(path: string) {
+  return path.replace(/^[/\\]+/, '');
+}
+
+export function removeTrailingSlash(path: string) {
+  return path.replace(/[/\\]+$/, '');
+}
+
+export function addLeadingSlash(path: string) {
+  return path.replace(/^\/?/, '/');
+}
+
+export function addTrailingSlash(path: string) {
+  return path.replace(/\/?$/, '/');
+}

--- a/skypack/tsconfig.json
+++ b/skypack/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "lib",
+    "module": "commonjs",
+    "target": "es2018",
+    "moduleResolution": "node",
+    "declaration": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "sourceMap": true,
+    "noImplicitAny": false,
+    "skipLibCheck": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7571,7 +7571,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-got@^11.7.0:
+got@^11.1.4, got@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.0.tgz#be0920c3586b07fd94add3b5b27cb28f49e6545f"
   integrity sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==
@@ -9365,7 +9365,7 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kleur@^4.1.1, kleur@^4.1.3:
+kleur@^4.1.0, kleur@^4.1.1, kleur@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.3.tgz#8d262a56d79a137ee1b706e967c0b08a7fef4f4c"
   integrity sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw==
@@ -11027,7 +11027,7 @@ p-queue@^4.0.0:
   dependencies:
     eventemitter3 "^3.1.0"
 
-p-queue@^6.6.1:
+p-queue@^6.2.1, p-queue@^6.6.1:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
   integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==


### PR DESCRIPTION
```typescript

export { rollupPluginSkypack } from './rollup-plugin-remote-cdn';
export const SKYPACK_ORIGIN = 'https://cdn.skypack.dev';
export function generateImportMap(webDependencies: Record<string, string>, inheritFromImportMap?: ImportMap): Promise<ImportMap>;
export function fetchCDN(resourceUrl: string, userAgent?: string): Promise<{
    body: string;
    headers: IncomingHttpHeaders;
    statusCode: number;
    isCached: boolean;
    isStale: boolean;
}>;
export function buildNewPackage(spec: string, semverString?: string, userAgent?: string): Promise<BuildNewPackageResponse>;
export function lookupBySpecifier(spec: string, semverString?: string, userAgent?: string): Promise<LookupBySpecifierResponse>;
export function clearCache(): Promise<void[]>;
```

## Changes

- Adds a new Skypack library (SDK) for interacting with the Skypack CDN
- Makes integrations like a Rollup plugin, Webpack plugin, and an upcoming Snowpack integration much easier.

## Docs

- This won't be documented until it's ready for public use. The README reflects this experimental nature.

## Testing

- TODO, wanted feedback before adding tests.
- You can see it used in the updated wip-remote branch