### PR TITLE
Correctly resolve preload urls from build manifest

### DIFF
--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -43,7 +43,7 @@ function collectDeepImports(
   set: Set<string>,
 ): void {
   const buildPrefix = removeLeadingSlash(config.buildOptions.out.replace(process.cwd(), ''));
-  const normalizedUrl = !url.startsWith(buildPrefix) ? path.join(buildPrefix, url) : url;
+  const normalizedUrl = !url.startsWith(buildPrefix) ? path.posix.join(buildPrefix, url) : url;
   const relativeImportUrl = url.replace(buildPrefix, '');
 
   if (set.has(relativeImportUrl)) {

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -42,11 +42,11 @@ function collectDeepImports(
   manifest: SnowpackMetaManifest,
   set: Set<string>,
 ): void {
-  const buildPrefix = removeLeadingSlash(config.buildOptions.out.replace(process.cwd(), ''));
+  const buildPrefix = removeLeadingSlash(config.buildOptions.out.replace(process.cwd(), '')).split(path.sep).join(path.posix.sep);
   const normalizedUrl = !url.startsWith(buildPrefix) ? path.posix.join(buildPrefix, url) : url;
   const relativeImportUrl = url.replace(buildPrefix, '');
 
-  console.log(buildPrefix, normalizedUrl, manifest)
+  console.log(buildPrefix, normalizedUrl, manifest);
 
   if (set.has(relativeImportUrl)) {
     return;

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -46,6 +46,8 @@ function collectDeepImports(
   const normalizedUrl = !url.startsWith(buildPrefix) ? path.posix.join(buildPrefix, url) : url;
   const relativeImportUrl = url.replace(buildPrefix, '');
 
+  console.log(buildPrefix, normalizedUrl, manifest)
+
   if (set.has(relativeImportUrl)) {
     return;
   }

--- a/test/snowpack/config/optimize/index.test.js
+++ b/test/snowpack/config/optimize/index.test.js
@@ -210,4 +210,49 @@ describe('optimize', () => {
     expect(result['_snowpack/pkg/array-flatten.js']).toBeDefined();
     expect(result['_snowpack/pkg/async.js']).toBeDefined();
   });
+
+  it('Creates preload links from entrypoints in HTML', async () => {
+    const result = await testFixture({
+      'public/index.html': dedent`
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta name="description" content="Web site created using create-snowpack-app" />
+            <link rel="stylesheet" type="text/css" href="/index.css" />
+            <title>Snowpack App</title>
+          </head>
+          <body>
+            <app-root></app-root>
+            <noscript>You need to enable JavaScript to run this app.</noscript>
+            <script type="module" src="/dist/index.js"></script>
+          </body>
+        </html> 
+      `,
+      'public/index.css': dedent`
+        body {
+          background: red;
+        }
+      `,
+      'src/app-root.ts': dedent`
+        import './app-root';
+      `,
+      'src/index.ts': dedent`
+        import './app-root';
+      `,
+      'snowpack.config.js': dedent`
+        module.exports = {
+          mount: {
+            public: { url: '/', static: true },
+            src: { url: '/dist' },
+          },
+          optimize: { preload: true },
+        };
+      `,
+    });
+
+    expect(result['index.html']).toContain('<link rel="modulepreload" href="/dist/index.js">');
+    expect(result['index.html']).toContain('<link rel="modulepreload" href="/dist/app-root.js">');
+  });
 });


### PR DESCRIPTION
## Changes

Fixes #3193 where the build would fail when `{ optimize: { preload: true  }}` was used in the config.

The error was due to trying to lookup keys in the manifest.imports that did not exist. This was because the keys (file paths) were not normalized to match how esbuild keys the imports in its metafile.

It seems that esbuild prefixes the keys (file paths) in `metafile.imports` with the supplied `outbase` (which is `config.buildOptions.out`) relative to the current working directory.

In order to make sure the preloadScripts are found in the manifest, the urls passed in to `collectDeepImports` are normalized appropriately; top level paths require the build prefix adding, imports found recursively within the manifest itself already have the appropriate prefix, both will have the prefix removed before being added to `collectedDeepImports` which eventually find their way into the HTML.

## Testing

Successfully reproduced the bug by following the steps outlined in the issue, then created a new test including the preload option in the config. This now lives in `snowpack/test/optimize` and is passing locally.

## Docs

Bug fix only.