### PR TITLE
chore: bump Snowpack version

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowpack",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "The ESM-powered frontend build tool. Fast, lightweight, unbundled.",
   "author": "Fred K. Schott <fkschott@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Manually done because CI failed: https://github.com/snowpackjs/snowpack/actions/runs/771232120