### PR TITLE
Add support for PostCSS dependency messages

### DIFF
--- a/plugins/plugin-postcss/worker.js
+++ b/plugins/plugin-postcss/worker.js
@@ -15,7 +15,7 @@ async function transformAsync(css, {filepath, config, cwd, map}) {
   }
 
   const result = await process(css);
-  return JSON.stringify({css: result.css, map: result.map});
+  return JSON.stringify({css: result.css, map: result.map, messages: result.messages});
 }
 
 // create a worker and register public functions


### PR DESCRIPTION
## Changes

This pull request adds support to `@snowpack/plugin-postcss` for dependency messages created by PostCSS plugins. These messages are used to signify to runners that the PostCSS compilation depends on files or directories other than the input file. The CSS should be rebuilt when these change.

Relevant documentation: https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies

## Testing

I'm really not sure how to add tests for this. Would appreciate any input on that!

## Docs

No docs added as this is not a user-facing change. The messages are created by PostCSS plugins and handled internally by `@snowpack/plugin-postcss`