### PR TITLE
Show mount points in debug log

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -268,6 +268,14 @@ export async function startServer(commandOptions: CommandOptions) {
   const filesBeingDeleted = new Set<string>();
   const filesBeingBuilt = new Map<string, Promise<SnowpackBuildMap>>();
 
+  logger.debug(`Using in-memory cache for mount points:`, {
+    task: () => {
+      for (const [dirDisk, dirUrl] of Object.entries(config.mount)) {
+        logger.debug(` -> '${dirDisk}' as URL '${dirUrl}'`);
+      }
+    },
+  });
+
   // Set the proper install options, in case an install is needed.
   const dependencyImportMapLoc = path.join(DEV_DEPENDENCIES_DIR, 'import-map.json');
   logger.debug(`Using cache folder: ${path.relative(cwd, DEV_DEPENDENCIES_DIR)}`);

--- a/snowpack/src/logger.ts
+++ b/snowpack/src/logger.ts
@@ -37,7 +37,17 @@ class SnowpackLogger {
     },
   };
 
-  private log({level, name, message}: {level: LoggerEvent; name: string; message: string}) {
+  private log({
+    level,
+    name,
+    message,
+    task,
+  }: {
+    level: LoggerEvent;
+    name: string;
+    message: string;
+    task?: Function;
+  }) {
     // test if this level is enabled or not
     if (levels[this.level] > levels[level]) {
       return; // do nothing
@@ -66,30 +76,34 @@ class SnowpackLogger {
     } else {
       throw new Error(`No logging method defined for ${level}`);
     }
+
+    // logger takes a possibly processor-intensive task, and only
+    // processes it when this log level is enabled
+    task && task(this);
   }
 
   /** emit messages only visible when --debug is passed */
   public debug(message: string, options?: LoggerOptions): void {
     const name = (options && options.name) || 'snowpack';
-    this.log({level: 'debug', name, message});
+    this.log({level: 'debug', name, message, task: options?.task});
   }
 
   /** emit general info */
   public info(message: string, options?: LoggerOptions): void {
     const name = (options && options.name) || 'snowpack';
-    this.log({level: 'info', name, message});
+    this.log({level: 'info', name, message, task: options?.task});
   }
 
   /** emit non-fatal warnings */
   public warn(message: string, options?: LoggerOptions): void {
     const name = (options && options.name) || 'snowpack';
-    this.log({level: 'warn', name, message});
+    this.log({level: 'warn', name, message, task: options?.task});
   }
 
   /** emit critical error messages */
   public error(message: string, options?: LoggerOptions): void {
     const name = (options && options.name) || 'snowpack';
-    this.log({level: 'error', name, message});
+    this.log({level: 'error', name, message, task: options?.task});
   }
 
   /** get full logging history */

--- a/snowpack/src/types/snowpack.ts
+++ b/snowpack/src/types/snowpack.ts
@@ -199,4 +199,6 @@ export type LoggerEvent = 'debug' | 'info' | 'warn' | 'error';
 export interface LoggerOptions {
   /** (optional) change name at beginning of line */
   name?: string;
+  /** (optional) do some additional work after logging a message, if log level is enabled */
+  task?: Function;
 }


### PR DESCRIPTION
## Changes

In dev mode, adds debug info regarding what directories on disk are available at what URLs.

Run dev server with debug enabled:

```
yarn start --verbose
```

See more info ("Using in-memory cache for mount points:"):

<img width="555" alt="image" src="https://user-images.githubusercontent.com/129/96060696-7f3eeb80-0e4e-11eb-8553-3dfd46d2a8f1.png">

## Testing

Tested locally. No tests written, it just adds debug info.

## Docs

We could add this to docs? I don't think it's necessary. But it is educational...