### PR TITLE
RFC check if a change occurred in a react function component and if not, …

### DIFF
--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -70,6 +70,10 @@ async function transformJs(contents, id, cwd, babelConfig) {
 
   return `
 /** React Refresh: Setup **/
+if (!window.oldComponents){
+  window.oldComponents = {}
+}
+window.functionComponentWasChanged = false
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
     console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
@@ -77,6 +81,12 @@ if (import.meta.hot) {
     var prevRefreshReg = window.$RefreshReg$;
     var prevRefreshSig = window.$RefreshSig$;
     window.$RefreshReg$ = (type, id) => {
+      const newComponent = type.toString()
+      //check if any (function) components tracked by React Refresh have been changed.
+      if (window.oldComponents[id] && window.oldComponents[id] !== newComponent){
+        window.functionComponentWasChanged = true
+      }
+      window.oldComponents[id] = newComponent
       window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
     }
     window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
@@ -90,7 +100,11 @@ if (import.meta.hot) {
   window.$RefreshReg$ = prevRefreshReg
   window.$RefreshSig$ = prevRefreshSig
   import.meta.hot.accept(() => {
-    window.$RefreshRuntime$.performReactRefresh()
+    // If a change occured somewhere outside of a function component,
+    // that means there is a change that React Refresh cannot deal with, so do a full reload.
+    if (window.functionComponentWasChanged) {
+      window.$RefreshRuntime$.performReactRefresh()
+    } else import.meta.hot.invalidate();
   });
 }`;
 }

--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -70,10 +70,10 @@ async function transformJs(contents, id, cwd, babelConfig) {
 
   return `
 /** React Refresh: Setup **/
-if (!window.oldComponents){
-  window.oldComponents = {}
+if (!window.$reactOldComponents$){
+  window.$reactOldComponents$ = {}
 }
-window.functionComponentWasChanged = false
+window.$reactfunctionComponentWasChanged$ = false
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
     console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
@@ -83,10 +83,10 @@ if (import.meta.hot) {
     window.$RefreshReg$ = (type, id) => {
       const newComponent = type.toString()
       //check if any (function) components tracked by React Refresh have been changed.
-      if (window.oldComponents[id] && window.oldComponents[id] !== newComponent){
-        window.functionComponentWasChanged = true
+      if (window.$reactOldComponents$[id] && window.$reactOldComponents$[id] !== newComponent){
+        window.$reactfunctionComponentWasChanged$ = true
       }
-      window.oldComponents[id] = newComponent
+      window.$reactOldComponents$[id] = newComponent
       window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
     }
     window.$RefreshSig$ = window.$RefreshRuntime$.createSignatureFunctionForTransform;
@@ -102,7 +102,7 @@ if (import.meta.hot) {
   import.meta.hot.accept(() => {
     // If a change occured somewhere outside of a function component,
     // that means there is a change that React Refresh cannot deal with, so do a full reload.
-    if (window.functionComponentWasChanged) {
+    if (window.$reactfunctionComponentWasChanged$) {
       window.$RefreshRuntime$.performReactRefresh()
     } else import.meta.hot.invalidate();
   });

--- a/plugins/plugin-react-refresh/plugin.js
+++ b/plugins/plugin-react-refresh/plugin.js
@@ -73,7 +73,7 @@ async function transformJs(contents, id, cwd, babelConfig) {
 if (!window.$reactOldComponents$){
   window.$reactOldComponents$ = {}
 }
-window.$reactfunctionComponentWasChanged$ = false
+window.$reactFunctionComponentWasChanged$ = false
 if (import.meta.hot) {
   if (!window.$RefreshReg$ || !window.$RefreshSig$ || !window.$RefreshRuntime$) {
     console.warn('@snowpack/plugin-react-refresh: HTML setup script not run. React Fast Refresh only works when Snowpack serves your HTML routes. You may want to remove this plugin.');
@@ -84,7 +84,7 @@ if (import.meta.hot) {
       const newComponent = type.toString()
       //check if any (function) components tracked by React Refresh have been changed.
       if (window.$reactOldComponents$[id] && window.$reactOldComponents$[id] !== newComponent){
-        window.$reactfunctionComponentWasChanged$ = true
+        window.$reactFunctionComponentWasChanged$ = true
       }
       window.$reactOldComponents$[id] = newComponent
       window.$RefreshRuntime$.register(type, ${JSON.stringify(id)} + " " + id);
@@ -102,7 +102,7 @@ if (import.meta.hot) {
   import.meta.hot.accept(() => {
     // If a change occured somewhere outside of a function component,
     // that means there is a change that React Refresh cannot deal with, so do a full reload.
-    if (window.$reactfunctionComponentWasChanged$) {
+    if (window.$reactFunctionComponentWasChanged$) {
       window.$RefreshRuntime$.performReactRefresh()
     } else import.meta.hot.invalidate();
   });


### PR DESCRIPTION
…invalidate HMR.

This is my attempt at a fix for issue https://github.com/snowpackjs/snowpack/issues/3323 and my first attempt at a pull request for snowpack so any feedback would be appreciated.

## Changes

It checks if a React function component has been changed. If not, that means that Fast Refresh won't work so the entire app is refreshed. This is the best solution that could come up with, however it's still not ideal, since in the case of a class component being edited, it should be possible to reload just that component and its children without reloading the entire app. It is a big improvement over the current behavior where changes to the `DoesntUpdate` component in the example below don't refresh at all, as well as changes to the file that occur outside of a React Component.

## Testing

Manually tested that it fixes HMR for this minimal example:
```
import React, { Component } from 'react';

function A({children}){
	return <div>{children}</div>
}

export default class DoesntUpdate extends Component{
	constructor(props){
		super(props)
	}
	render(){
		return <A>not updating when changed</A>
	}
}
```

I would appreciate any advice as to how to add more comprehensive tests.

## Docs
bug fix only
