### PR TITLE
Chore: update fsevents

### DIFF
--- a/snowpack/package.json
+++ b/snowpack/package.json
@@ -56,7 +56,7 @@
     "rollup": "~2.37.1"
   },
   "optionalDependencies": {
-    "fsevents": "^2.2.0"
+    "fsevents": "^2.3.2"
   },
   "devDependencies": {
     "@npmcli/arborist": "^2.2.9",


### PR DESCRIPTION
## Changes

Removes the following warning while using Snowpack:

```
warning snowpack > rollup > fsevents@2.1.3: "Please update to latest v2.3 or v2.2"
```

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

We test the bundled version of Snowpack, so existing tests should suffice

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

Behind-the-scenes change

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
