### PR TITLE
fix: do not assume a build script failed completely if there's stderr

### DIFF
--- a/plugins/plugin-build-script/plugin.js
+++ b/plugins/plugin-build-script/plugin.js
@@ -29,11 +29,9 @@ function buildScriptPlugin(_, {input, output, cmd}) {
       if (exitCode !== 0) {
         throw new Error(stderr || stdout);
       }
-      // If the plugin output tp stderr, how it to the user.
-      if (stderr) {
-        throw new Error(stderr);
-      }
-      return {[output[0]]: stdout};
+
+      const output = [stderr, stdout].filter((value) => !!value).join('\n\n');
+      return {[output[0]]: output};
     },
   };
 }

--- a/plugins/plugin-build-script/plugin.js
+++ b/plugins/plugin-build-script/plugin.js
@@ -29,9 +29,11 @@ function buildScriptPlugin(_, {input, output, cmd}) {
       if (exitCode !== 0) {
         throw new Error(stderr || stdout);
       }
-
-      const output = [stderr, stdout].filter((value) => !!value).join('\n\n');
-      return {[output[0]]: output};
+      // If the plugin outputs to stderr, show it to the user.
+      if (stderr) {
+        console.warn(stderr);
+      }
+      return {[output[0]]: stdout};
     },
   };
 }


### PR DESCRIPTION
Using experimental features in tailwindcss currently causes build failures in the snowpack-build-script plugin because it considers any stderr output as a critical failure of the script.

I've also opened an issue on the tailwind repository: https://github.com/tailwindlabs/tailwindcss/issues/2522