### PR TITLE
avoid conflicting JS entries when parsing HTML for Webpack

### DIFF
--- a/plugins/plugin-webpack/.gitignore
+++ b/plugins/plugin-webpack/.gitignore
@@ -1,1 +1,1 @@
-test/stubs/minimal_ignore/
+test/stubs/*_ignore/

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -33,7 +33,13 @@ function parseHTMLFiles({buildDirectory}) {
     for (const el of scripts) {
       const src = el.src.trim();
       const parsedPath = path.parse(src);
-      const name = parsedPath.name;
+
+      // Using path + filename to avoid problems if files have the same name, i.e.
+      // /index.js and /admin/index.js
+      const name = path.join(parsedPath.dir, parsedPath.name)
+        // Paths other than the root will have a leading separator
+        .match(/[\\/]?(.+)/)[1];
+
       if (!(name in jsEntries)) {
         jsEntries[name] = {
           path: path.join(buildDirectory, src),

--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -37,8 +37,9 @@ function parseHTMLFiles({buildDirectory}) {
       // Using path + filename to avoid problems if files have the same name, i.e.
       // /index.js and /admin/index.js
       const name = path.join(parsedPath.dir, parsedPath.name)
+        .replace(/\\/g, '/')
         // Paths other than the root will have a leading separator
-        .match(/[\\/]?(.+)/)[1];
+        .replace(/^\//, '');
 
       if (!(name in jsEntries)) {
         jsEntries[name] = {

--- a/plugins/plugin-webpack/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-webpack/test/__snapshots__/plugin.test.js.snap
@@ -101,3 +101,39 @@ console.log('test');
   },
 ]
 `;
+
+exports[`@snowpack/plugin-webpack multiple entrypoints w/ same filename: files 1`] = `
+Array [
+  Object {
+    "content": "<!DOCTYPE html><html lang=\\"en\\"><head><meta charset=\\"UTF-8\\"><title>Multiple entrypoints test - root</title></head><body><script src=\\"/js/webpack-runtime.XXXXXXXXXXXXXXXXXXXX.js\\" async=\\"\\" defer=\\"\\"></script><script src=\\"/js/index.XXXXXXXXXXXXXXXXXXXX.js\\" async=\\"\\" defer=\\"\\"></script></body></html>",
+    "filename": "index.html",
+  },
+  Object {
+    "content": "console.log('root test');
+",
+    "filename": "index.js",
+  },
+  Object {
+    "content": "{
+  \\"name\\": \\"plugin-webpack-test-minimal\\",
+  \\"main\\": \\"src/index.js\\"
+}
+",
+    "filename": "package.json",
+  },
+]
+`;
+
+exports[`@snowpack/plugin-webpack multiple entrypoints w/ same filename: files 2`] = `
+Array [
+  Object {
+    "content": "<!DOCTYPE html><html lang=\\"en\\"><head><meta charset=\\"UTF-8\\"><title>Multiple entrypoints test - /admin</title></head><body><script src=\\"/js/webpack-runtime.XXXXXXXXXXXXXXXXXXXX.js\\" async=\\"\\" defer=\\"\\"></script><script src=\\"/js/admin/index.XXXXXXXXXXXXXXXXXXXX.js\\" async=\\"\\" defer=\\"\\"></script></body></html>",
+    "filename": "index.html",
+  },
+  Object {
+    "content": "console.log('admin test');
+",
+    "filename": "index.js",
+  },
+]
+`;

--- a/plugins/plugin-webpack/test/plugin.test.js
+++ b/plugins/plugin-webpack/test/plugin.test.js
@@ -7,15 +7,22 @@ const readFilesSync = require('./readFilesSync');
 const STUBS_DIR = path.join(__dirname, 'stubs/minimal/');
 const IGNORED_STUBS_DIR = path.join(__dirname, 'stubs/minimal_ignore/');
 
+const MULTIPLE_DIR = path.join(__dirname, 'stubs/multiple-entrypoints/');
+const IGNORED_MULTIPLE_DIR = path.join(__dirname, 'stubs/multiple-entrypoints_ignore/');
+
 describe('@snowpack/plugin-webpack', () => {
   // Copy over the stub folder to an git-ignored path and mock console.log
   beforeEach(() => {
     if (fs.existsSync(IGNORED_STUBS_DIR)) fs.removeSync(IGNORED_STUBS_DIR);
     fs.copySync(STUBS_DIR, IGNORED_STUBS_DIR);
+
+    if (fs.existsSync(IGNORED_MULTIPLE_DIR)) fs.removeSync(IGNORED_MULTIPLE_DIR);
+    fs.copySync(MULTIPLE_DIR, IGNORED_MULTIPLE_DIR);
   });
 
   afterAll(() => {
     if (fs.existsSync(IGNORED_STUBS_DIR)) fs.removeSync(IGNORED_STUBS_DIR);
+    if (fs.existsSync(IGNORED_MULTIPLE_DIR)) fs.removeSync(IGNORED_MULTIPLE_DIR);
   });
 
   it('minimal - no options', async () => {
@@ -51,5 +58,26 @@ describe('@snowpack/plugin-webpack', () => {
     });
 
     expect(readFilesSync(IGNORED_STUBS_DIR)).toMatchSnapshot('files');
+  });
+
+  it('multiple entrypoints w/ same filename', async () => {
+    const pluginInstance = plugin({
+      buildOptions: {},
+    });
+
+    await pluginInstance.optimize({
+      buildDirectory: IGNORED_MULTIPLE_DIR,
+    });
+
+    const rootHtml = fs.readFileSync(path.join(IGNORED_MULTIPLE_DIR, 'index.html'), { encoding: 'utf8' });
+    const adminHtml = fs.readFileSync(path.join(IGNORED_MULTIPLE_DIR, 'admin/index.html'), { encoding: 'utf8' });
+
+    const rootScripts = rootHtml.match(/<script src="([^>]+)">/g);
+    const adminScripts = adminHtml.match(/<script src="([^>]+)">/g);
+
+    expect(rootScripts).not.toEqual(expect.arrayContaining(adminScripts));
+
+    expect(readFilesSync(IGNORED_MULTIPLE_DIR)).toMatchSnapshot('files');
+    expect(readFilesSync(path.join(IGNORED_MULTIPLE_DIR, 'admin'))).toMatchSnapshot('files');
   });
 });

--- a/plugins/plugin-webpack/test/stubs/multiple-entrypoints/admin/index.html
+++ b/plugins/plugin-webpack/test/stubs/multiple-entrypoints/admin/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Multiple entrypoints test - /admin</title>
+  </head>
+  <body>
+    <script type="module" src="/admin/index.js" async defer></script>
+  </body>
+</html>

--- a/plugins/plugin-webpack/test/stubs/multiple-entrypoints/admin/index.js
+++ b/plugins/plugin-webpack/test/stubs/multiple-entrypoints/admin/index.js
@@ -1,0 +1,1 @@
+console.log('admin test');

--- a/plugins/plugin-webpack/test/stubs/multiple-entrypoints/index.html
+++ b/plugins/plugin-webpack/test/stubs/multiple-entrypoints/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Multiple entrypoints test - root</title>
+  </head>
+  <body>
+    <script type="module" src="index.js" async defer></script>
+  </body>
+</html>

--- a/plugins/plugin-webpack/test/stubs/multiple-entrypoints/index.js
+++ b/plugins/plugin-webpack/test/stubs/multiple-entrypoints/index.js
@@ -1,0 +1,1 @@
+console.log('root test');

--- a/plugins/plugin-webpack/test/stubs/multiple-entrypoints/package.json
+++ b/plugins/plugin-webpack/test/stubs/multiple-entrypoints/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "plugin-webpack-test-minimal",
+  "main": "src/index.js"
+}


### PR DESCRIPTION
## Changes

If multiple entrypoints load scripts with the same filename, such as:
```
// index.html
<script src="/index.js"></script>

// admin/index.html
<script src="/admin/index.js"></script>
```
the Webpack plugin generates references to only the last JS file it parsed and adds script tags for it in each entrypoint, rather than bundling and tagging their scripts separately.

### Example
These files originally had the script tags listed above.
```
// index.html
<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Multiple entrypoints test - root</title></head><body><script src="/js/webpack-runtime.b633529d123a156852b7.js" async="" defer=""></script><script src="/js/index.cae95caeabd315ef3db2.js" async="" defer=""></script></body></html>

// admin/index.html
<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Multiple entrypoints test - /admin</title></head><body><script src="/js/webpack-runtime.b633529d123a156852b7.js" async="" defer=""></script><script src="/js/index.cae95caeabd315ef3db2.js" async="" defer=""></script></body></html>
```

This PR uses paths + filenames (`index`, `admin/index`) relative to the build directory for JS entries rather than just the name (`index`) to avoid keys being written over each other.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->

- Added a test for this case to the Webpack plugin
- Tested in my own project

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Bug fix.
