### PR TITLE
Make docs layout full-width

### DIFF
--- a/www/_eleventy/layouts/base.njk
+++ b/www/_eleventy/layouts/base.njk
@@ -280,7 +280,9 @@
       .markdown-body {
         padding: 0 3em;
         margin-bottom: 50vh;
-
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 1000px;
       }
       .github-button {
         display: none;
@@ -363,7 +365,6 @@
       }
 
       .container {
-        max-width: 1200px;
         margin: auto;
       }
       .search-form {


### PR DESCRIPTION
## Changes

As discussed in https://github.com/pikapkg/snowpack/discussions/1293, instead of limiting the whole page to 1200 px, limit the markdown content to 1000px and center it.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/115237/96170626-1cb81f00-0f24-11eb-939f-cfe75b10bde3.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/115237/96170745-496c3680-0f24-11eb-80a4-7d75f0252b62.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/115237/96170666-2a6da480-0f24-11eb-8438-7b3a1c7e0ee0.png">

## Testing

Visual only

## Docs

None