### PR TITLE
improve sass partial matching

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -5,6 +5,10 @@ const npmRunPath = require('npm-run-path');
 
 const IMPORT_REGEX = /\@(use|import)\s*['"](.*?)['"]/g;
 
+function stripFileExtension(filename) {
+  return filename.split('.').slice(0, -1).join('.');
+}
+
 function scanSassImports(fileContents, filePath, fileExt) {
   // TODO: Replace with matchAll once Node v10 is out of TLS.
   // const allMatches = [...result.matchAll(new RegExp(HTML_JS_REGEX))];
@@ -19,28 +23,21 @@ function scanSassImports(fileContents, filePath, fileExt) {
     .map((match) => match[2])
     .filter((s) => s.trim())
     .map((s) => {
-      // Inherit the default file extension of the importer. This is a cheap
-      // but effective shortcut to supporting both ".scss" and ".sass"
-      // since users rarely mix both, and performing multiple lookups
-      // would be too expensive.
-      if (!path.extname(s)) {
-        s += fileExt;
-      }
       return path.resolve(path.dirname(filePath), s);
     });
 }
 
 module.exports = function postcssPlugin(_, {native}) {
+
+  /** A map of partially resolved imports to the files that imported them. */
   const importedByMap = new Map();
 
-  function addImportsToMap(filePath, sassImports) {
-    for (const imported of sassImports) {
-      const importedBy = importedByMap.get(imported);
-      if (importedBy) {
-        importedBy.add(filePath);
-      } else {
-        importedByMap.set(imported, new Set([filePath]));
-      }
+  function addImportsToMap(filePath, sassImport) {
+    const importedBy = importedByMap.get(sassImport);
+    if (importedBy) {
+      importedBy.add(filePath);
+    } else {
+      importedByMap.set(sassImport, new Set([filePath]));
     }
   }
 
@@ -50,15 +47,38 @@ module.exports = function postcssPlugin(_, {native}) {
       input: ['.scss', '.sass'],
       output: ['.css'],
     },
-    /** when a file changes, also mark it's importers as changed. */
-    onChange({filePath}) {
-      const importedBy = importedByMap.get(filePath);
-      if (!importedBy) {
-        return;
+    /**
+     * If any files imported the given file path, mark them as changed.
+     * @private
+     */
+    _markImportersAsChanged(filePath) {
+      if (importedByMap.has(filePath)) {
+        const importedBy = importedByMap.get(filePath);
+        importedByMap.delete(filePath);
+        for (const importerFilePath of importedBy) {
+          this.markChanged(importerFilePath);
+        }
       }
-      importedByMap.delete(filePath);
-      for (const importerFilePath of importedBy) {
-        this.markChanged(importerFilePath);
+    },
+    /** 
+     * When a file changes, also mark it's importers as changed.
+     * Note that Sass has very lax matching of imports -> files.
+     * Follow these rules to find a match: https://sass-lang.com/documentation/at-rules/use
+     */
+    onChange({filePath}) {
+      const filePathNoExt = stripFileExtension(filePath);
+      // check exact: "_index.scss" (/a/b/c/foo/_index.scss)
+      this._markImportersAsChanged(filePath);
+      // check no ext: "_index" (/a/b/c/foo/_index)
+      this._markImportersAsChanged(filePathNoExt);
+      // check no underscore: "index.scss" (/a/b/c/foo/index.scss)
+      this._markImportersAsChanged(filePath.replace(/([\\\/])_/, '$1'));
+      // check no ext, no underscore: "index" (/a/b/c/foo/index)
+      this._markImportersAsChanged(filePathNoExt.replace(/([\\\/])_/, '$1'));
+      // check folder import: "foo" (/a/b/c/foo)
+      if (filePathNoExt.endsWith('_index')) {
+        const folderPathNoIndex = filePathNoExt.substring(0, filePathNoExt.length - 7);
+        this._markImportersAsChanged(folderPathNoIndex);
       }
     },
     /** Load the Sass file and compile it to CSS. */
@@ -68,7 +88,7 @@ module.exports = function postcssPlugin(_, {native}) {
       // During development, we need to track changes to Sass dependencies.
       if (isDev) {
         const sassImports = scanSassImports(contents, filePath, fileExt);
-        addImportsToMap(filePath, sassImports);
+        sassImports.forEach((imp) => addImportsToMap(filePath, imp));
       }
       // If file is `.sass`, use YAML-style. Otherwise, use default.
       const args = ['--stdin', '--load-path', path.dirname(filePath)];

--- a/plugins/plugin-sass/test/fixtures/sass/App.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/App.sass
@@ -1,4 +1,8 @@
 @use 'base'
+@use 'folder'
+
+body
+    font-family: folder.$font-stack
 
 .App 
   text-align: center

--- a/plugins/plugin-sass/test/fixtures/sass/_base.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/_base.sass
@@ -1,0 +1,2 @@
+// _base.scss
+$primary-color: #333

--- a/plugins/plugin-sass/test/fixtures/sass/base.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/base.sass
@@ -1,6 +1,0 @@
-// _base.scss
-$font-stack: Helvetica, sans-serif
-$primary-color: #333
-
-body
-    font-family: $font-stack

--- a/plugins/plugin-sass/test/fixtures/sass/folder/_index.sass
+++ b/plugins/plugin-sass/test/fixtures/sass/folder/_index.sass
@@ -1,0 +1,2 @@
+// folder/_index.sass
+$font-stack: Helvetica, sans-serif

--- a/plugins/plugin-sass/test/fixtures/scss/App.scss
+++ b/plugins/plugin-sass/test/fixtures/scss/App.scss
@@ -1,4 +1,10 @@
 @use 'base';
+@use 'folder';
+
+
+body {
+  font-family: folder.$font-stack;
+}
 
 .App {
   text-align: center;

--- a/plugins/plugin-sass/test/fixtures/scss/_base.scss
+++ b/plugins/plugin-sass/test/fixtures/scss/_base.scss
@@ -1,0 +1,2 @@
+// _base.scss
+$primary-color: #333;

--- a/plugins/plugin-sass/test/fixtures/scss/base.scss
+++ b/plugins/plugin-sass/test/fixtures/scss/base.scss
@@ -1,7 +1,0 @@
-// _base.scss
-$font-stack:    Helvetica, sans-serif;
-$primary-color: #333;
-
-body {
-    font-family: $font-stack;
-}

--- a/plugins/plugin-sass/test/fixtures/scss/folder/_index.scss
+++ b/plugins/plugin-sass/test/fixtures/scss/folder/_index.scss
@@ -1,0 +1,2 @@
+// folder/_index.scss
+$font-stack:    Helvetica, sans-serif;


### PR DESCRIPTION
## Changes

- Resolves #1271
- We now match more flexible Sass imports, including those with `_` (partials) and folders (`foo/_index`) 
- partials are also never meant to be built directly, so skip them in the final build.
- /cc @heikkilamarko 

## Testing

- Tests updated.
- Confirmed working in https://github.com/heikkilamarko/mobx-lit-html-app

## Docs

- Not needed.