### PR TITLE
Set `preventAssignment` option of rollup-plugin-replace to true

### DIFF
--- a/esinstall/package.json
+++ b/esinstall/package.json
@@ -43,7 +43,7 @@
     "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
-    "@rollup/plugin-replace": "^2.3.3",
+    "@rollup/plugin-replace": "^2.4.2",
     "builtin-modules": "^3.2.0",
     "cjs-module-lexer": "^1.0.0",
     "es-module-lexer": "^0.3.24",

--- a/esinstall/src/index.ts
+++ b/esinstall/src/index.ts
@@ -329,7 +329,10 @@ ${colors.dim(
         namedExports: true,
       }),
       rollupPluginCss(),
-      rollupPluginReplace(generateReplacements(env)),
+      rollupPluginReplace({
+        preventAssignment: true,
+        values: generateReplacements(env),
+      }),
       rollupPluginCommonjs({
         extensions: ['.js', '.cjs'],
         esmExternals: Array.isArray(externalEsm)

--- a/test/esinstall/dep-list-simple/__snapshots__
+++ b/test/esinstall/dep-list-simple/__snapshots__
@@ -7,7 +7,7 @@ Array [
 ]
 `;
 
-exports[`dep-list-simple matches the snapshot: cli output 1`] = `"@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to \`true\`, as the next major version will default this option to \`true\`."`;
+exports[`dep-list-simple matches the snapshot: cli output 1`] = `""`;
 
 exports[`dep-list-simple matches the snapshot: web_modules/async.js 1`] = `
 "/* SNOWPACK PROCESS POLYFILL (based on https://github.com/calvinmetcalf/node-process-es6) */

--- a/test/esinstall/exclude-external-packages/__snapshots__
+++ b/test/esinstall/exclude-external-packages/__snapshots__
@@ -7,7 +7,7 @@ Array [
 ]
 `;
 
-exports[`exclude-external-packages matches the snapshot: cli output 1`] = `"@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to \`true\`, as the next major version will default this option to \`true\`."`;
+exports[`exclude-external-packages matches the snapshot: cli output 1`] = `""`;
 
 exports[`exclude-external-packages matches the snapshot: web_modules/import-map.json 1`] = `
 "{

--- a/test/esinstall/package-react/__snapshots__
+++ b/test/esinstall/package-react/__snapshots__
@@ -8,7 +8,7 @@ Array [
 ]
 `;
 
-exports[`package-react matches the snapshot: cli output 1`] = `"@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to \`true\`, as the next major version will default this option to \`true\`."`;
+exports[`package-react matches the snapshot: cli output 1`] = `""`;
 
 exports[`package-react matches the snapshot: web_modules/import-map.json 1`] = `
 "{

--- a/test/esinstall/source-map-strip/__snapshots__
+++ b/test/esinstall/source-map-strip/__snapshots__
@@ -7,7 +7,7 @@ Array [
 ]
 `;
 
-exports[`source-map-strip matches the snapshot: cli output 1`] = `"@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to \`true\`, as the next major version will default this option to \`true\`."`;
+exports[`source-map-strip matches the snapshot: cli output 1`] = `""`;
 
 exports[`source-map-strip matches the snapshot: web_modules/@auth0/auth0-spa-js.js 1`] = `
 "/*! *****************************************************************************

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,7 +2557,7 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-replace@^2.3.3":
+"@rollup/plugin-replace@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz#a2d539314fbc77c244858faa523012825068510a"
   integrity sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==


### PR DESCRIPTION
## Changes

Fixes #3151.

This sets the `preventAssignment` option of rollup-plugin-replace to true.  It moves the other replacements into a `values` key, as documented in https://github.com/rollup/plugins/tree/master/packages/replace#values

## Testing

I ran an `npm link` and tested in my app.  No more deprecation warnings were printed.  You can also see that the snapshots were updated to remove the warnings.

## Docs

Docs were not updated.  This only removes a deprecation warning during builds.
