### PR TITLE
Typo on class OneToManyMap

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -59,7 +59,7 @@ export class OneToManyMap {
     this.keyToValue.delete(key);
     if (value) {
       for (const val of value) {
-        this.keyToValue.delete(val);
+        this.valueToKey.delete(val);
       }
     }
   }


### PR DESCRIPTION
I think it is a typo which may give rise to tiny bit performance issue.

## Changes

<!-- What does this change, in plain language? -->
A typo fixed
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I think it is not necessary to add test.
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
