### PR TITLE
Fix broken image import in bundled build.

### DIFF
--- a/snowpack/src/build/process.ts
+++ b/snowpack/src/build/process.ts
@@ -110,8 +110,6 @@ export async function createBuildState(commandOptions: CommandOptions): Promise<
   const isSSR = !!config.buildOptions.ssr;
   const isHMR = getIsHmrEnabled(config);
 
-  // Seems like maybe we shouldn't be doing this...
-  config.buildOptions.resolveProxyImports = !config.optimize?.bundle;
   config.devOptions.hmrPort = isHMR ? config.devOptions.hmrPort : undefined;
   config.devOptions.port = 0;
 


### PR DESCRIPTION
The line I removed set resolveProxyImports to false for bundled builds and cause image and json files to be imported directly instead of through proxy imports.

```js
// build/dist/App.js
import logo from "./logo.svg";
```

This change fixes:

[BUG] sowpack bundle build generate import statement for images and json files #3109
https://github.com/snowpackjs/snowpack/issues/3109

## Changes

This change prevents optimize.bundle to automatically set buildOptions.resolveProxyImports to false.

## Testing

Tested bundled builds with @snowpack/app-template-react and the the proxy imports is properly resolved to:

```
// build/dist/logo.svg.proxy.js
var logo_svg_proxy_default = "/dist/logo.svg";
```

## Docs

Bug fix only
