### PR TITLE
Add CSS Modules in Build SSR

### DIFF
--- a/snowpack/src/build/build-import-proxy.ts
+++ b/snowpack/src/build/build-import-proxy.ts
@@ -1,6 +1,4 @@
 import path from 'path';
-import postCss from 'postcss';
-import postCssModules from 'postcss-modules';
 import {logger} from '../logger';
 import {SnowpackConfig} from '../types';
 import {
@@ -12,6 +10,7 @@ import {
 } from '../util';
 import {generateSRI} from './import-sri';
 import {scanImportGlob} from '../scan-import-glob';
+import {cssModuleJSON} from './import-css';
 
 export const SRI_CLIENT_HMR_SNOWPACK = generateSRI(Buffer.from(HMR_CLIENT_CODE));
 export const SRI_ERROR_HMR_SNOWPACK = generateSRI(Buffer.from(HMR_OVERLAY_CODE));
@@ -238,26 +237,9 @@ async function generateCssModuleImportProxy({
   hmr: boolean;
   config: SnowpackConfig;
 }) {
-  let moduleJson: string | undefined;
-  const processor = postCss([
-    postCssModules({
-      getJSON: (_, json) => {
-        moduleJson = json;
-      },
-    }),
-  ]);
-  const result = await processor.process(code, {
-    from: url,
-    to: url + '.proxy.js',
-  });
-  // log any warnings that happened.
-  result
-    .warnings()
-    .forEach((element) => logger.warn(`${url} - ${element.text}`, {name: 'snowpack:cssmodules'}));
-  // return the JS+CSS proxy file.
   return `
-export let code = ${JSON.stringify(result.css)};
-let json = ${JSON.stringify(moduleJson)};
+export let code = ${JSON.stringify(code)};
+let json = ${cssModuleJSON(url)};
 export default json;
 ${
   hmr

--- a/snowpack/src/build/file-urls.ts
+++ b/snowpack/src/build/file-urls.ts
@@ -32,6 +32,12 @@ export function getBuiltFileUrls(filepath: string, config: SnowpackConfig): stri
   const fileName = path.basename(filepath);
   const extensionMatch = getExtensionMatch(fileName, config._extensionMap);
   if (!extensionMatch) {
+    // CSS Modules require a special .json mapping here
+    if (filepath.endsWith('.module.css')) {
+      return [filepath, filepath + '.json'];
+    }
+
+    // Otherwise, return only the requested file
     return [filepath];
   }
   const [inputExt, outputExts] = extensionMatch;

--- a/snowpack/src/build/import-css.ts
+++ b/snowpack/src/build/import-css.ts
@@ -1,0 +1,39 @@
+import postCss from 'postcss';
+import postCssModules from 'postcss-modules';
+import {logger} from '../logger';
+
+const cssModuleNames = new Map<string, string>();
+
+/** Generate CSS Modules for a given URL */
+export async function cssModules({
+  contents,
+  url,
+}: {
+  contents: string;
+  url: string;
+}): Promise<{css: string; json: any}> {
+  let json: any = {};
+  const processor = postCss([
+    postCssModules({
+      getJSON: (_, moduleNames) => {
+        json = moduleNames;
+        cssModuleNames.set(url, JSON.stringify(moduleNames));
+      },
+    }),
+  ]);
+
+  const result = await processor.process(contents, {from: url, to: url});
+  // log any warnings that happened.
+  result
+    .warnings()
+    .forEach((element) => logger.warn(`${url} - ${element.text}`, {name: 'snowpack:cssmodules'}));
+  return {
+    css: result.css,
+    json,
+  };
+}
+
+/** Return CSS Modules JSON from URL */
+export function cssModuleJSON(url: string) {
+  return cssModuleNames.get(url) || '{}';
+}

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -35,6 +35,7 @@ import {
   SnowpackDevServer,
 } from '../types';
 import {
+  createInstallTarget,
   getCacheKey,
   HMR_CLIENT_CODE,
   HMR_OVERLAY_CODE,
@@ -663,6 +664,11 @@ export async function startServer(
       }
       if (resourcePath !== reqPath && reqPath.endsWith('.proxy.js')) {
         finalizedResponse = await fileBuilder.getProxy(resourcePath, resourceType);
+
+        // CSS Modules only: also generate JSON module mapping (not imported so must be added manually)
+        if (reqPath.endsWith('.module.css.proxy.js') && fileBuilder.buildOutput['.json']) {
+          resolvedImports.push(createInstallTarget(`${resourcePath}.json`));
+        }
       } else if (resourcePath !== reqPath && reqPath.endsWith('.map')) {
         finalizedResponse = fileBuilder.getSourceMap(resourcePath);
       } else {

--- a/snowpack/src/ssr-loader/transform.ts
+++ b/snowpack/src/ssr-loader/transform.ts
@@ -57,9 +57,16 @@ export function transform(data) {
 
       const source = node.source.value;
 
-      if (source.endsWith('.css.proxy.js') && !source.endsWith('.module.css.proxy.js')) {
+      if (source.endsWith('.module.css.proxy.js')) {
+        // CSS Modules: include both CSS and JS
+        const cssSource = source.replace(/\.proxy\.js$/, '');
+        css.push(cssSource);
+        deps.push({name, source});
+      } else if (source.endsWith('.css.proxy.js')) {
+        // CSS proxy: only include CSS
         css.push(source.replace(/\.proxy\.js$/, ''));
       } else {
+        // everything else: mark as a dep
         deps.push({name, source});
 
         if (!is_namespace) {

--- a/test/build/css-modules/css-modules.test.js
+++ b/test/build/css-modules/css-modules.test.js
@@ -21,7 +21,11 @@ describe('', () => {
     expect(files['/src/App.module.css.proxy.js']).not.toEqual(expect.stringContaining(`.App {`));
   });
 
-  it('keeps original CSS file', () => {
-    expect(files['/src/App.module.css']).toEqual(expect.stringContaining(`.App {`));
+  it('preserves CSS file (with CSS Module names)', () => {
+    expect(files['/src/App.module.css']).not.toEqual(expect.stringContaining(`.App {`));
+  });
+
+  it('generates JSON', () => {
+    expect(files['/src/App.module.css.json']).toBeTruthy();
   });
 });

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -6868,45 +6868,25 @@ Array [
 `;
 
 exports[`create-snowpack-app app-template-lit-element-typescript > build: dist/app-root.js 1`] = `
-"function _decorate(decorators, factory, superClass, mixins) { var api = _getDecoratorsApi(); if (mixins) { for (var i = 0; i < mixins.length; i++) { api = mixins[i](api); } } var r = factory(function initialize(O) { api.initializeInstanceElements(O, decorated.elements); }, superClass); var decorated = api.decorateClass(_coalesceClassElements(r.d.map(_createElementDescriptor)), decorators); api.initializeClassElements(r.F, decorated.elements); return api.runClassFinishers(r.F, decorated.finishers); }
-function _getDecoratorsApi() { _getDecoratorsApi = function () { return api; }; var api = { elementsDefinitionOrder: [[\\"method\\"], [\\"field\\"]], initializeInstanceElements: function (O, elements) { [\\"method\\", \\"field\\"].forEach(function (kind) { elements.forEach(function (element) { if (element.kind === kind && element.placement === \\"own\\") { this.defineClassElement(O, element); } }, this); }, this); }, initializeClassElements: function (F, elements) { var proto = F.prototype; [\\"method\\", \\"field\\"].forEach(function (kind) { elements.forEach(function (element) { var placement = element.placement; if (element.kind === kind && (placement === \\"static\\" || placement === \\"prototype\\")) { var receiver = placement === \\"static\\" ? F : proto; this.defineClassElement(receiver, element); } }, this); }, this); }, defineClassElement: function (receiver, element) { var descriptor = element.descriptor; if (element.kind === \\"field\\") { var initializer = element.initializer; descriptor = { enumerable: descriptor.enumerable, writable: descriptor.writable, configurable: descriptor.configurable, value: initializer === void 0 ? void 0 : initializer.call(receiver) }; } Object.defineProperty(receiver, element.key, descriptor); }, decorateClass: function (elements, decorators) { var newElements = []; var finishers = []; var placements = { static: [], prototype: [], own: [] }; elements.forEach(function (element) { this.addElementPlacement(element, placements); }, this); elements.forEach(function (element) { if (!_hasDecorators(element)) return newElements.push(element); var elementFinishersExtras = this.decorateElement(element, placements); newElements.push(elementFinishersExtras.element); newElements.push.apply(newElements, elementFinishersExtras.extras); finishers.push.apply(finishers, elementFinishersExtras.finishers); }, this); if (!decorators) { return { elements: newElements, finishers: finishers }; } var result = this.decorateConstructor(newElements, decorators); finishers.push.apply(finishers, result.finishers); result.finishers = finishers; return result; }, addElementPlacement: function (element, placements, silent) { var keys = placements[element.placement]; if (!silent && keys.indexOf(element.key) !== -1) { throw new TypeError(\\"Duplicated element (\\" + element.key + \\")\\"); } keys.push(element.key); }, decorateElement: function (element, placements) { var extras = []; var finishers = []; for (var decorators = element.decorators, i = decorators.length - 1; i >= 0; i--) { var keys = placements[element.placement]; keys.splice(keys.indexOf(element.key), 1); var elementObject = this.fromElementDescriptor(element); var elementFinisherExtras = this.toElementFinisherExtras((0, decorators[i])(elementObject) || elementObject); element = elementFinisherExtras.element; this.addElementPlacement(element, placements); if (elementFinisherExtras.finisher) { finishers.push(elementFinisherExtras.finisher); } var newExtras = elementFinisherExtras.extras; if (newExtras) { for (var j = 0; j < newExtras.length; j++) { this.addElementPlacement(newExtras[j], placements); } extras.push.apply(extras, newExtras); } } return { element: element, finishers: finishers, extras: extras }; }, decorateConstructor: function (elements, decorators) { var finishers = []; for (var i = decorators.length - 1; i >= 0; i--) { var obj = this.fromClassDescriptor(elements); var elementsAndFinisher = this.toClassDescriptor((0, decorators[i])(obj) || obj); if (elementsAndFinisher.finisher !== undefined) { finishers.push(elementsAndFinisher.finisher); } if (elementsAndFinisher.elements !== undefined) { elements = elementsAndFinisher.elements; for (var j = 0; j < elements.length - 1; j++) { for (var k = j + 1; k < elements.length; k++) { if (elements[j].key === elements[k].key && elements[j].placement === elements[k].placement) { throw new TypeError(\\"Duplicated element (\\" + elements[j].key + \\")\\"); } } } } } return { elements: elements, finishers: finishers }; }, fromElementDescriptor: function (element) { var obj = { kind: element.kind, key: element.key, placement: element.placement, descriptor: element.descriptor }; var desc = { value: \\"Descriptor\\", configurable: true }; Object.defineProperty(obj, Symbol.toStringTag, desc); if (element.kind === \\"field\\") obj.initializer = element.initializer; return obj; }, toElementDescriptors: function (elementObjects) { if (elementObjects === undefined) return; return _toArray(elementObjects).map(function (elementObject) { var element = this.toElementDescriptor(elementObject); this.disallowProperty(elementObject, \\"finisher\\", \\"An element descriptor\\"); this.disallowProperty(elementObject, \\"extras\\", \\"An element descriptor\\"); return element; }, this); }, toElementDescriptor: function (elementObject) { var kind = String(elementObject.kind); if (kind !== \\"method\\" && kind !== \\"field\\") { throw new TypeError('An element descriptor\\\\'s .kind property must be either \\"method\\" or' + ' \\"field\\", but a decorator created an element descriptor with' + ' .kind \\"' + kind + '\\"'); } var key = _toPropertyKey(elementObject.key); var placement = String(elementObject.placement); if (placement !== \\"static\\" && placement !== \\"prototype\\" && placement !== \\"own\\") { throw new TypeError('An element descriptor\\\\'s .placement property must be one of \\"static\\",' + ' \\"prototype\\" or \\"own\\", but a decorator created an element descriptor' + ' with .placement \\"' + placement + '\\"'); } var descriptor = elementObject.descriptor; this.disallowProperty(elementObject, \\"elements\\", \\"An element descriptor\\"); var element = { kind: kind, key: key, placement: placement, descriptor: Object.assign({}, descriptor) }; if (kind !== \\"field\\") { this.disallowProperty(elementObject, \\"initializer\\", \\"A method descriptor\\"); } else { this.disallowProperty(descriptor, \\"get\\", \\"The property descriptor of a field descriptor\\"); this.disallowProperty(descriptor, \\"set\\", \\"The property descriptor of a field descriptor\\"); this.disallowProperty(descriptor, \\"value\\", \\"The property descriptor of a field descriptor\\"); element.initializer = elementObject.initializer; } return element; }, toElementFinisherExtras: function (elementObject) { var element = this.toElementDescriptor(elementObject); var finisher = _optionalCallableProperty(elementObject, \\"finisher\\"); var extras = this.toElementDescriptors(elementObject.extras); return { element: element, finisher: finisher, extras: extras }; }, fromClassDescriptor: function (elements) { var obj = { kind: \\"class\\", elements: elements.map(this.fromElementDescriptor, this) }; var desc = { value: \\"Descriptor\\", configurable: true }; Object.defineProperty(obj, Symbol.toStringTag, desc); return obj; }, toClassDescriptor: function (obj) { var kind = String(obj.kind); if (kind !== \\"class\\") { throw new TypeError('A class descriptor\\\\'s .kind property must be \\"class\\", but a decorator' + ' created a class descriptor with .kind \\"' + kind + '\\"'); } this.disallowProperty(obj, \\"key\\", \\"A class descriptor\\"); this.disallowProperty(obj, \\"placement\\", \\"A class descriptor\\"); this.disallowProperty(obj, \\"descriptor\\", \\"A class descriptor\\"); this.disallowProperty(obj, \\"initializer\\", \\"A class descriptor\\"); this.disallowProperty(obj, \\"extras\\", \\"A class descriptor\\"); var finisher = _optionalCallableProperty(obj, \\"finisher\\"); var elements = this.toElementDescriptors(obj.elements); return { elements: elements, finisher: finisher }; }, runClassFinishers: function (constructor, finishers) { for (var i = 0; i < finishers.length; i++) { var newConstructor = (0, finishers[i])(constructor); if (newConstructor !== undefined) { if (typeof newConstructor !== \\"function\\") { throw new TypeError(\\"Finishers must return a constructor.\\"); } constructor = newConstructor; } } return constructor; }, disallowProperty: function (obj, name, objectType) { if (obj[name] !== undefined) { throw new TypeError(objectType + \\" can't have a .\\" + name + \\" property.\\"); } } }; return api; }
-function _createElementDescriptor(def) { var key = _toPropertyKey(def.key); var descriptor; if (def.kind === \\"method\\") { descriptor = { value: def.value, writable: true, configurable: true, enumerable: false }; } else if (def.kind === \\"get\\") { descriptor = { get: def.value, configurable: true, enumerable: false }; } else if (def.kind === \\"set\\") { descriptor = { set: def.value, configurable: true, enumerable: false }; } else if (def.kind === \\"field\\") { descriptor = { configurable: true, writable: true, enumerable: true }; } var element = { kind: def.kind === \\"field\\" ? \\"field\\" : \\"method\\", key: key, placement: def.static ? \\"static\\" : def.kind === \\"field\\" ? \\"own\\" : \\"prototype\\", descriptor: descriptor }; if (def.decorators) element.decorators = def.decorators; if (def.kind === \\"field\\") element.initializer = def.value; return element; }
-function _coalesceGetterSetter(element, other) { if (element.descriptor.get !== undefined) { other.descriptor.get = element.descriptor.get; } else { other.descriptor.set = element.descriptor.set; } }
-function _coalesceClassElements(elements) { var newElements = []; var isSameElement = function (other) { return other.kind === \\"method\\" && other.key === element.key && other.placement === element.placement; }; for (var i = 0; i < elements.length; i++) { var element = elements[i]; var other; if (element.kind === \\"method\\" && (other = newElements.find(isSameElement))) { if (_isDataDescriptor(element.descriptor) || _isDataDescriptor(other.descriptor)) { if (_hasDecorators(element) || _hasDecorators(other)) { throw new ReferenceError(\\"Duplicated methods (\\" + element.key + \\") can't be decorated.\\"); } other.descriptor = element.descriptor; } else { if (_hasDecorators(element)) { if (_hasDecorators(other)) { throw new ReferenceError(\\"Decorators can't be placed on different accessors with for \\" + \\"the same property (\\" + element.key + \\").\\"); } other.decorators = element.decorators; } _coalesceGetterSetter(element, other); } } else { newElements.push(element); } } return newElements; }
-function _hasDecorators(element) { return element.decorators && element.decorators.length; }
-function _isDataDescriptor(desc) { return desc !== undefined && !(desc.value === undefined && desc.writable === undefined); }
-function _optionalCallableProperty(obj, name) { var value = obj[name]; if (value !== undefined && typeof value !== \\"function\\") { throw new TypeError(\\"Expected '\\" + name + \\"' to be a function\\"); } return value; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, \\"string\\"); return typeof key === \\"symbol\\" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== \\"object\\" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || \\"default\\"); if (typeof res !== \\"object\\") return res; throw new TypeError(\\"@@toPrimitive must return a primitive value.\\"); } return (hint === \\"string\\" ? String : Number)(input); }
-function _toArray(arr) { return _arrayWithHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableRest(); }
-function _nonIterableRest() { throw new TypeError(\\"Invalid attempt to destructure non-iterable instance.In order to be iterable, non-array objects must have a [Symbol.iterator]() method.\\"); }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === \\"string\\") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === \\"Object\\" && o.constructor) n = o.constructor.name; if (n === \\"Map\\" || n === \\"Set\\") return Array.from(o); if (n === \\"Arguments\\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function _iterableToArray(iter) { if (typeof Symbol !== \\"undefined\\" && Symbol.iterator in Object(iter)) return Array.from(iter); }
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-import { customElement, property, LitElement, html, css } from '../_snowpack/pkg/lit-element.js';
-export let AppRoot = _decorate([customElement('app-root')], function (_initialize, _LitElement) {
-  class AppRoot extends _LitElement {
-    constructor(...args) {
-      super(...args);
-      _initialize(this);
-    }
+"var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __decorate = (decorators, target, key, kind) => {
+  var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target;
+  for (var i = decorators.length - 1, decorator; i >= 0; i--)
+    if (decorator = decorators[i])
+      result = (kind ? decorator(target, key, result) : decorator(result)) || result;
+  if (kind && result)
+    __defProp(target, key, result);
+  return result;
+};
+import {customElement, property, LitElement, html, css} from \\"../_snowpack/pkg/lit-element.js\\";
+export let AppRoot = class extends LitElement {
+  constructor() {
+    super(...arguments);
+    this.message = \\"Learn LitElement\\";
   }
-  return {
-    F: AppRoot,
-    d: [{
-      kind: \\"field\\",
-      decorators: [property()],
-      key: \\"message\\",
-      value() {
-        return 'Learn LitElement';
-      }
-    }, {
-      kind: \\"get\\",
-      static: true,
-      key: \\"styles\\",
-      value: function styles() {
-        return css\`
+  static get styles() {
+    return css\`
       h1 {
         font-size: 4rem;
       }
@@ -6924,12 +6904,9 @@ export let AppRoot = _decorate([customElement('app-root')], function (_initializ
         color: white;
       }
     \`;
-      }
-    }, {
-      kind: \\"method\\",
-      key: \\"render\\",
-      value: function render() {
-        return html\`
+  }
+  render() {
+    return html\`
       <div class=\\"wrapper\\">
         <h1>LitElement + Snowpack</h1>
         <p>Edit <code>src/app-root.ts</code> and save to reload.</p>
@@ -6943,13 +6920,17 @@ export let AppRoot = _decorate([customElement('app-root')], function (_initializ
         </a>
       </div>
     \`;
-      }
-    }]
-  };
-}, LitElement);"
+  }
+};
+__decorate([
+  property()
+], AppRoot.prototype, \\"message\\", 2);
+AppRoot = __decorate([
+  customElement(\\"app-root\\")
+], AppRoot);"
 `;
 
-exports[`create-snowpack-app app-template-lit-element-typescript > build: dist/index.js 1`] = `"import './app-root.js';"`;
+exports[`create-snowpack-app app-template-lit-element-typescript > build: dist/index.js 1`] = `"import \\"./app-root.js\\";"`;
 
 exports[`create-snowpack-app app-template-lit-element-typescript > build: index.css 1`] = `
 "body {
@@ -19454,12 +19435,14 @@ Array [
   "dist/App.vue.js",
   "dist/components/Bar.js",
   "dist/components/Bar.module.css",
+  "dist/components/Bar.module.css.json",
   "dist/components/Bar.module.css.proxy.js",
   "dist/components/BarJsx.vue.css",
   "dist/components/BarJsx.vue.css.proxy.js",
   "dist/components/BarJsx.vue.js",
   "dist/components/Foo.js",
   "dist/components/Foo.module.css",
+  "dist/components/Foo.module.css.json",
   "dist/components/Foo.module.css.proxy.js",
   "dist/components/FooTsx.vue.css",
   "dist/components/FooTsx.vue.css.proxy.js",
@@ -19593,16 +19576,7 @@ export default defaultExport;"
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Bar.js 1`] = `
-"import { Fragment } from '../../_snowpack/pkg/vue.js';
-import {createVNode, isVNode} from '../../_snowpack/pkg/vue.js';
-const slice = Array.prototype.slice;
-export function jsx(tag, props = null, children = null) {
-  if (arguments.length > 3 || isVNode(children)) {
-    children = slice.call(arguments, 2);
-  }
-  return createVNode(tag, props, children);
-}
-import {defineComponent, reactive} from \\"../../_snowpack/pkg/vue.js\\";
+"import {defineComponent, reactive} from \\"../../_snowpack/pkg/vue.js\\";
 import styles from \\"./Bar.module.css.proxy.js\\";
 export default defineComponent({
   name: \\"BarJsx\\",
@@ -19610,7 +19584,7 @@ export default defineComponent({
     const state = reactive({
       name: \\"BarJsx\\"
     });
-    return () => /* @__PURE__ */ jsx(Fragment, null, /* @__PURE__ */ jsx(\\"div\\", {
+    return () => /* @__PURE__ */ React.createElement(React.Fragment, null, /* @__PURE__ */ React.createElement(\\"div\\", {
       className: styles[\\"bar-jsx\\"]
     }, state.name));
   }
@@ -19618,10 +19592,12 @@ export default defineComponent({
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Bar.module.css 1`] = `
-".bar-jsx {
+"._bar-jsx_XXXXX_XX {
   color: red;
 }"
 `;
+
+exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Bar.module.css.json 1`] = `"{\\"bar-jsx\\":\\"_bar-jsx_XXXXX_XX\\"}"`;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Bar.module.css.proxy.js 1`] = `
 "
@@ -19683,16 +19659,7 @@ export default defineComponent({
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Foo.js 1`] = `
-"import { Fragment } from '../../_snowpack/pkg/vue.js';
-import {createVNode, isVNode} from '../../_snowpack/pkg/vue.js';
-const slice = Array.prototype.slice;
-export function jsx(tag, props = null, children = null) {
-  if (arguments.length > 3 || isVNode(children)) {
-    children = slice.call(arguments, 2);
-  }
-  return createVNode(tag, props, children);
-}
-import {defineComponent, reactive} from \\"../../_snowpack/pkg/vue.js\\";
+"import {defineComponent, reactive} from \\"../../_snowpack/pkg/vue.js\\";
 import styles from \\"./Foo.module.css.proxy.js\\";
 export default defineComponent({
   name: \\"FooTsx\\",
@@ -19700,7 +19667,7 @@ export default defineComponent({
     const state = reactive({
       name: \\"FooTsx\\"
     });
-    return () => /* @__PURE__ */ jsx(Fragment, null, /* @__PURE__ */ jsx(\\"div\\", {
+    return () => /* @__PURE__ */ React.createElement(React.Fragment, null, /* @__PURE__ */ React.createElement(\\"div\\", {
       className: styles[\\"foo-tsx\\"]
     }, state.name));
   }
@@ -19708,10 +19675,12 @@ export default defineComponent({
 `;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Foo.module.css 1`] = `
-".foo-tsx {
+"._foo-tsx_XXXXX_XX {
     color: green;
 }"
 `;
+
+exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Foo.module.css.json 1`] = `"{\\"foo-tsx\\":\\"_foo-tsx_XXXXX_XX\\"}"`;
 
 exports[`create-snowpack-app app-template-vue-typescript > build: dist/components/Foo.module.css.proxy.js 1`] = `
 "


### PR DESCRIPTION
## Changes

CSS Modules, when generated by Snowpack, are missing from SSR builds. This PR is a quick unblocker to get that working. This PR only affects the build & SSR responses, and leaves dev server as-is.

#### Problem

The problem with Snowpack and CSS Modules is two-fold:

1. Snowpack doesn‘t have full support for nested extensions (`.module.css`). We don’t have the ability to target behavior based on a nested extension. This is good when you _do_ want to run the same CSS passes on everything. But bad for CSS Modules when we need an extra step to run there and only there.
2. Snowpack generates the CSS Module response within the `.module.css.proxy.js` file. This means during SSR, we end up with an incorrect `.css` file that doesn’t match the transformed values. We can’t just run the proxy file, either, as that tries to add `<style>` tags to a DOM that doesn’t exist (yet).
 
#### This PR

This PR doesn’t address #1, as that’s a much larger, more sweeping change across Snowpack that also has plugin implications. But it does resolve #2, moving the CSS Module pass into a centralized place that transforms the CSS. And then it updates the proxy file to use the new CSS Module code.

This PR doesn’t change the dev server response. It does change the build result, but not in a way that affects users (the output CSS now has the correct CSS Module names, which is expected, and there’s an addition of a `.module.css.json` file with module names, but it is only used if users manually do something with it). This PR does fix the SSR response so that the correct transformed CSS is not only output; it’s included in the `css` array for response.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

✅ Tested dev server and it works as it did before
<img width="1272" alt="Screen Shot 2021-04-15 at 22 25 36" src="https://user-images.githubusercontent.com/1369770/115054322-59e27700-9e9d-11eb-97d5-6f2c0303e082.png">
✅ Updated our `css-modules` build test to ensure build is working, too.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs needed; behind-the-scenes
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
