### PR TITLE
docs(PULL_REQUEST_TEMPLATE): add "docs" section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,8 @@
 
 <!-- How was this change tested? -->
 <!-- DON'T DELETE THIS SECTION! If no tests were added, explain why. -->
+
+## Docs
+
+<!-- Have new features been added or existing behavior changed? Please state places the changes were documented -->
+<!-- DON'T DELETE THIS SECTION! If no docs were added, explain why (e.g. "bug fix only") -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@
 
 ## Docs
 
-<!-- List places where documentation was updated, if applicable -->
-<!-- DON'T DELETE THIS SECTION! If no docs were added, explain why (e.g. "bug fix only") -->
+<!-- List places where documentation was updated -->
+<!-- If no docs were added, explain why (e.g. "bug fix only") -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@
 
 ## Docs
 
-<!-- Have new features been added or existing behavior changed? Please state places the changes were documented -->
+<!-- List places where documentation was updated, if applicable -->
 <!-- DON'T DELETE THIS SECTION! If no docs were added, explain why (e.g. "bug fix only") -->


### PR DESCRIPTION
I love the simplicity of the pull request template. I was wondering if we should add a "docs" section to nudge us and every other contributor to remember to update documentation if applicable?