### PR TITLE
fix svelte template

### DIFF
--- a/create-snowpack-app/app-template-svelte/src/App.svelte
+++ b/create-snowpack-app/app-template-svelte/src/App.svelte
@@ -1,6 +1,15 @@
 <script>
-  $: count = 0;
-  setInterval(() => count++, 1000);
+  import { onMount } from 'svelte'
+
+  let count = 0
+
+  onMount(() => {
+    const interval = setInterval(() => count++, 1000);
+    return () => {
+      clearInterval(interval)
+    }
+  })
+
   const message = 'Learn Svelte';
 </script>
 


### PR DESCRIPTION
## Changes

Fixes component lifecycle and HMR.

A `setInterval` requires a `clearInterval` when the component is destroyed, or they will add up and keep running forever. In the case of the root component, this is not obviously visible, but it becomes so with HMR since the component will be created and created again.

The following reactive declaration is a bit nonsensical (akin to "each time nothing changes, set count to 0") but it breaks HMR state preservation because reactive blocks are recomputed after HMR (hence the count is reset to 0 in this case).

```svelte
$: count = 0
```

## Testing

just a refactor, functionality is not expected to have changed

## Docs

bug fix only