### PR TITLE
Remove an empty bullet in the `mount` documentation.

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,7 +76,6 @@ Mount local directories to custom URLs in your built application.
 - `mount.url` | `string` | _required_ : The URL to mount to, matching the string in the simple form above.
 - `mount.static` | `boolean` | _optional_ | **Default**: `false` : If true, don't build files in this directory. Copy and serve them directly from disk to the browser.
 - `mount.resolve` | `boolean` | _optional_ | **Default**: `true`: If false, don't resolve JS & CSS imports in your JS, CSS, and HTML files. Instead send every import to the browser, as written.
--
 
 Example:
 


### PR DESCRIPTION
Small formatting fix.