### PR TITLE
feat: allow configuring the top level `this` value

### DIFF
--- a/docs/docs/10-reference.md
+++ b/docs/docs/10-reference.md
@@ -149,6 +149,7 @@ Options:
   - Snowpack uses Rollup internally to install your packages. This `rollup` config option gives you deeper control over the internal rollup configuration that we use.
   - **`installOptions.rollup.plugins`** - Specify [Custom Rollup plugins](#installing-non-js-packages) if you are dealing with non-standard files.
   - **`installOptions.rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve#usage) for more documentation.
+  - **`installOptions.rollup.context`** - Specify top-level `this` value.
 
 #### `config.devOptions`
 

--- a/docs/docs/10-reference.md
+++ b/docs/docs/10-reference.md
@@ -149,7 +149,7 @@ Options:
   - Snowpack uses Rollup internally to install your packages. This `rollup` config option gives you deeper control over the internal rollup configuration that we use.
   - **`installOptions.rollup.plugins`** - Specify [Custom Rollup plugins](#installing-non-js-packages) if you are dealing with non-standard files.
   - **`installOptions.rollup.dedupe`** - If needed, deduplicate multiple versions/copies of a packages to a single one. This helps prevent issues with some packages when multiple versions are installed from your node_modules tree. See [rollup-plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve#usage) for more documentation.
-  - **`installOptions.rollup.context`** - Specify top-level `this` value.
+  - **`installOptions.rollup.context`** - Specify top-level `this` value. Useful to silence install errors caused by legacy common.js packages that reference a top-level this variable, which does not exist in a pure ESM environment.
 
 #### `config.devOptions`
 

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -229,6 +229,7 @@ interface InstallOptions {
   externalPackage: string[];
   namedExports: string[];
   rollup: {
+    context?: string;
     plugins?: RollupPlugin[]; // for simplicity, only Rollup plugins are supported for now
     dedupe?: string[];
   };
@@ -351,6 +352,9 @@ ${colors.dim(
   let isFatalWarningFound = false;
   const inputOptions: InputOptions = {
     input: installEntrypoints,
+    ...(userDefinedRollup.context && {
+      context: userDefinedRollup.context,
+    }),
     external: (id) => externalPackages.some((packageName) => isImportOfPackage(id, packageName)),
     treeshake: {moduleSideEffects: 'no-external'},
     plugins: [

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -352,9 +352,7 @@ ${colors.dim(
   let isFatalWarningFound = false;
   const inputOptions: InputOptions = {
     input: installEntrypoints,
-    ...(userDefinedRollup.context && {
-      context: userDefinedRollup.context,
-    }),
+    context: userDefinedRollup.context,
     external: (id) => externalPackages.some((packageName) => isImportOfPackage(id, packageName)),
     treeshake: {moduleSideEffects: 'no-external'},
     plugins: [

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -123,6 +123,7 @@ const configSchema = {
         rollup: {
           type: 'object',
           properties: {
+            context: {type: 'string'},
             plugins: {type: 'array', items: {type: 'object'}},
             dedupe: {
               type: 'array',


### PR DESCRIPTION
Hi. This annoyed me a bit (I hate warnings in logs ;-)). Not sure if this is the most appropriate way of solving this but it does get the job done ...

## Changes

<!-- What does this change, in plain language? -->
Expose the `context` configuration option from rollup. Using this configuration, one can e.g. specify the context as `window`. This helps to get rid of the `'this' keyword is equivalent to 'undefined'` warnings when using packages that for one reason or another have that in their esm output.

## Testing

Install and use a package that directly references `this` in the global scope, e.g. `@xstate/inspect`.

Before this change, it would report `node_modules/@xstate/inspect/es/index.js:1:16 The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`.

After this change, you can specify `context: 'window'` in your snowpack config, eliminating this warning.