### PR TITLE
Fix websocket proxying

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -838,9 +838,6 @@ export async function startServer(
     const matchedRouteHandler = matchRouteHandler(reqUrl, 'upgrade');
     if (matchedRouteHandler) {
       matchedRouteHandler(req, socket, head);
-      // NOTE(fks): Why do we destory the socket here? Is it so that HMR client doesn't hijack?
-      socket.destroy();
-      return;
     }
   }
 


### PR DESCRIPTION
## Changes

Fixes web socket proxying, as discussed in https://github.com/snowpackjs/snowpack/pull/3073

## Some context

There are currently two places where the dev server listens to web socket 'upgrade' events:

- in `createServer`, to handle custom proxying routes: https://github.com/snowpackjs/snowpack/blob/1ddacd646d445251b7c43116df384cc05b58bc58/snowpack/src/commands/dev.ts#L874
- in `EsmHmrEngine`: https://github.com/snowpackjs/snowpack/blob/1ddacd646d445251b7c43116df384cc05b58bc58/snowpack/src/hmr-server-engine.ts#L55

> Note: in the future there might be more places where we listen to websocket upgrades: if a plugin system allows it for example, or if we need more websocket connections?

When [websocket proxying was introduced](https://github.com/snowpackjs/snowpack/commit/844cbcbeb577885a535b0b4e43395f06d71765f1#diff-71665e88d7a453bdcd75407adf4c33c4462f08002e3af074bb66487a0311688dR802), it broke HMR engine because it assumed that no other handler would need the socket. A [recent change](https://github.com/snowpackjs/snowpack/commit/0663c1acecf776dc941a7b8c1a339214ab1593de) moved `socket.destroy()` to fix the issue but also broke socket proxying.

**The underlying issue is that we don't know in `handleUpgrade` if another handler might need the socket or not. We cannot close it because it might still be in use.**
There might be a slight memory leak risk, in case the frontend opens connections that are never closed, but I think this should be the responsibility of the frontend to not do that.

## Testing

Here's a reproduction repository: https://github.com/gaelduplessix/snowpack-app/tree/proxy-example

Run `yarn start` to start snowpack and a dummy websocket server.

### Without the patch

"Socket closed" is logged in console:
<img width="172" alt="image" src="https://user-images.githubusercontent.com/2292908/116439350-4c65af00-a804-11eb-9bcc-5b7f45989fbf.png">

And "WS Result" is empty:
<img width="273" alt="image" src="https://user-images.githubusercontent.com/2292908/116439408-5be4f800-a804-11eb-861e-9bd5478227ca.png">

### With the patch

Console shows connection logs:
<img width="453" alt="image" src="https://user-images.githubusercontent.com/2292908/116439511-7cad4d80-a804-11eb-9790-d39b2ec4416f.png">

"WS Result" shows "Hello World"
<img width="277" alt="image" src="https://user-images.githubusercontent.com/2292908/116439469-6f905e80-a804-11eb-8cf2-2472d7dbf174.png">
