### PR TITLE
Allow result of load step to have map with binary data

### DIFF
--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -81,7 +81,9 @@ async function runPipelineLoadStep(
           const output = result[ext];
 
           // normalize to {code, map} format
-          if (typeof output === 'string') result[ext] = {code: output};
+          if (typeof output === 'string' || Buffer.isBuffer(output)) {
+            result[ext] = {code: output};
+          }
 
           // ensure source maps are strings (it’s easy for plugins to pass back a JSON object)
           if (result[ext].map && typeof result[ext].map === 'object')


### PR DESCRIPTION
## Changes

Previously, the load step only allowed plugins with Buffer type results when there was a single result (i.e. not a map of results--see https://github.com/pikapkg/snowpack/blob/master/snowpack/src/build/build-pipeline.ts#L72). This PR allows a plugin to have multiple results, some string type, other Buffer type.

## Testing

I tested this using a modified version of `snowpack-plugin-inliner`; however, this is my first PR to snowpack and I'm unfamiliar with the test directory structure.

## Docs

This is a bug fix only.