### PR TITLE
Chore: tag snowpack releases with primary tag

### DIFF
--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -80,6 +80,8 @@ module.exports = function release(pkgFolder, tag, bump, skipBuild) {
   console.log(execa.sync('git', ['add', '-A'], {cwd: dir}));
   console.log(execa.sync('git', ['commit', '-m', `[skip ci] ${newPkgTag}`], {cwd: dir}));
   console.log(execa.sync('git', ['tag', newPkgTag], {cwd: dir}));
+  if (pkgName === 'snowpack')
+    console.log(execa.sync('git', ['tag', `v${newPkgVersion}`], {cwd: dir})); // 'snowpack' only: also tag as vX.X.X (for GitHub releases)
   console.log(execa.sync('npm', ['publish', '--tag', tag], {cwd: dir}));
 
   // Only push to github on latest release, since a pre-release will break


### PR DESCRIPTION
## Changes

This improves GitHub release notes (see #3200). Before, Snowpack releases were only tagged with `snowpack@vX.X.X`. Now, also tag Snowpack releases with `vX.X.X`. This automatically bumps the “latest release” display on the main GitHub page, which used to be out-of-date.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Will be tested on next release!

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
