### PR TITLE
:fire: Remove `.jsx` extension on `import`

### DIFF
--- a/docs/tutorials/react.md
+++ b/docs/tutorials/react.md
@@ -173,7 +173,9 @@ Now include it in `index.jsx`
   import React from 'react';
   import ReactDOM from 'react-dom';
 - ReactDOM.render(<div>"HELLO WORLD"</div>, document.getElementById('root'));
-+ import App from './App.jsx';
+
++ // No need to specify `.jsx` on imports
++ import App from './App';
 + ReactDOM.render(
 +   <React.StrictMode>
 +     <App />


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
It simplifies the `import` to not have `.jsx`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
It wasn't...because it just removes the `.jsx` extension.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
This was just shwon in the code snippet, and was not called out in the public documentation originally.