### PR TITLE
feat: check if preact is being used in tsx

### DIFF
--- a/snowpack/src/plugins/plugin-esbuild.ts
+++ b/snowpack/src/plugins/plugin-esbuild.ts
@@ -9,7 +9,7 @@ let esbuildService: Service | null = null;
 
 const IS_PREACT = /from\s+['"]preact['"]/;
 function checkIsPreact(filePath: string, contents: string) {
-  return filePath.endsWith('.jsx') && IS_PREACT.test(contents);
+  return (filePath.endsWith('.jsx') || filePath.endsWith('.tsx')) && IS_PREACT.test(contents);
 }
 
 function getLoader(filePath: string): 'js' | 'jsx' | 'ts' | 'tsx' {


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Fixes `checkIsPreact` returning false for `.tsx`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Only tested on my own Preact template.

It *should* work with the official TS template, though there might be a need for a separate PR that removes `@babel/preset-react` from the config.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Not needed.
