### PR TITLE
Add new docs team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @pikapkg/maintainers
+docs/* @pikapkg/docs


### PR DESCRIPTION
## Changes

Adds a new docs team to the CODEOWNERS file so the docs team gets notified of docs changes

## Testing

No tests, for Github configuration only

## Docs
No docs, for Github configuration only
