### PR TITLE
normalize svelte.config.js format

### DIFF
--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -25,9 +25,9 @@ module.exports = function plugin(snowpackConfig, {hot: hotOptions, ...sveltePlug
 
   if (fs.existsSync(userSvelteConfigLoc)) {
     const userSvelteConfig = require(userSvelteConfigLoc);
-    const {preprocess, ..._svelteOptions} = userSvelteConfig;
+    const {preprocess, compilerOptions} = userSvelteConfig;
     preprocessOptions = preprocess;
-    userSvelteOptions = _svelteOptions;
+    userSvelteOptions = compilerOptions;
   } else {
     //user svelte.config.js is optional and should not error if not configured
     if (configFilePath !== 'svelte.config.js')


### PR DESCRIPTION
## Changes

Currently, `@snowpack/plugin-svelte` will read configuration from a svelte.config.js file assuming the following structure:

```js
module.exports = {
  preprocess: {...},
  ...compilerOptions
};
```

Unfortunately, this makes it impossible to add any config *other* than compiler options. For example, in the Snowpack/Svelte integration we're working on, it's necessary to specify an `adapter` to process the build output, and if we can't do so in svelte.config.js then we would have to introduce a new config file.

This PR changes the plugin behaviour to be in line with the format articulated [here](https://github.com/sveltejs/svelte/issues/1101#issuecomment-708104278), which we're encouraging all members of the ecosystem to adopt:

```js
module.exports = {
  preprocess: {...},
  compilerOptions: {...}
};
```

Unfortunately, I don't think there's a way to do this as a non-breaking change. (It should affect very few people, since most people only use svelte.config.js to specify `preprocess`, the behaviour of which is unchanged.)

## Testing

Tested with a local project. There aren't any automated tests that currently cover this aspect of the plugin's behaviour.

## Docs

The current expected svelte.config.js structure isn't documented anywhere, so this PR doesn't change anything.