### PR TITLE
Fix bad async sass test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "publish": "npm run build && lerna publish --no-private",
     "format": "prettier --write '{snowpack,esinstall}/src/**/*.{ts,js}' '{test,plugins}/**/*.{ts,js}' '*.{js,json,md}' '**/*.{json,md}' '.github/**/*.{md,yml}' '!**/{_dist_,build,packages,pkg,TEST_BUILD_OUT,web_modules}/**' !test/create-snowpack-app/test-install",
     "test": "jest /test/ --test-timeout=30000",
-    "test:docs": "cd docs && yarn && yarn docs:build && jest /__test__/"
+    "test:docs": "cd www && yarn && yarn build && jest /__test__/"
   },
   "workspaces": [
     "create-snowpack-app/*",

--- a/plugins/plugin-sass/test/plugin.test.js
+++ b/plugins/plugin-sass/test/plugin.test.js
@@ -45,6 +45,6 @@ describe('plugin-sass', () => {
   test('uses native sass CLI when native option = true', async () => {
     const p = plugin(null, {native: true});
     process.env.PATH = '';
-    expect(p.load({filePath: pathToSassApp, isDev: false})).rejects.toThrow('EPIPE');
+    await expect(p.load({filePath: pathToSassApp, isDev: false})).rejects.toThrow(/(EPIPE|'sass' is not recognized)/);
   });
 });

--- a/plugins/plugin-sass/test/plugin.test.js
+++ b/plugins/plugin-sass/test/plugin.test.js
@@ -45,6 +45,6 @@ describe('plugin-sass', () => {
   test('uses native sass CLI when native option = true', async () => {
     const p = plugin(null, {native: true});
     process.env.PATH = '';
-    await expect(p.load({filePath: pathToSassApp, isDev: false})).rejects.toThrow(/(EPIPE|'sass' is not recognized)/);
+    await expect(p.load({filePath: pathToSassApp, isDev: false})).rejects.toThrow(/(EPIPE|ENOENT)/);
   });
 });

--- a/plugins/plugin-sass/test/plugin.test.js
+++ b/plugins/plugin-sass/test/plugin.test.js
@@ -17,7 +17,7 @@ describe('plugin-sass', () => {
 
   test('throws an error when stderr output is returned', async () => {
     const p = plugin(null, {});
-    expect(p.load({filePath: pathToBadCode, isDev: false})).rejects.toThrow(
+    await expect(p.load({filePath: pathToBadCode, isDev: false})).rejects.toThrow(
       'Command failed with exit code',
     );
   });


### PR DESCRIPTION
## Changes

Two test problems fixed here:
1. async `expect` tests weren't being awaited
2. the "sass CLI is missing" warning was different on windows than unix

The result was that windows tests were breaking, but with the wrong test being marked as "broken".

Update: Added a fast follow from #1250 which didn't have CI due to a vercel config change

## Testing

- Test fixes.

## Docs

- N/A
