### PR TITLE
Recovers webpack magic comments and adds to import

### DIFF
--- a/snowpack/src/rewrite-imports.ts
+++ b/snowpack/src/rewrite-imports.ts
@@ -4,6 +4,8 @@ import {matchDynamicImportValue} from './scan-imports';
 
 const {parse} = require('es-module-lexer');
 
+const WEBPACK_MAGIC_COMMENT_REGEX = /\/\*[\s\S]*?\*\//g;
+
 function spliceString(source: string, withSlice: string, start: number, end: number) {
   return source.slice(0, start) + (withSlice || '') + source.slice(end);
 }
@@ -32,12 +34,17 @@ export async function transformEsmImports(
   let rewrittenCode = _code;
   for (const imp of imports.reverse()) {
     let spec = rewrittenCode.substring(imp.s, imp.e);
+    let webpackMagicCommentMatches;
     if (imp.d > -1) {
+      // Extracting comments from spec as they are stripped in `matchDynamicImportValue`
+      webpackMagicCommentMatches = spec.match(WEBPACK_MAGIC_COMMENT_REGEX);
       spec = matchDynamicImportValue(spec) || '';
     }
     let rewrittenImport = replaceImport(spec);
     if (imp.d > -1) {
-      rewrittenImport = JSON.stringify(rewrittenImport);
+        rewrittenImport = webpackMagicCommentMatches
+          ? `${webpackMagicCommentMatches.join(' ')} ${JSON.stringify(rewrittenImport)}`
+          : JSON.stringify(rewrittenImport);
     }
     rewrittenCode = spliceString(rewrittenCode, rewrittenImport, imp.s, imp.e);
   }

--- a/test/build/__snapshots__/build.test.js.snap
+++ b/test/build/__snapshots__/build.test.js.snap
@@ -602,7 +602,7 @@ import def, {
     all/* , */,
 } from '../web_modules/async.js';
 console.log(def, waterfall, all);
-import(\\"../web_modules/array-flatten.js\\")"
+import(/* webpackChunkName: \\"array-flatten\\" */ \\"../web_modules/array-flatten.js\\")"
 `;
 
 exports[`snowpack build config-treeshake: allFiles 1`] = `


### PR DESCRIPTION
This is my first contribution to snowpack. Please, let me know if there is anything missing from this PR. 🙇‍♂️ 

## Changes
https://github.com/pikapkg/snowpack/blob/b21848be11041ad87656617b6b56a5084023e054/snowpack/src/rewrite-imports.ts#L36
`matchDynamicImportValue` strips the magic comments and the result spec is passed to the `replaceImport` handler.

The process begins in the `buildFile` method of the build command:
https://github.com/pikapkg/snowpack/blob/75ad50315d18d7d4deac0c6efc649b2b650282a8/snowpack/src/commands/build.ts#L195

This PR extracts Webpack's magic comments from dynamic imports before the spec is passed to `matchDynamicImportValue`. If a match is found for these types of comments, they are appended to the rewritten import.

## Testing
All tests pass locally. The snapshot for `build.test.js` has been updated. Please, review this change as I am not sure if will affect snowpack's treeshaking logic.

## Docs
No docs were added for this change.
