### PR TITLE
add option to show hmr error overlay, update docs

### DIFF
--- a/docs/docs/10-reference.md
+++ b/docs/docs/10-reference.md
@@ -188,6 +188,8 @@ Options:
   - The hostname where the browser tab will be open.
 - **`devOptions.hmr`** | `boolean` | Default: `true`
   - Toggles whether or not Snowpack dev server should have HMR enabled.
+- **`devOptions.hmrErrorOverlay`** | `boolean` | Default: `true`
+  - When HMR is enabled, toggles whether or not a browser overlay should display javascript errors.
 - **`devOptions.secure`** | `boolean`
   - Toggles whether or not Snowpack dev server should use HTTPS with HTTP2 enabled.
 

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -75,7 +75,10 @@ export function wrapHtmlResponse({
   });
 
   if (hmr) {
-    const hmrScript = `<script type="module" src="${getMetaUrlPath('hmr-client.js', config)}"></script><script type="module" src="${getMetaUrlPath('hmr-error-overlay.js', config)}"></script>`;
+    let hmrScript = `<script type="module" src="${getMetaUrlPath('hmr-client.js', config)}"></script>`;
+    if (config.devOptions.hmrErrorOverlay) {
+      hmrScript += `<script type="module" src="${getMetaUrlPath('hmr-error-overlay.js', config)}"></script>`;
+    }
     code = appendHtmlToHead(code, hmrScript);
   }
   return code;

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -50,6 +50,7 @@ const DEFAULT_CONFIG: Partial<SnowpackConfig> = {
     fallback: 'index.html',
     hmrDelay: 0,
     hmrPort: 12321,
+    hmrErrorOverlay: true,
   },
   buildOptions: {
     baseUrl: '/',
@@ -97,6 +98,7 @@ const configSchema = {
         hmr: {type: 'boolean'},
         hmrDelay: {type: 'number'},
         hmrPort: {type: 'number'},
+        hmrErrorOverlay: {type: 'boolean'},
       },
     },
     installOptions: {

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -138,6 +138,7 @@ export interface SnowpackConfig {
     hmr?: boolean;
     hmrDelay: number;
     hmrPort: number;
+    hmrErrorOverlay: boolean;
   };
   installOptions: InstallOptions;
   buildOptions: {


### PR DESCRIPTION
## Changes

Adds a `devOptions.hmrErrorOverlay` option for disabling the new error overlay. From discussion: https://github.com/pikapkg/snowpack/discussions/1229
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Ran `snowpack dev --reload` with this in package.json 
```
"snowpack": {
    "devOptions": {
        "hmr": true,
        "hmrErrorOverlay": false,
    }
}
```

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Added an entry into the reference section

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
