### PR TITLE
fix common react packages with broken "browser" entrypoint

### DIFF
--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -75,6 +75,10 @@ const CJS_PACKAGES_TO_AUTO_DETECT = [
   'react-table',
 ];
 
+// Rarely, a package will ship a broken "browser" package.json entrypoint.
+// Ignore the "browser" entrypoint in those packages.
+const BROKEN_BROWSER_ENTRYPOINT = ['@sheerun/mutationobserver-shim'];
+
 function isImportOfPackage(importUrl: string, packageName: string) {
   return packageName === importUrl || importUrl.startsWith(packageName + '/');
 }
@@ -154,8 +158,12 @@ function resolveWebDependency(dep: string, {cwd}: {cwd: string}): DependencyLoc 
   let foundEntrypoint: string =
     depManifest['browser:module'] ||
     depManifest.module ||
-    depManifest['main:esnext'] ||
-    depManifest.browser;
+    depManifest['main:esnext'];
+    
+  if (!foundEntrypoint && !BROKEN_BROWSER_ENTRYPOINT.includes(packageName)) {
+    foundEntrypoint = depManifest.browser;
+  }
+
   // Some packages define "browser" as an object. We'll do our best to find the
   // right entrypoint in an entrypoint object, or fail otherwise.
   // See: https://github.com/defunctzombie/package-browser-field-spec


### PR DESCRIPTION
## Changes

- Resolve issue brought up in https://github.com/pikapkg/snowpack/discussions/1160

## Testing

- Covered a bit by existing tests, and not worth a new test, imo.

## Docs

- n/a