### PR TITLE
Expand devOptions.open documentation

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -198,7 +198,7 @@ module.exports = {
 **Type**: `string`  
 **Default**: `localhost`
 
-The hostname that the dev server is running on. Snowpack uses this information to configure the HMR websocket and properly 
+The hostname that the dev server is running on. Snowpack uses this information to configure the HMR websocket and properly open
 your browser on startup (see: [`devOptions.open`](#devoptions.open)).
 
 ### devOptions.port

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -198,7 +198,8 @@ module.exports = {
 **Type**: `string`  
 **Default**: `localhost`
 
-The hostname that the dev server is running on. Snowpack uses this information to configure the HMR websocket and properly open your browser on startup (see: [`devOptions.open`](#devoptions.open)).
+The hostname that the dev server is running on. Snowpack uses this information to configure the HMR websocket and properly 
+your browser on startup (see: [`devOptions.open`](#devoptions.open)).
 
 ### devOptions.port
 
@@ -231,7 +232,7 @@ When using the Single-Page Application (SPA) pattern, this is the HTML "shell" f
 
 Configures how the dev server opens in the browser when it starts.
 
-Any installed browser, e.g., "chrome", "firefox", "brave". Set "none" to disable.
+Any installed browser, e.g., "chrome", "firefox", "brave", or the path to a browser. Set "none" to disable.
 
 ### devOptions.output
 


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Adds a snippet to the description of the devOptions.open config that explains you can also use a path to specify which browser to open. I prefer to use firefox developer edition for web development and I couldn't any documentation that said how to. I did some messing around and found that paths work for devOptions.open (though you can't pass any flags) and it seemed like I could help someone else who might have a similar problem in the future.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
No, this is a change to documentation

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Yes, noted in change. Better describes the allowed input to the config option.