### PR TITLE
don't resolve lazy file extensions if they are absolute paths/urls

### DIFF
--- a/test/build/resolve-imports/__snapshots__
+++ b/test/build/resolve-imports/__snapshots__
@@ -63,9 +63,16 @@ exports[`snowpack build resolve-imports: build/_dist_/index.html 1`] = `
       console.log(flatten, aliasedDep);
       // Importing a file
       import sort from './sort.js'; // relative import
-      import sort_ from './sort.js'; // bare import using alias
-      import sort__ from './sort.js'; // bare import using alias + extension
-      console.log(sort, sort_, sort__);
+      import sort_ from './sort.js'; // absolute import
+      import sort__ from './sort.js'; // bare import using alias
+      import sort___ from './sort.js'; // bare import using alias + extension
+      console.log(sort, sort_, sort__, sort___);
+      // Note: file does not need to exist for these checks:
+      import svelteFile from './foo.js'; // plugin-provided file extension
+      import svelteFile_ from './foo.js'; // plugin-provided, missing file extension
+      import svelteFile__ from '../foo.js'; // absolute URL, plugin-provided file extension
+      import svelteFile___ from '../foo.js'; // absolute URL, missing file extension
+      console.log(svelteFile, svelteFile_, svelteFile__, svelteFile___);
       // Importing a directory index.js file
       import components from './components/index.js'; // relative import
       import components_ from './components/index.js'; // relative import with index appended
@@ -104,10 +111,17 @@ import * as aliasedDep from '../TEST_WMU/array-flatten.js';
 console.log(flatten, aliasedDep);
 // Importing a file
 import sort from './sort.js'; // relative import
-import sort_ from './sort.js'; // bare import using alias
-import sort__ from './sort.js'; // bare import using alias + extension
-import sort___ from './sort.js'; // bare import using alias with trailing slash
-console.log(sort, sort_, sort__, sort___);
+import sort_ from './sort.js'; // absolute import
+import sort__ from './sort.js'; // bare import using alias
+import sort___ from './sort.js'; // bare import using alias + extension
+import sort____ from './sort.js'; // bare import using alias with trailing slash
+console.log(sort, sort_, sort__, sort___, sort___, sort____);
+// Note: file does not need to exist for these checks:
+import svelteFile from './foo.js'; // plugin-provided file extension
+import svelteFile_ from './foo.js'; // plugin-provided, missing file extension
+import svelteFile__ from '../foo.js'; // absolute URL, plugin-provided file extension
+import svelteFile___ from '../foo.js'; // absolute URL, missing file extension
+console.log(svelteFile, svelteFile_, svelteFile__, svelteFile___);
 // Importing a directory index.js file
 import components from './components/index.js'; // relative import
 import components______ from './components/index.js'; // relative import with trailing slash

--- a/test/build/resolve-imports/package.json
+++ b/test/build/resolve-imports/package.json
@@ -6,25 +6,6 @@
     "start": "snowpack dev",
     "testbuild": "snowpack build"
   },
-  "snowpack": {
-    "alias": {
-      "aliased-dep": "array-flatten",
-      "@app": "./src",
-      "@/": "./src/",
-      "%": "."
-    },
-    "mount": {
-      "./src": "/_dist_"
-    },
-    "devOptions": {
-      "fallback": "_dist_/index.html"
-    },
-    "buildOptions": {
-      "baseUrl": "https://example.com/foo",
-      "webModulesUrl": "/TEST_WMU/",
-      "minify": false
-    }
-  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "array-flatten": "^3.0.0",

--- a/test/build/resolve-imports/simple-file-extension-change-plugin.js
+++ b/test/build/resolve-imports/simple-file-extension-change-plugin.js
@@ -1,0 +1,14 @@
+const {load} = require('signal-exit');
+
+module.exports = function () {
+  return {
+    resolve: {
+      input: ['.svelte'],
+      output: ['.js', '.css'],
+    },
+    load() {
+      // Not tested in this test.
+      return null;
+    },
+  };
+};

--- a/test/build/resolve-imports/snowpack.config.js
+++ b/test/build/resolve-imports/snowpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  alias: {
+    'aliased-dep': 'array-flatten',
+    '@app': './src',
+    '@/': './src/',
+    '%': '.',
+  },
+  mount: {
+    './src': '/_dist_',
+  },
+  devOptions: {
+    fallback: '_dist_/index.html',
+  },
+  buildOptions: {
+    baseUrl: 'https://example.com/foo',
+    webModulesUrl: '/TEST_WMU/',
+    minify: false,
+  },
+  plugins: ['./simple-file-extension-change-plugin.js']
+};

--- a/test/build/resolve-imports/src/index.html
+++ b/test/build/resolve-imports/src/index.html
@@ -16,9 +16,17 @@
 
       // Importing a file
       import sort from './sort'; // relative import
-      import sort_ from '@app/sort'; // bare import using alias
-      import sort__ from '@app/sort.js'; // bare import using alias + extension
-      console.log(sort, sort_, sort__);
+      import sort_ from '/_dist_/sort.js'; // absolute import
+      import sort__ from '@app/sort'; // bare import using alias
+      import sort___ from '@app/sort.js'; // bare import using alias + extension
+      console.log(sort, sort_, sort__, sort___);
+
+      // Note: file does not need to exist for these checks:
+      import svelteFile from './foo.svelte'; // plugin-provided file extension
+      import svelteFile_ from './foo'; // plugin-provided, missing file extension
+      import svelteFile__ from '/foo.svelte'; // absolute URL, plugin-provided file extension
+      import svelteFile___ from '/foo'; // absolute URL, missing file extension
+      console.log(svelteFile, svelteFile_, svelteFile__, svelteFile___);
 
       // Importing a directory index.js file
       import components from './components'; // relative import

--- a/test/build/resolve-imports/src/index.js
+++ b/test/build/resolve-imports/src/index.js
@@ -5,10 +5,18 @@ console.log(flatten, aliasedDep);
 
 // Importing a file
 import sort from './sort'; // relative import
-import sort_ from '@app/sort'; // bare import using alias
-import sort__ from '@app/sort.js'; // bare import using alias + extension
-import sort___ from '@/sort'; // bare import using alias with trailing slash
-console.log(sort, sort_, sort__, sort___);
+import sort_ from '/_dist_/sort.js'; // absolute import
+import sort__ from '@app/sort'; // bare import using alias
+import sort___ from '@app/sort.js'; // bare import using alias + extension
+import sort____ from '@/sort'; // bare import using alias with trailing slash
+console.log(sort, sort_, sort__, sort___, sort___, sort____);
+
+// Note: file does not need to exist for these checks:
+import svelteFile from './foo.svelte'; // plugin-provided file extension
+import svelteFile_ from './foo'; // plugin-provided, missing file extension
+import svelteFile__ from '/foo.svelte'; // absolute URL, plugin-provided file extension
+import svelteFile___ from '/foo'; // absolute URL, missing file extension
+console.log(svelteFile, svelteFile_, svelteFile__, svelteFile___);
 
 // Importing a directory index.js file
 import components from './components'; // relative import


### PR DESCRIPTION
## Changes

- Fixes an issue that the Svelte team was seeing where they had to rewrite ".svelte.js" to ".svelte" themselves (/cc @Rich-Harris)
- Instead of doing a lazy replace instantly, we now check first if the file extension is known/valid (this is the way the ordering should have been from the start)

## Testing

- Test added.

## Docs

- N/A