### PR TITLE
Fix missing build files from load plugins

### DIFF
--- a/snowpack/src/build/file-builder.ts
+++ b/snowpack/src/build/file-builder.ts
@@ -85,15 +85,12 @@ export class FileBuilder {
     this.urls = urls;
   }
 
-  private verifyRequestFromBuild(type: string): SnowpackBuiltFile {
-    // Verify that the requested file exists in the build output map.
-    if (!this.resolvedOutput[type] || !Object.keys(this.resolvedOutput).length) {
+  private verifyRequestFromBuild(type: string): SnowpackBuiltFile | undefined {
+    const possibleExtensions = this.urls.map((url) => path.extname(url));
+    if (!possibleExtensions.includes(type))
       throw new Error(
-        `${this.loc} - Requested content "${type}" but built ${
-          Object.keys(this.resolvedOutput).toString() || 'none'
-        }.`,
+        `${this.loc} - Requested content "${type}" but only built ${possibleExtensions.join(', ')}`,
       );
-    }
     return this.resolvedOutput[type];
   }
 
@@ -325,9 +322,12 @@ export class FileBuilder {
     return content;
   }
 
-  getResult(type: string): string | Buffer {
-    const {code /*, map */} = this.verifyRequestFromBuild(type);
-    return code;
+  getResult(type: string): string | Buffer | undefined {
+    const result = this.verifyRequestFromBuild(type);
+    if (result) {
+      // TODO: return result.map
+      return result.code;
+    }
   }
 
   getSourceMap(type: string): string | undefined {

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -54,16 +54,21 @@ export interface LoadUrlOptions {
   encoding?: undefined | BufferEncoding | null;
   importMap?: ImportMap;
 }
+
 export interface SnowpackDevServer {
   port: number;
   hmrEngine?: EsmHmrEngine;
   rawServer?: http.Server | http2.Http2Server | undefined;
   loadUrl: {
     (reqUrl: string, opt?: (LoadUrlOptions & {encoding?: undefined}) | undefined): Promise<
-      LoadResult<Buffer | string>
+      LoadResult<Buffer | string> | undefined
     >;
-    (reqUrl: string, opt: LoadUrlOptions & {encoding: BufferEncoding}): Promise<LoadResult<string>>;
-    (reqUrl: string, opt: LoadUrlOptions & {encoding: null}): Promise<LoadResult<Buffer>>;
+    (reqUrl: string, opt: LoadUrlOptions & {encoding: BufferEncoding}): Promise<
+      LoadResult<string> | undefined
+    >;
+    (reqUrl: string, opt: LoadUrlOptions & {encoding: null}): Promise<
+      LoadResult<Buffer> | undefined
+    >;
   };
   handleRequest: (
     req: http.IncomingMessage,

--- a/test/snowpack/plugin/custom/index.test.js
+++ b/test/snowpack/plugin/custom/index.test.js
@@ -1,0 +1,46 @@
+const {testFixture} = require('../../../fixture-utils');
+const dedent = require('dedent');
+
+describe('custom plugin', () => {
+  it('allows custom filetypes to be created', async () => {
+    const result = await testFixture({
+      'dev/html-plugin.js': dedent`
+        module.exports = function htmlPlugin(_snowpackConfig, _pluginOptions) {
+          return {
+            name: 'html-plugin',
+            resolve: {
+              input: ['.h1'],
+              output: ['.html', '.css'],
+            },
+            async load() {
+              return {
+                '.html': { code: '<h1>Hello world</h1>' },
+                '.css': { code: '.h1 { color: red }' },
+              }
+            },
+          }
+        }
+      `,
+      'src/test.h1': ``, // empty file (generated via plugin)
+      'snowpack.config.json': dedent`
+        {
+          "mount": {
+            "src": "/"
+          },
+          "plugins": [
+            "./dev/html-plugin.js"
+          ]
+        }
+      `,
+    });
+
+    // Test 1: HTML is correctly output
+    expect(result['test.h1.html']).toBe(`<h1>Hello world</h1>`);
+
+    // Test 2: CSS is correctly output
+    expect(result['test.h1.css']).toBe(`.h1 { color: red }`);
+
+    // Test 3: the source file didn’t clutter up the build folder
+    expect(result['test.h1']).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Changes

Fixes #3099. This resolves an issue where a load plugin would generate files, only to be discarded.

This was caused by a discrepancy in how we said load plugins worked, vs how they actually worked.

Consider the Svelte output, for instance:

```js
  input: ['.svelte'],
  output: ['.js', '.css'],
```

In Svelte’s case, it will always output JS, but only sometimes output CSS. In the v3.1 changes, we changed the behavior of Snowpack to say ”because CSS may or may not exist, it won’t be requested.” I believe the intent was that this would happen as some sort of followup step, which in some cases wouldn’t be hit. This led to #3099, where some files were just simply never requested.

This PR makes a change to Snowpack that makes it more comfortable requesting conditional outputs that may or may not exist. It also cleans up some false type assertions that were getting in the way.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Test added.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Bugfix; no documentation necessary.

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
