### PR TITLE
typo(docs): Adds one bracket to a javascript example

### DIFF
--- a/docs/04-features.md
+++ b/docs/04-features.md
@@ -6,7 +6,7 @@ Snowpack was designed to support JavaScript's native ES Module (ESM) syntax. ESM
 
 ```js
 // ESM Example - src/user.js
-export function getUser() { /* ... */
+export function getUser() { /* ... */ }
 
 // src/index.js
 import {getUser} from './user.js';


### PR DESCRIPTION
## Changes

The JavaScript example had a typo that made it invalid JavaScript, 
thus adding back the bracket to fixed the mistake

![image](https://user-images.githubusercontent.com/7430964/95560699-ed804a00-0a19-11eb-8b9b-e4289b4501d1.png)

## Testing

Building the documentation and see that the mistake is gone

## Docs

Documentation was changed by fixing 
