### PR TITLE
Fix appending port 80 to url sometimes breaks hmr connectivity #3268

### DIFF
--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -50,6 +50,7 @@ let socketURL = isWindowDefined && window.HMR_WEBSOCKET_URL;
 if (!socketURL) {
   const socketHost =
     isWindowDefined && window.HMR_WEBSOCKET_PORT
+      ? window.HMR_WEBSOCKET_PORT === 80 ? location.host
       ? `${location.hostname}:${window.HMR_WEBSOCKET_PORT}`
       : location.host;
   socketURL = (location.protocol === 'http:' ? 'ws://' : 'wss://') + socketHost + '/';

--- a/snowpack/assets/hmr-client.js
+++ b/snowpack/assets/hmr-client.js
@@ -49,8 +49,7 @@ function sendSocketMessage(msg) {
 let socketURL = isWindowDefined && window.HMR_WEBSOCKET_URL;
 if (!socketURL) {
   const socketHost =
-    isWindowDefined && window.HMR_WEBSOCKET_PORT
-      ? window.HMR_WEBSOCKET_PORT === 80 ? location.host
+    isWindowDefined && window.HMR_WEBSOCKET_PORT && (window.HMR_WEBSOCKET_PORT !== 80)
       ? `${location.hostname}:${window.HMR_WEBSOCKET_PORT}`
       : location.host;
   socketURL = (location.protocol === 'http:' ? 'ws://' : 'wss://') + socketHost + '/';


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

When hmrPort is set to 80, the port number is not appended to the HMR URL

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

Manually tested on a fresh snowpack install with fix applied on Google Cloud Shell.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only
