### PR TITLE
Add "Installing Non-JS Packages" section back to the docs

### DIFF
--- a/docs/docs/04-features.md
+++ b/docs/docs/04-features.md
@@ -308,20 +308,3 @@ Note that `@snowpack/plugin-optimize` will optimize your build, but won't bundle
   "plugins": [["@snowpack/plugin-webpack", {/* ... */}]]
 }
 ```
-
-### Installing Non-JS Packages
-
-When installing packages from npm, You may encounter some non-JS code that can only run with additional parsing/processing. Svelte packages, for example, commonly include `.svelte` files that will require additional tooling to parse and install for the browser.
-
-Because our internal installer is powered by Rollup, you can add Rollup plugins to your [Snowpack config](#configuration-options) to handle these special, rare files:
-
-```js
-/* snowpack.config.js */
-module.exports = {
-  rollup: {
-    plugins: [require('rollup-plugin-svelte')()],
-  },
-};
-```
-
-Refer to [Rollup’s documentation on plugins](https://rollupjs.org/guide/en/#using-plugins) for more information.

--- a/docs/docs/04-features.md
+++ b/docs/docs/04-features.md
@@ -308,3 +308,20 @@ Note that `@snowpack/plugin-optimize` will optimize your build, but won't bundle
   "plugins": [["@snowpack/plugin-webpack", {/* ... */}]]
 }
 ```
+
+### Installing Non-JS Packages
+
+When installing packages from npm, You may encounter some non-JS code that can only run with additional parsing/processing. Svelte packages, for example, commonly include `.svelte` files that will require additional tooling to parse and install for the browser.
+
+Because our internal installer is powered by Rollup, you can add Rollup plugins to your [Snowpack config](#configuration-options) to handle these special, rare files:
+
+```js
+/* snowpack.config.js */
+module.exports = {
+  rollup: {
+    plugins: [require('rollup-plugin-svelte')()],
+  },
+};
+```
+
+Refer to [Rollup’s documentation on plugins](https://rollupjs.org/guide/en/#using-plugins) for more information.

--- a/docs/docs/09-troubleshooting.md
+++ b/docs/docs/09-troubleshooting.md
@@ -21,3 +21,20 @@ If you see this error message, that means that you've imported a file path not a
 This is usually seen when importing a named export from a package written in the older Common.js format. Snowpack will try to automatically scan and detect these named exports for legacy Common.js packages, but this is not always possible.
 
 **To solve this issue:** See our documentation on the ["namedExports"](#install-options) configuration option to resolve manually
+
+### Installing Non-JS Packages
+
+When installing packages from npm, you may encounter some file formats that can only run with additional parsing/processing. First check to see if there is a [Snowpack plugin for the type of file](#plugins).
+
+Because our internal installer is powered by Rollup, you can also add Rollup plugins to your [Snowpack config](#configuration-options) to handle these special, rare files:
+
+```js
+/* snowpack.config.js */
+module.exports = {
+  rollup: {
+    plugins: [require('rollup-plugin-sass')()],
+  },
+};
+```
+
+Refer to [Rollup’s documentation on plugins](https://rollupjs.org/guide/en/#using-plugins) for more information.


### PR DESCRIPTION
Tried to find latest version ([I think it is this](https://github.com/pikapkg/snowpack/blob/e4d86c7c04d342020a6a39a6bd8c61e23888afac/docs/04-advanced-usage.md)). This will fix issue #1124. Needs review since this information may be outdated but this will fix the broken link. 

## Changes
- Adds "Installing Non-JS Packages" section back to the docs

## Testing
Docs only

## Docs
Docs only
