### PR TITLE
Don't scan imports from non-JS files

### DIFF
--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -275,10 +275,7 @@ function filterObject(obj, predicate) {
 
 function findExtension(filePath, extensions) {
   const baseExt = getExtension(filePath);
-  for (const extension of extensions) {
-    if (extension.toLowerCase() == baseExt) return true;
-  }
-  return false;
+  return extensions.has(baseExt);
 }
 
 export async function scanImports(

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -288,7 +288,7 @@ export async function scanImports(
   await initESModuleLexer;
   const mountWithoutStatic = filterObject(config.mount, item => item.resolve);
   const assetsExtensions = [".jpg", ".jpeg", ".png", ".gif"];
-  const filterAssets = (path, isDirectory) => !isDirectory && !findExtension(path, assetsExtensions);
+  const filterAssets = (path, isDirectory) => isDirectory || !findExtension(path, assetsExtensions);
   const includeFileSets = await Promise.all(
     Object.keys(mountWithoutStatic).map(async (fromDisk) => {
       return (await new fdir().filter(filterAssets).withFullPaths().crawl(fromDisk).withPromise()) as string[];

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -273,16 +273,25 @@ function filterObject(obj, predicate) {
   return result;
 }
 
+function findExtension(filePath, extensions) {
+  const baseExt = getExtension(filePath);
+  for (const extension of extensions) {
+    if (extension.toLowerCase() == baseExt) return true;
+  }
+  return false;
+}
+
 export async function scanImports(
   includeTests: boolean,
   config: SnowpackConfig,
 ): Promise<InstallTarget[]> {
   await initESModuleLexer;
-  const mountWithResolve = filterObject(config.mount, item => item.resolve);
-  const filterJS = (path, isDirectory) => !isDirectory && (path.endsWith(".js") || path.endsWith(".mjs"));
+  const mountWithoutStatic = filterObject(config.mount, item => item.resolve);
+  const assetsExtensions = [".jpg", ".jpeg", ".png", ".gif"];
+  const filterAssets = (path, isDirectory) => !isDirectory && !findExtension(path, assetsExtensions);
   const includeFileSets = await Promise.all(
-    Object.keys(mountWithResolve).map(async (fromDisk) => {
-      return (await new fdir().filter(filterJS).withFullPaths().crawl(fromDisk).withPromise()) as string[];
+    Object.keys(mountWithoutStatic).map(async (fromDisk) => {
+      return (await new fdir().filter(filterAssets).withFullPaths().crawl(fromDisk).withPromise()) as string[];
     }),
   );
   const includeFiles = Array.from(new Set(([] as string[]).concat.apply([], includeFileSets)));

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -287,7 +287,7 @@ export async function scanImports(
 ): Promise<InstallTarget[]> {
   await initESModuleLexer;
   const mountWithoutStatic = filterObject(config.mount, item => item.resolve);
-  const assetsExtensions = [".jpg", ".jpeg", ".png", ".gif"];
+  const assetsExtensions = new Set([".jpg", ".jpeg", ".png", ".gif"]);
   const filterAssets = (path, isDirectory) => isDirectory || !findExtension(path, assetsExtensions);
   const includeFileSets = await Promise.all(
     Object.keys(mountWithoutStatic).map(async (fromDisk) => {

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -182,7 +182,6 @@ function parseFileForInstallTargets({
   root,
 }: SnowpackSourceFile<string>): InstallTarget[] {
   const relativeLoc = path.relative(root, locOnDisk);
-
   try {
     if (cssExts.test(baseExt)) {
       logger.debug(`Scanning ${relativeLoc} for imports as CSS`);
@@ -204,40 +203,6 @@ function parseFileForInstallTargets({
         `Skip scanning ${relativeLoc} for imports (unknown file extension ${baseExt})`,
       );
       return [];
-    }
-
-    switch (baseExt) {
-      case '.css':
-      case '.less':
-      case '.sass':
-      case '.scss': {
-        logger.debug(`Scanning ${relativeLoc} for imports as CSS`);
-        return parseCssForInstallTargets(contents);
-      }
-      case '.html':
-      case '.svelte':
-      case '.interface':
-      case '.vue': {
-        logger.debug(`Scanning ${relativeLoc} for imports as HTML`);
-        return [
-          ...parseCssForInstallTargets(extractCssFromHtml(contents)),
-          ...parseJsForInstallTargets(extractJsFromHtml({contents, baseExt})),
-        ];
-      }
-      case '.js':
-      case '.jsx':
-      case '.mjs':
-      case '.ts':
-      case '.tsx': {
-        logger.debug(`Scanning ${relativeLoc} for imports as JS`);
-        return parseJsForInstallTargets(contents);
-      }
-      default: {
-        logger.debug(
-          `Skip scanning ${relativeLoc} for imports (unknown file extension ${baseExt})`,
-        );
-        return [];
-      }
     }
   } catch (err) {
     // Another error! No hope left, just abort.


### PR DESCRIPTION
## Changes

This very important change fixes the error when building a project containing many non-JS files, and, most likely, speeds up the build, since all such files are skipped when searching for imports (import of SVG files does not break).

`[snowpack] EMFILE: too many open files, open 'some path to jpg-file'`

## Testing

I successfully launched a project with a lot of jpg-pictures inside of `public` and `src` folders.

## Docs

bug fix only
