### PR TITLE
resolve `.css` ESM imports to `.css.{js,ts}` if there's no `.css` file on disk

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -33,8 +33,6 @@ function resolveSourceSpecifier(
 
   if (lazyFileStat && lazyFileStat.isFile()) {
     lazyFileLoc = lazyFileLoc;
-  } else if (hasExtension(lazyFileLoc, '.css')) {
-    lazyFileLoc = lazyFileLoc;
   } else if (hasExtension(lazyFileLoc, '.js')) {
     const tsWorkaroundImportFileLoc = replaceExtension(lazyFileLoc, '.js', '.ts');
     if (getFsStat(tsWorkaroundImportFileLoc)) {

--- a/test/snowpack/import/css.ts/index.test.js
+++ b/test/snowpack/import/css.ts/index.test.js
@@ -1,0 +1,46 @@
+const {testFixture} = require('../../../fixture-utils');
+const dedent = require('dedent');
+
+describe('css.ts', () => {
+  beforeAll(() => {
+    // Needed until we make Snowpack's JS Build Interface quiet by default
+    require('snowpack').logger.level = 'error';
+  });
+
+  it('.css.ts and .css.js files are imported properly', async () => {
+    const result = await testFixture({
+      'globalStyles.css': dedent`
+        * { box-sizing: border-box; }
+      `,
+      'cssModule.module.css': dedent`
+        .foo { border: 1px solid hotpink; }
+      `,
+      'styles.css.ts': dedent`
+        export const container = 'container-de42';
+      `,
+      'shared.css.js': dedent`
+        export const shadow = 'shadow-12fb';
+      `,
+      'index.js': dedent`
+        import './globalStyles.css';
+        import { foo } './cssModule.module.css';
+        import { container } from './styles.css';
+        import { shadow } from './shared.css';
+        console.log({ container, shadow, foo });
+      `,
+    });
+    expect(result['index.js']).toBeDefined();
+    expect(result['globalStyles.css']).toBeDefined();
+    expect(result['cssModule.module.css']).toBeDefined();
+    expect(result['styles.css.js']).toBeDefined();
+    expect(result['shared.css.js']).toBeDefined();
+
+    expect(result['index.js']).toMatchInlineSnapshot(`
+      "import './globalStyles.css.proxy.js';
+      import { foo } './cssModule.module.css.proxy.js';
+      import { container } from './styles.css.js';
+      import { shadow } from './shared.css.js';
+      console.log({ container, shadow, foo });"
+    `);
+  });
+});


### PR DESCRIPTION
fixes #3312

## Changes

This removes a special case for `.css` files when resolving imports; imports will still resolve to `.css` files [if the exact file exists on disk](https://github.com/mxmul/snowpack/blob/d9c27c3a4fbe9b365ec9766bf2037e0162c6ed85/snowpack/src/build/import-resolver.ts#L34). When there's no such file, this allows the normal module resolution algorithm (e.g. trying `.css.js`) to proceed.

## Testing

Unit test added.

## Docs

bug fix only