### PR TITLE
partition the build cache

### DIFF
--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -260,18 +260,22 @@ class FileBuilder {
     }
   }
 
-  async writeProxyToDisk(originalFileLoc: string) {
+  async getProxy(originalFileLoc: string) {
     const proxiedCode = this.output[originalFileLoc];
-    const importProxyFileLoc = originalFileLoc + '.proxy.js';
     const proxiedUrl = originalFileLoc
       .substr(this.config.devOptions.out.length)
       .replace(/\\/g, '/');
-    const proxyCode = await wrapImportProxy({
+    return wrapImportProxy({
       url: proxiedUrl,
       code: proxiedCode,
       hmr: false,
       config: this.config,
     });
+  }
+
+  async writeProxyToDisk(originalFileLoc: string) {
+    const proxyCode = await this.getProxy(originalFileLoc);
+    const importProxyFileLoc = originalFileLoc + '.proxy.js';
     await fs.writeFile(importProxyFileLoc, proxyCode, 'utf-8');
   }
 }


### PR DESCRIPTION
## Changes

- Supports SSR + non-SSR caching, even though file results differ
- Supports test + dev + build caching, even though file results differ
- required by both #1052 and #1036 

## Testing

- Covered by current tests, and tested manually.
- Testing the steps/workflow to set/clear/update files in the cache is outside the scope of our current test suite.

## Docs

- Not needed.