### PR TITLE
Bugfix: Allow clean shutdown of dev server

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -44,6 +44,8 @@ import {
 } from '../util';
 import {getPort, startDashboard, paintEvent} from './paint';
 import {cssModuleJSON} from '../build/import-css';
+import {runPipelineCleanupStep} from '../build/build-pipeline';
+
 export class OneToManyMap {
   readonly keyToValue = new Map<string, string[]>();
   readonly valueToKey = new Map<string, string>();
@@ -1013,6 +1015,7 @@ export async function startServer(
     getServerRuntime: (options) => getServerRuntime(sp, options),
     async shutdown() {
       watcher && (await watcher.close());
+      await runPipelineCleanupStep(config);
       server && server.close();
     },
   };


### PR DESCRIPTION
## Changes

When starting the Snowpack dev server via Node.js, the `shutdown()` command doesn’t send the cleanup signal to all plugins (which is important if they spawned workers). This calls all plugins’ `cleanup()` methods before shutting down, making sure to kill any processes started.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Manually tested; mostly affects the Node.js API

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
