### PR TITLE
simplify svelte plugin

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -45,17 +45,10 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
           })
         ).code;
       }
-      // COMPILE
-      const ssrOptions = {};
-      if (isSSR) {
-        ssrOptions.generate = 'ssr';
-        ssrOptions.hydratable = true;
-        ssrOptions.css = true;
-      }
 
       const {js, css} = svelte.compile(codeToCompile, {
         ...svelteOptions,
-        ...ssrOptions,
+        generate: isSSR ? 'ssr' : 'dom',
         outputFilename: filePath,
         filename: filePath,
       });


### PR DESCRIPTION
## Changes

Doesn't change any functionality, just tidies up the Svelte plugin a tiny bit. Previously in SSR mode, the plugin was setting `hydratable: true` and `css: true`, but these options have no effect in SSR mode. We can therefore get rid of `ssrOptions` altogether and just toggle the `generate` option.

## Testing

Tested manually with a local project

## Docs

N/A
