### PR TITLE
Minor optimization on resolving path starts with '.'

### DIFF
--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -106,7 +106,7 @@ export function createImportResolver({fileLoc, config}: {fileLoc: string; config
     if (spec[0] === '/') {
       return spec;
     }
-    if (isPathImport(spec)) {
+    if (spec[0] === '.') {
       const importedFileLoc = path.resolve(path.dirname(fileLoc), path.normalize(spec));
       return resolveSourceSpecifier(importedFileLoc, {parentFile: fileLoc, config}) || spec;
     }

--- a/snowpack/src/build/import-resolver.ts
+++ b/snowpack/src/build/import-resolver.ts
@@ -7,7 +7,6 @@ import {
   findMatchingAliasEntry,
   getExtensionMatch,
   hasExtension,
-  isPathImport,
   isRemoteUrl,
   replaceExtension,
 } from '../util';


### PR DESCRIPTION
in case `spec[0]= '/' `, it will return instead of going to line 109.  This change, I feel, will make the code clearer.

