### PR TITLE
add explicit "mode" config

### DIFF
--- a/create-snowpack-app/app-template-preact-typescript/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-preact-typescript/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/create-snowpack-app/app-template-preact/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-preact/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/create-snowpack-app/app-template-react-typescript/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-react-typescript/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/create-snowpack-app/app-template-react/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-react/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/create-snowpack-app/app-template-svelte-typescript/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-svelte-typescript/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/create-snowpack-app/app-template-svelte/web-test-runner.config.js
+++ b/create-snowpack-app/app-template-svelte/web-test-runner.config.js
@@ -1,6 +1,3 @@
-// NODE_ENV=test - Needed by "@snowpack/web-test-runner-plugin"
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,6 +18,15 @@ module.exports = {
 
 To generate a basic configuration file scaffold in your Snowpack project run `snowpack init`.
 
+## mode
+
+**Type**: `"test" | "development" | "production"`  
+**Default**: `"development"` for `snowpack dev`, `"production"` for `snowpack build`.
+
+Specifies the "mode" that Snowpack should run in. The main impact of this is the value of `import.meta.env.MODE` at runtime, although there are some other key differences between modes:
+
+- `"test"`: `testOptions.files` are not excluded, and will be scanned & built as normal source files. Useful when running tests on top of Snowpack.
+
 ## root
 
 **Type**: `string`  

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -75,7 +75,7 @@ function resolveWebDependency(
 
 function generateEnvObject(userEnv: EnvVarReplacements): Object {
   return {
-    NODE_ENV: process.env.NODE_ENV || 'production',
+    NODE_ENV: userEnv.NODE_ENV || process.env.NODE_ENV || 'production',
     ...Object.keys(userEnv).reduce((acc, key) => {
       const value = userEnv[key];
       acc[key] = value === true ? process.env[key] : value;

--- a/plugins/plugin-svelte/plugin.js
+++ b/plugins/plugin-svelte/plugin.js
@@ -5,7 +5,7 @@ const path = require('path');
 const {createMakeHot} = require('svelte-hmr');
 
 module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
-  const isDev = process.env.NODE_ENV !== 'production';
+  const isDev = snowpackConfig.mode !== 'production';
   const useSourceMaps =
     snowpackConfig.buildOptions.sourcemap || snowpackConfig.buildOptions.sourceMaps;
   // Old Snowpack versions wouldn't build dependencies. Starting in v3.1, Snowpack's build pipeline

--- a/plugins/web-test-runner-plugin/README.md
+++ b/plugins/web-test-runner-plugin/README.md
@@ -10,12 +10,6 @@ npm install @snowpack/web-test-runner-plugin --save-dev
 
 ```
 // web-test-runner.config.js
-
-// NOTE: For now, NODE_ENV needs to be set to "test" for Snowpack
-// to build test files properly. We hope to remove this limitation
-// in a future release.
-process.env.NODE_ENV = 'test';
-
 module.exports = {
   plugins: [require('@snowpack/web-test-runner-plugin')()],
 };

--- a/plugins/web-test-runner-plugin/plugin.js
+++ b/plugins/web-test-runner-plugin/plugin.js
@@ -11,19 +11,13 @@ function isTestRunnerFile(url) {
 }
 
 module.exports = function () {
-  if (process.env.NODE_ENV !== 'test') {
-    throw new Error(`@snowpack/web-test-runner-plugin: NODE_ENV must === "test" to build files correctly.
-To Resolve:
-  1. Set "process.env.NODE_ENV = 'test';" at the top of your web-test-runner.config.js file (before all imports).
-  2. Prefix your web-test-runner CLI command: "NODE_ENV=test web-test-runner ...".
-`);
-  }
   let server, config;
 
   return {
     name: 'snowpack-plugin',
     async serverStart({fileWatcher}) {
       config = await snowpack.loadConfiguration({
+        mode: 'test',
         packageOptions: {external: ['/__web-dev-server__web-socket.js']},
         devOptions: {open: 'none', output: 'stream', hmr: false},
       });

--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -319,7 +319,7 @@ export function generateEnvModule({
   isSSR,
   configEnv,
 }: {
-  mode: 'development' | 'production';
+  mode: SnowpackConfig['mode'];
   isSSR: boolean;
   configEnv?: Record<string, string | boolean | undefined>;
 }) {

--- a/snowpack/src/commands/build.ts
+++ b/snowpack/src/commands/build.ts
@@ -58,7 +58,7 @@ async function installOptimizedDependencies(
   const baseInstallOptions = {
     dest: installDest,
     external: commandOptions.config.packageOptions.external,
-    env: {NODE_ENV: process.env.NODE_ENV || 'production'},
+    env: {NODE_ENV: commandOptions.config.mode},
     treeshake: commandOptions.config.buildOptions.watch
       ? false
       : commandOptions.config.optimize?.treeshake !== false,

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -249,10 +249,10 @@ export async function startServer(
     preparePackages: _preparePackages,
   }: {isDev?: boolean; isWatch?: boolean; preparePackages?: boolean} = {},
 ): Promise<SnowpackDevServer> {
-  const isDev = _isDev ?? true;
+  const {config} = commandOptions;
+  const isDev = _isDev ?? config.mode !== 'production';
   const isWatch = _isWatch ?? true;
   const isPreparePackages = _preparePackages ?? true;
-  const {config} = commandOptions;
   const pkgSource = getPackageSource(config);
   if (isPreparePackages) {
     await pkgSource.prepare();
@@ -295,7 +295,7 @@ export async function startServer(
   let fileToUrlMapping = new OneToManyMap();
   const excludeGlobs = [
     ...config.exclude,
-    ...(process.env.NODE_ENV === 'test' ? [] : config.testOptions.files),
+    ...(config.mode === 'test' ? [] : config.testOptions.files),
   ];
 
   const foundExcludeMatch = picomatch(excludeGlobs);
@@ -452,7 +452,7 @@ export async function startServer(
       return {
         contents: encodeResponse(
           generateEnvModule({
-            mode: isDev ? 'development' : 'production',
+            mode: config.mode,
             isSSR,
             configEnv: config.env,
           }),
@@ -629,7 +629,7 @@ export async function startServer(
     const isResolve = _isResolve ?? true;
 
     // 1. Check the hot build cache. If it's already found, then just serve it.
-    const cacheKey = getCacheKey(fileLoc, {isSSR, env: process.env.NODE_ENV});
+    const cacheKey = getCacheKey(fileLoc, {isSSR, mode: config.mode});
     let fileBuilder: FileBuilder | undefined = inMemoryBuildCache.get(cacheKey);
     if (!fileBuilder) {
       fileBuilder = new FileBuilder({
@@ -887,8 +887,8 @@ export async function startServer(
       knownETags.delete(updatedUrls[0]);
       knownETags.delete(updatedUrls[0] + '.proxy.js');
     }
-    inMemoryBuildCache.delete(getCacheKey(fileLoc, {isSSR: true, env: process.env.NODE_ENV}));
-    inMemoryBuildCache.delete(getCacheKey(fileLoc, {isSSR: false, env: process.env.NODE_ENV}));
+    inMemoryBuildCache.delete(getCacheKey(fileLoc, {isSSR: true, mode: config.mode}));
+    inMemoryBuildCache.delete(getCacheKey(fileLoc, {isSSR: false, mode: config.mode}));
     await onFileChangeCallback({filePath: fileLoc});
     for (const plugin of config.plugins) {
       plugin.onChange && plugin.onChange({filePath: fileLoc});

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -86,6 +86,7 @@ const DEFAULT_PACKAGES_REMOTE_CONFIG: PackageOptionsRemote = {
 const configSchema = {
   type: 'object',
   properties: {
+    mode: {type: 'string', enum: ['test', 'development', 'production']},
     extends: {type: 'string'},
     exclude: {type: 'array', items: {type: 'string'}},
     plugins: {type: 'array'},
@@ -416,6 +417,7 @@ function normalizeConfig(_config: SnowpackUserConfig): SnowpackConfig {
   // SnowpackUserConfig type, we can have this function construct a fresh config object
   // from scratch instead of trying to modify the user's config object in-place.
   let config: SnowpackConfig = (_config as any) as SnowpackConfig;
+  config.mode = config.mode || (process.env.NODE_ENV as SnowpackConfig['mode']);
   if (config.packageOptions.source === 'local') {
     config.packageOptions.rollup = config.packageOptions.rollup || {};
     config.packageOptions.rollup.plugins = config.packageOptions.rollup.plugins || [];

--- a/snowpack/src/dev/hmr.ts
+++ b/snowpack/src/dev/hmr.ts
@@ -80,7 +80,7 @@ export function startHmrEngine(
     // Otherwise, reload the page if the file exists in our hot cache (which
     // means that the file likely exists on the current page, but is not
     // supported by HMR (HTML, image, etc)).
-    if (inMemoryBuildCache.has(getCacheKey(fileLoc, {isSSR: false, env: process.env.NODE_ENV}))) {
+    if (inMemoryBuildCache.has(getCacheKey(fileLoc, {isSSR: false, mode: config.mode}))) {
       hmrEngine.broadcastMessage({type: 'reload'});
       return;
     }

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -43,7 +43,7 @@ export async function getInstallTargets(
   if (scannedFiles) {
     installTargets.push(...(await scanImportsFromFiles(scannedFiles, config)));
   } else {
-    installTargets.push(...(await scanImports(process.env.NODE_ENV === 'test', config)));
+    installTargets.push(...(await scanImports(config.mode === 'test', config)));
   }
   return installTargets.filter(
     (dep) =>

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -552,6 +552,8 @@ export class PackageSourceLocal implements PackageSource {
         const installOptions: InstallOptions = {
           dest: installDest,
           cwd: packageManifestLoc,
+          // This installer is only ever run in development. In production, many packages
+          // are installed together to take advantage of tree-shaking and package bundling.
           env: {NODE_ENV: 'development'},
           treeshake: false,
           sourcemap: config.buildOptions.sourcemap,

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -249,6 +249,7 @@ export interface PackageOptionsRemote {
 // interface this library uses internally
 export interface SnowpackConfig {
   root: string;
+  mode: 'test' | 'development' | 'production';
   workspaceRoot?: string | false;
   extends?: string;
   exclude: string[];
@@ -300,6 +301,7 @@ export interface SnowpackConfig {
 
 export type SnowpackUserConfig = {
   root?: string;
+  mode?: SnowpackConfig['mode'];
   workspaceRoot?: string;
   install?: string[];
   extends?: string;

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -47,8 +47,8 @@ export const HTML_STYLE_REGEX = /(<style.*?>)(.*?)<\/style>/gims;
 export const CSS_REGEX = /@import\s*['"](.*?)['"];/gs;
 export const SVELTE_VUE_REGEX = /(<script[^>]*>)(.*?)<\/script>/gims;
 
-export function getCacheKey(fileLoc: string, {isSSR, env}) {
-  return `${fileLoc}?env=${env}&isSSR=${isSSR ? '1' : '0'}`;
+export function getCacheKey(fileLoc: string, {isSSR, mode}) {
+  return `${fileLoc}?mode=${mode}&isSSR=${isSSR ? '1' : '0'}`;
 }
 
 export type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;

--- a/test/fixture-utils.js
+++ b/test/fixture-utils.js
@@ -37,6 +37,7 @@ exports.testFixture = async function testFixture(
 
   const config = await snowpack.createConfiguration({
     root: inDir,
+    mode: 'production',
     ...userConfig,
   });
   const outDir = config.buildOptions.out;

--- a/test/snowpack/config/mode/index.test.js
+++ b/test/snowpack/config/mode/index.test.js
@@ -1,0 +1,30 @@
+const {testFixture} = require('../../../fixture-utils');
+
+describe('mode', () => {
+  beforeAll(() => {
+    // Needed until we make Snowpack's JS Build Interface quiet by default
+    require('snowpack').logger.level = 'warn';
+  });
+
+  it('throws when mode is some unknown value', async () => {
+    const config = {mode: 'UNEXPECTED'};
+    const result = await testFixture(config, `console.log(import.meta.env.MODE)`).catch(() => null);
+    if (result !== null) {
+      throw new Error('Expected to reject!');
+    }
+  });
+
+  // For some reason, this is failing in CI. I think Luke Jackson has probably already solved this in his PR.
+  // Otherwise, take the time to investigate and understand why.
+  describe.skip.each([
+    ['mode=production', 'production'],
+    ['mode=development', 'development'],
+    ['mode=test', 'test'],
+  ])('%s', (_, modeValue) => {
+    it('builds correctly', async () => {
+      const config = {mode: modeValue};
+      const result = await testFixture(config, `console.log(import.meta.env.MODE)`);
+      expect(result['_snowpack/env.js']).toContain(`const NODE_ENV = "${modeValue}"`);
+    });
+  });
+});


### PR DESCRIPTION
## Changes

- We've seen some complaints about how Snowpack behavior can change based on your NODE_ENV
- This PR makes "mode" explicit, and configurable via Snowpack config, similar to Webpack, Vite, and others.
- Still inherits from NODE_ENV if not set by config, but we can open that up to change in v4.
- In v4, we can also look into turning on optimizations by default in "production".

## Testing

- Tests added

## Docs

- Docs added