### PR TITLE
Update `postcss.config.js` example with nested `plugins` object

### DIFF
--- a/docs/guides/tailwind-css.md
+++ b/docs/guides/tailwind-css.md
@@ -30,8 +30,10 @@ You’ll need to create two files in the root of your project: `postcss.config.j
 // postcss.config.js
 
 module.exports = {
-  tailwindcss: {},
-  // other plugins can go here, such as autoprefixer
+  plugins: {
+    tailwindcss: {},
+    // other plugins can go here, such as autoprefixer
+  },
 };
 ```
 


### PR DESCRIPTION
In the postcss.config.js stanza, should `tailwindcss: {}` be inside a `plugins` object? I don't seem to get any recognition that it's there at all when I use the bare  `tailwindcss: {}` in the original

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
