### PR TITLE
chore: update tailwind import path

### DIFF
--- a/docs/docs/08-guides.md
+++ b/docs/docs/08-guides.md
@@ -101,9 +101,9 @@ You can add [Tailwind](https://tailwindcss.com) to any project via native CSS `@
 
 ```css
 /* index.css */
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import 'tailwindcss/dist/base.css';
+@import 'tailwindcss/dist/components.css';
+@import 'tailwindcss/dist/utilities.css';
 ```
 
 #### Using PostCSS

--- a/docs/docs/08-guides.md
+++ b/docs/docs/08-guides.md
@@ -101,9 +101,9 @@ You can add [Tailwind](https://tailwindcss.com) to any project via native CSS `@
 
 ```css
 /* index.css */
-@import 'tailwindcss/dist/base.css';
-@import 'tailwindcss/dist/components.css';
-@import 'tailwindcss/dist/utilities.css';
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 ```
 
 #### Using PostCSS

--- a/docs/docs/08-guides.md
+++ b/docs/docs/08-guides.md
@@ -106,9 +106,9 @@ You can add [Tailwind](https://tailwindcss.com) to any project via native CSS `@
 @import 'tailwindcss/dist/utilities.css';
 ```
 
-#### Using PostCSS
+#### Using Tailwind with PostCSS
 
-Tailwind also ships with first-class support for PostCSS. If you are using PostCSS in your project ([see above](#postcss)) then you can just add the Tailwind PostCSS plugin to your PostCSS config file to take advantage of the `@tailwind` keyword.
+If you are using PostCSS in your project ([see above](#postcss)) then you can just add Tailwind as a plugin to your `postcss.config.js`:
 
 ```js
 // postcss.config.js
@@ -121,6 +121,14 @@ module.exports = {
     // ...
   ],
 };
+```
+
+And import Tailwind's `base`, `components`, and `utilities` styles into your CSS:
+```css
+/* index.css */
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 ```
 
 Follow the official [Tailwind CSS Docs](https://tailwindcss.com/docs/installation/#using-tailwind-with-postcss) for more information.

--- a/docs/docs/08-guides.md
+++ b/docs/docs/08-guides.md
@@ -123,12 +123,16 @@ module.exports = {
 };
 ```
 
-And import Tailwind's `base`, `components`, and `utilities` styles into your CSS:
-```css
+Once you have added the Tailwind PostCSS plugin, you can replace your native CSS `dist` imports with Tailwind's more powerful `base`, `components`, and `utilities` imports:
+
+```diff
 /* index.css */
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+- @import 'tailwindcss/dist/base.css';
+- @import 'tailwindcss/dist/components.css';
+- @import 'tailwindcss/dist/utilities.css';
++ @import 'tailwindcss/base';
++ @import 'tailwindcss/components';
++ @import 'tailwindcss/utilities';
 ```
 
 Follow the official [Tailwind CSS Docs](https://tailwindcss.com/docs/installation/#using-tailwind-with-postcss) for more information.


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
I removed the `dist`-part from the Tailwind CSS imports because otherwise purging and plugins are not working.

## Testing

<!-- How was this change tested? -->
I used a markdown view to take a look at my changes.

## Docs

<!-- Was public documentation updated? -->
Yes, because this is an update of the public documentation.
