### PR TITLE
Making the index.css for the minimal starter more minimal

### DIFF
--- a/create-snowpack-app/app-template-minimal/index.css
+++ b/create-snowpack-app/app-template-minimal/index.css
@@ -1,6 +1,4 @@
 /* Add CSS styles here! */
 body {
   font-family: sans-serif;
-  margin: 2em 1em;
-  line-height: 1.5em;
 }

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -7322,8 +7322,6 @@ exports[`create-snowpack-app app-template-minimal > build: index.css 1`] = `
 "/* Add CSS styles here! */
 body {
   font-family: sans-serif;
-  margin: 2em 1em;
-  line-height: 1.5em;
 }"
 `;
 


### PR DESCRIPTION
## Changes

Removes some styles from `index.css` in the minimal starter, leaving only one style. This is because we're using this starter in some tutorials where the styles might conflict. 

## Testing

Snapshot test reviewed updated since this changes the snapshot for the build.

## Docs
No docs needed
