### PR TITLE
RFC (attempt 2) Dev server support for customizing headers

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -407,7 +407,7 @@ function normalizeMount(config: SnowpackConfig) {
 }
 
 function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
-  return routes.map(({src, dest, upgrade, match}, i) => {
+  return routes.map(({src, dest, match, ...rest}, i) => {
     // Normalize
     if (typeof dest === 'string') {
       dest = addLeadingSlash(dest);
@@ -420,7 +420,7 @@ function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
     }
     // Validate
     try {
-      return {src, dest, upgrade, match: match || 'all', _srcRegex: new RegExp(src)};
+      return { ...rest, src, dest, match: match || 'all', _srcRegex: new RegExp(src)};
     } catch (err) {
       throw new Error(`config.routes[${i}].src: invalid regular expression syntax "${src}"`);
     }

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -407,7 +407,7 @@ function normalizeMount(config: SnowpackConfig) {
 }
 
 function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
-  return routes.map(({src, dest, match, ...rest}, i) => {
+  return routes.map(({src = '.*', dest, match, ...rest}, i) => {
     // Normalize
     if (typeof dest === 'string') {
       dest = addLeadingSlash(dest);

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -224,10 +224,16 @@ export interface OptimizeOptions {
   target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
 }
 
+export type HeadersTransformer = (
+  req: http.IncomingMessage,
+  proposed: http.OutgoingHttpHeaders | http.OutgoingHttpHeader[] | undefined
+) => http.OutgoingHttpHeaders | http.OutgoingHttpHeader[] | undefined;
+
 export interface RouteConfigObject {
   src: string;
   dest: string | ((req: http.IncomingMessage, res: http.ServerResponse) => void) | undefined;
   upgrade: ((req: http.IncomingMessage, socket: net.Socket, head: Buffer) => void) | undefined;
+  headers?: HeadersTransformer;
   match: 'routes' | 'all';
   _srcRegex: RegExp;
 }
@@ -323,7 +329,7 @@ export type SnowpackUserConfig = {
   testOptions?: Partial<SnowpackConfig['testOptions']>;
   packageOptions?: Partial<SnowpackConfig['packageOptions']>;
   optimize?: Partial<SnowpackConfig['optimize']>;
-  routes?: Pick<RouteConfigObject, 'src' | 'dest' | 'match'>[];
+  routes?: Pick<RouteConfigObject, 'src' | 'dest' | 'match' | 'headers'>[];
   experiments?: {
     /* intentionally left blank */
   };

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -230,7 +230,8 @@ export type HeadersTransformer = (
 ) => http.OutgoingHttpHeaders | http.OutgoingHttpHeader[] | undefined;
 
 export interface RouteConfigObject {
-  src: string;
+  /** @default '.*' */
+  src?: string;
   dest: string | ((req: http.IncomingMessage, res: http.ServerResponse) => void) | undefined;
   upgrade: ((req: http.IncomingMessage, socket: net.Socket, head: Buffer) => void) | undefined;
   headers?: HeadersTransformer;


### PR DESCRIPTION
_Incorporates some review feedback from https://github.com/snowpackjs/snowpack/pull/3030;  
Narrower in scope, API is non-mutating, and exposed via routes config rather than via plugin API._

Exposes via `RouteConfigObject` an API for customizing the response headers on assets returned by dev server.

```ts
export type HeadersTransformer = (
  req: http.IncomingMessage,
  proposed: http.OutgoingHttpHeaders | http.OutgoingHttpHeader[] | undefined
) => http.OutgoingHttpHeaders | http.OutgoingHttpHeader[] | undefined;

export interface RouteConfigObject {
  // (other properties omitted)
  headers?: HeadersTransformer;
}
```

This enables me to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer); I needed my index.html served with additional response headers.

This also resolves @denis-sokolov's request:  
https://github.com/snowpackjs/snowpack/discussions/2420

I can also see its being useful for [serving WebAssembly assets with the appropriate headers](https://emscripten.org/docs/compiling/WebAssembly.html?highlight=fastcomp#web-server-setup).

## Changes

Monkey-patches `res.writeHead()` early in `handleRequest()`, so that any subsequent `writeHead` can be intercepted. If the user has supplied a `HeadersTransformer` callback: it will be invoked with the proposed headers; the user returns a new headers structure of their choosing, which we give to the original `writeHead` implementation.

Additionally, I made a small brevity change: `RouteConfigObject` now treats `src` as optional, defaulting to `'.*'`. I did this because when I tried to guess how to configure my routes, I got baffling feedback when I omitted src, and felt that "all sources" would be an intuitive default.

## Testing

I wrote a sample application, with the following routes configured in snowpack.config.js:

```js
  routes: [
    {
      match: 'all',
      /**
       * @param {import('http').IncomingMessage} req
       * @param {import('http').OutgoingHttpHeaders | import('http').OutgoingHttpHeader[] | undefined} proposed
       * @returns {import('http').OutgoingHttpHeaders | import('http').OutgoingHttpHeader[]}
       */
      headers: (req, proposed) => {
        /** @type {import('http').OutgoingHttpHeaders} */
        const extraHeaders = {
          'Cross-Origin-Opener-Policy': 'same-origin',
          'Cross-Origin-Embedder-Policy': 'require-corp'
        }
        if (Array.isArray(proposed)) {
          return [...proposed, ...Object.entries(extraHeaders).flat()]
        }
        return {
          ...proposed,
          // note: for headers defined as comma-separated lists
          // (such as Cache-control), you'll have to decide whether you want to
          // overwrite (like we do here) or concatenate.
          // https://stackoverflow.com/a/4371395/5257399
          ...extraHeaders
        }
      }
    }
  ],
```

With that change made to my [liquidfun-play](https://github.com/Birch-san/liquidfun-play) repository: my `index.html` is served with served with `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers, which makes `console.log(window.crossOriginIsolated)` return `true` (previously `false`).

## Docs

No documentation added (except TypeScript types) — first looking for feedback on whether this is the right shape for such an API.