### PR TITLE
fix Webpack error formatting

### DIFF
--- a/plugins/plugin-webpack/plugin.js
+++ b/plugins/plugin-webpack/plugin.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
+const util = require('util');
 const url = require('url');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -396,12 +397,12 @@ module.exports = function plugin(config, args = {}) {
           }
           const info = stats.toJson(extendedConfig.stats);
           if (stats.hasErrors()) {
-            console.error('Webpack errors:\n' + info.errors.join('\n-----\n'));
+            console.error('Webpack errors:\n' + info.errors.map((err) => err.message).join('\n-----\n'));
             reject(Error(`Webpack failed with ${info.errors} error(s).`));
             return;
           }
           if (stats.hasWarnings()) {
-            console.error('Webpack warnings:\n' + info.warnings.join('\n-----\n'));
+            console.error('Webpack warnings:\n' + info.warnings.map((err) => err.message).join('\n-----\n'));
             if (args.failOnWarnings) {
               reject(Error(`Webpack failed with ${info.warnings} warnings(s).`));
               return;


### PR DESCRIPTION
## Changes

This PR updates the Webpack plugin's error logs to match changes to the returned errors in Webpack 5.

#### Webpack 4
```
Webpack warnings:
asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  js/index.d904624102a1d2a471b9.js (611 KiB)
-----
entrypoint size limit: The following entrypoint(s) combined asset size exceeds...
...
```

#### Webpack 5 (Current)
```
Webpack warnings:
[object Object]
-----
[object Object]
...
```

#### This PR
```
Webpack warnings:
asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  js/index.bb849e436b06c7be72e6.js (517 KiB)
-----
entrypoint size limit: The following entrypoint(s) combined asset size exceeds...
...
```
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested against an existing project.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Bug fix only.