### PR TITLE
[plugin-svelte] reveal `config` option

### DIFF
--- a/plugins/plugin-svelte/README.md
+++ b/plugins/plugin-svelte/README.md
@@ -17,7 +17,13 @@ npm install --save-dev @snowpack/plugin-svelte
 
 ## Plugin Options
 
-- `config: string` - relative URL from working directory to `svelte.config.js`. Defaults to project root directory. 
+- `configFilePath: string` - relative URL to Svelte config, usually named `svelte.config.js`. Defaults to `svelte.config.js` in project root directory. 
+```js
+// Example usage
+   ...
+   ["@snowpack/plugin-svelte", { configFilePath: './dir/svelte.config.js' }]
+   ...
+```
 
 This plugin also supports all Svelte compiler options. See [here](https://svelte.dev/docs#svelte_compile) for a list of supported options.
 

--- a/plugins/plugin-svelte/README.md
+++ b/plugins/plugin-svelte/README.md
@@ -17,7 +17,7 @@ npm install --save-dev @snowpack/plugin-svelte
 
 ## Plugin Options
 
-- `config: string` - relative URL from working directory to `svelte.config.js`
+- `config: string` - relative URL from working directory to `svelte.config.js`. Defaults to project root directory. 
 
 This plugin also supports all Svelte compiler options. See [here](https://svelte.dev/docs#svelte_compile) for a list of supported options.
 

--- a/plugins/plugin-svelte/README.md
+++ b/plugins/plugin-svelte/README.md
@@ -17,6 +17,8 @@ npm install --save-dev @snowpack/plugin-svelte
 
 ## Plugin Options
 
+- `config: string` - relative URL from working directory to `svelte.config.js`
+
 This plugin also supports all Svelte compiler options. See [here](https://svelte.dev/docs#svelte_compile) for a list of supported options.
 
 ### HMR Options

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -17,23 +17,25 @@ module.exports = function plugin(snowpackConfig, {hot: hotOptions, ...sveltePlug
     svelteRollupPlugin({include: '**/node_modules/**', dev: isDev}),
   );
 
-  let svelteOptions;
+  let {config = '.', ...svelteOptions} = sveltePluginOptions || {};
+  let userSvelteOptions;
   let preprocessOptions;
-  // Note(drew): __config is for internal testing use; maybe we should make this public at some point?
-  const userSvelteConfigLoc =
-    sveltePluginOptions.__config || path.join(process.cwd(), 'svelte.config.js');
+
+  const userSvelteConfigLoc = path.resolve(process.cwd(), `${config}/svelte.config.js`);
+  
   if (fs.existsSync(userSvelteConfigLoc)) {
     const userSvelteConfig = require(userSvelteConfigLoc);
     const {preprocess, ..._svelteOptions} = userSvelteConfig;
     preprocessOptions = preprocess;
-    svelteOptions = _svelteOptions;
+    userSvelteOptions = _svelteOptions;
   }
+  
   // Generate svelte options from user provided config (if given)
   svelteOptions = {
     dev: isDev,
     css: false,
+    ...userSvelteOptions,
     ...svelteOptions,
-    ...sveltePluginOptions,
   };
 
   return {

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -17,17 +17,20 @@ module.exports = function plugin(snowpackConfig, {hot: hotOptions, ...sveltePlug
     svelteRollupPlugin({include: '**/node_modules/**', dev: isDev}),
   );
 
-  let {config = '.', ...svelteOptions} = sveltePluginOptions || {};
+  let {configFilePath = 'svelte.config.js', ...svelteOptions} = sveltePluginOptions || {};
   let userSvelteOptions;
   let preprocessOptions;
 
-  const userSvelteConfigLoc = path.resolve(process.cwd(), `${config}/svelte.config.js`);
-  
+  const userSvelteConfigLoc = path.resolve(process.cwd(), configFilePath);
+
   if (fs.existsSync(userSvelteConfigLoc)) {
     const userSvelteConfig = require(userSvelteConfigLoc);
     const {preprocess, ..._svelteOptions} = userSvelteConfig;
     preprocessOptions = preprocess;
     userSvelteOptions = _svelteOptions;
+  } else {
+    //user svelte.config.js is optional and should not error if not configured
+    if (configFilePath !== 'svelte.config.js') console.error(`[plugin-svelte] failed to find Svelte config file: could not locate "${userSvelteConfigLoc}"`);
   }
   
   // Generate svelte options from user provided config (if given)

--- a/plugins/plugin-svelte/test/mocked.test.js
+++ b/plugins/plugin-svelte/test/mocked.test.js
@@ -20,17 +20,21 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
       generate: 'ssr',
       isDev: false,
     };
-    const sveltePlugin = plugin(mockConfig, options);
+    const optionsConfig = {configFilePath: './plugins/plugin-svelte/test/svelte.config.js'}
+
+    const sveltePlugin = plugin(mockConfig, {...options, ...optionsConfig});
     await sveltePlugin.load({filePath: mockComponent});
     const passedOptions = mockCompiler.mock.calls[0][1];
 
     // this tests that all options passed above made it to the compiler
     // objectContaining() allows additional options to be passed, but we only care that our options have been preserved
     expect(passedOptions).toEqual(expect.objectContaining(options));
+    // `configFilePath` option is expected not to be passed into Svelte
+    expect(passedOptions).toEqual(expect.not.objectContaining(optionsConfig));
   });
 
   it('handles preprocessing', async () => {
-    const options = {config: './plugins/plugin-svelte/test'};
+    const options = {configFilePath: './plugins/plugin-svelte/test/svelte.config.js'};
 
     const sveltePlugin = plugin(mockConfig, options);
 

--- a/plugins/plugin-svelte/test/mocked.test.js
+++ b/plugins/plugin-svelte/test/mocked.test.js
@@ -30,8 +30,7 @@ describe('@snowpack/plugin-svelte (mocked)', () => {
   });
 
   it('handles preprocessing', async () => {
-    // test-only config option
-    const options = {__config: path.join(__dirname, 'svelte.config.js')};
+    const options = {config: './plugins/plugin-svelte/test'};
 
     const sveltePlugin = plugin(mockConfig, options);
 

--- a/plugins/plugin-svelte/test/unmocked.test.js
+++ b/plugins/plugin-svelte/test/unmocked.test.js
@@ -6,12 +6,20 @@ const mockComponent = path.join(__dirname, 'Button.svelte');
 
 describe('@snowpack/plugin-svelte (unmocked)', () => {
   it('generates code', async () => {
-    const options = {config: './plugins/plugin-svelte/test'};
+    const options = {configFilePath: './plugins/plugin-svelte/test/svelte.config.js'};
     const sveltePlugin = plugin(mockConfig, options);
     const result = await sveltePlugin.load({filePath: mockComponent});
 
     // assume if some CSS & JS were returned, it transformed successfully
     expect(result['.css'].code).toBeTruthy();
     expect(result['.js'].code).toBeTruthy();
+  });
+  it('logs error if config options set but finds no file', async () => {
+    const consoleSpy = await jest.spyOn(console, 'error').mockImplementation(() => {});
+    const options = {configFilePath: './plugins/plugin-svelte/svelte.config.js'};
+    const sveltePlugin = plugin(mockConfig, options);
+    const result = await sveltePlugin.load({filePath: mockComponent});
+
+    expect(consoleSpy).toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-svelte/test/unmocked.test.js
+++ b/plugins/plugin-svelte/test/unmocked.test.js
@@ -6,7 +6,7 @@ const mockComponent = path.join(__dirname, 'Button.svelte');
 
 describe('@snowpack/plugin-svelte (unmocked)', () => {
   it('generates code', async () => {
-    const options = {};
+    const options = {config: './plugins/plugin-svelte/test'};
     const sveltePlugin = plugin(mockConfig, options);
     const result = await sveltePlugin.load({filePath: mockComponent});
 


### PR DESCRIPTION
## Changes
In plugin-svelte, reveals `config` option allowing dev to config where `svelte.config.js` is located. My use case is for both monorepo and testing.  Started/mentioned in #1241. Happy to make any changes! 

## Testing
Existing plugin tests (mocked & unmocked) updated.

## Docs
Added `config` option and expected value to **Plugin Options**
