### PR TITLE
Update readme to add missing mention of `env.local` support

### DIFF
--- a/plugins/plugin-dotenv/README.md
+++ b/plugins/plugin-dotenv/README.md
@@ -24,6 +24,7 @@ SNOWPACK_PUBLIC_ENABLE_FEATURE=true
 
 - [dotenv-expand](https://github.com/motdotla/dotenv-expand)
 - `.env.NODE_ENV.local`
+- `.env.local`
 - `.env.NODE_ENV`
 - `.env`
 


### PR DESCRIPTION
## Changes

The readme was missing the fact that `env.local` is supported, which is confirmed by the test suite.

## Testing

N/A

## Docs

N/A
