### PR TITLE
fix: CSS Modules exporting {} when no mount config

### DIFF
--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -103,6 +103,7 @@ async function runPipelineLoadStep(
           url = srcPath
             .replace(dir, config.mount[dir].url)
             .replace(/\\/g, '/')
+            .replace(/\/+/g, '/')
             .replace(/\.(scss|sass)$/i, '.css');
           break;
         }

--- a/test/snowpack/cssModules/index.test.js
+++ b/test/snowpack/cssModules/index.test.js
@@ -128,6 +128,19 @@ describe('cssModules', () => {
     expect(result['_dist_/App.module.css.json']).toBeDefined();
   });
 
+  it('Generates CSS Modules (unmounted)', async () => {
+    const result = await testFixture({
+      ...files(),
+    });
+
+    // (same as above, just at different path)
+    expect(result['src/App.js']).toContain(`import Styles from "./App.module.css.proxy.js";`);
+    expect(result['src/App.module.css.proxy.js']).toMatch(/\._App_[A-Za-z0-9]+_[A-Za-z0-9]+ \{/);
+    expect(result['src/App.module.css.proxy.js']).toContain(`let json = {"App":"_App_`);
+    expect(result['src/App.module.css']).not.toContain(`.App {`);
+    expect(result['src/App.module.css.json']).toBeDefined();
+  });
+
   it('Generates CSS Modules from Sass', async () => {
     const result = await testFixture({
       ...files('.scss'),


### PR DESCRIPTION
## Changes

Fixes #3219. For CSS modules mounted at the root, there was a bug in JSON generation. The bug is fixed in this PR and a test added to make sure this doesn’t happen again.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tests added

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Bugfix; no docs needed

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
