### PR TITLE
add bubbled esm-hmr property

### DIFF
--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -110,7 +110,7 @@ export function createHotContext(fullUrl) {
 }
 
 /** Called when a new module is loaded, to pass the updated module to the "active" module */
-async function runModuleAccept(id) {
+async function runModuleAccept({url: id, bubbled}) {
   const state = REGISTERED_MODULES[id];
   if (!state) {
     return false;
@@ -125,7 +125,7 @@ async function runModuleAccept(id) {
       import(id + `?mtime=${updateID}`),
       ...deps.map((d) => import(d + `?mtime=${updateID}`)),
     ]);
-    acceptCallback({module, deps: depModules});
+    acceptCallback({module, bubbled, deps: depModules});
   }
   return true;
 }
@@ -165,7 +165,7 @@ socket.addEventListener('message', ({data: _data}) => {
   }
   if (data.type === 'update') {
     log('message: update', data);
-    runModuleAccept(data.url)
+    runModuleAccept(data)
       .then((ok) => {
         if (ok) {
           clearErrorOverlay();

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -970,11 +970,12 @@ export async function startServer(commandOptions: CommandOptions) {
     if (visited.has(url)) {
       return;
     }
-    visited.add(url);
     const node = hmrEngine.getEntry(url);
+    const isBubbled = visited.size > 0;
     if (node && node.isHmrEnabled) {
-      hmrEngine.broadcastMessage({type: 'update', url});
+      hmrEngine.broadcastMessage({type: 'update', url, bubbled: isBubbled});
     }
+    visited.add(url);
     if (node && node.isHmrAccepted) {
       // Found a boundary, no bubbling needed
     } else if (node && node.dependents.size > 0) {

--- a/snowpack/src/hmr-server-engine.ts
+++ b/snowpack/src/hmr-server-engine.ts
@@ -14,7 +14,7 @@ interface Dependency {
 
 type HMRMessage =
   | {type: 'reload'}
-  | {type: 'update'; url: string}
+  | {type: 'update'; url: string; bubbled: boolean;}
   | {
       type: 'error';
       title: string;


### PR DESCRIPTION
## Changes

- Adds `bubbled` property to accept HMR callback, defined here: https://github.com/pikapkg/esm-hmr/issues/13
- Allows svelte-hmr to make better CSS upgrades

## Testing

- Tested manually
- TODO: @rixo to test manually in #1223 (Update: done)

## Docs

- Once this is merged, I'll push a big update to `esm-hmr` repo with all of our latest changes (that repo has fallen out of date compared to Snowpack).