### PR TITLE
Improve plugin-vue output

### DIFF
--- a/plugins/plugin-vue/plugin.js
+++ b/plugins/plugin-vue/plugin.js
@@ -108,6 +108,10 @@ module.exports = function plugin(snowpackConfig) {
         if (sourceMaps && js.map) output['.js'].map += JSON.stringify(js.map);
       }
 
+      // clean up
+      if (!output['.js'].code) delete output['.js'];
+      if (!output['.css'].code) delete output['.css'];
+
       return output;
     },
   };

--- a/plugins/plugin-vue/test/__snapshots__/plugin-vue-ts-tsx-jsx.test.js.snap
+++ b/plugins/plugin-vue/test/__snapshots__/plugin-vue-ts-tsx-jsx.test.js.snap
@@ -2,10 +2,6 @@
 
 exports[`plugin vue with jsx 1`] = `
 Object {
-  ".css": Object {
-    "code": "",
-    "map": "",
-  },
   ".js": Object {
     "code": "import { Fragment } from 'vue';
 import {createVNode, isVNode} from 'vue';
@@ -31,10 +27,6 @@ export default defineComponent({
 
 exports[`plugin vue with ts 1`] = `
 Object {
-  ".css": Object {
-    "code": "",
-    "map": "",
-  },
   ".js": Object {
     "code": "import {defineComponent} from \\"vue\\";
 const defaultExport = defineComponent({
@@ -58,10 +50,6 @@ export default defaultExport",
 
 exports[`plugin vue with tsx 1`] = `
 Object {
-  ".css": Object {
-    "code": "",
-    "map": "",
-  },
   ".js": Object {
     "code": "import { Fragment } from 'vue';
 import {createVNode, isVNode} from 'vue';

--- a/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
@@ -87,10 +87,6 @@ export default defaultExport",
 
 exports[`plugin base only tpl 1`] = `
 Object {
-  ".css": Object {
-    "code": "",
-    "map": "",
-  },
   ".js": Object {
     "code": "const defaultExport = {};
 import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock } from \\"vue\\"


### PR DESCRIPTION
## Changes

Before, we were sending `.css` files to Snowpack from _every_ Vue file, even if the Vue file generated no styles. This PR changes that, and only sends styles to Snowpack when needed.

Here are screenshots of a Vue application that loads external styles:

**Before** (1 empty CSS file generated per-component)

![Screen Shot 2020-10-14 at 12 00 33 PM](https://user-images.githubusercontent.com/1369770/96028950-3455b180-0e17-11eb-9b90-0505e4d0ecd8.png)

**After** (no empty CSS files generated)

![Screen Shot 2020-10-14 at 12 15 08 PM](https://user-images.githubusercontent.com/1369770/96028978-3b7cbf80-0e17-11eb-8320-36cde2359ace.png)

Basically, all the empty `<style>` tags were dozens of empty `.css.proxy.js` files being generated & loaded.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested manually, as seen from screenshots.

But you can also see the snapshot diff in the changes, where some empty CSS files were deleted (comment below)

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
