### PR TITLE
Fix docs nav scroll

### DIFF
--- a/www/_eleventy/layouts/base.njk
+++ b/www/_eleventy/layouts/base.njk
@@ -268,7 +268,7 @@
         flex-shrink: 0;
         flex-grow: 0;
         width: 360px;
-        max-height: 100vh;
+        max-height: calc(100vh - 52px);
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
         position: sticky;


### PR DESCRIPTION
## Changes

Docs nav is `100vh`, but it’s `52px` from the top. This cuts off the very bottom of the nav.

**Before**
<img width="421" alt="Screen Shot 2020-10-13 at 2 59 37 PM" src="https://user-images.githubusercontent.com/1369770/95915798-f435f680-0d64-11eb-8b07-7639db394521.png">


**After**
<img width="449" alt="Screen Shot 2020-10-13 at 2 59 27 PM" src="https://user-images.githubusercontent.com/1369770/95915810-f7c97d80-0d64-11eb-85b4-f083d911cc2a.png">

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Check out the preview link—see if it helps!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
