### PR TITLE
feat: update install targets's specifier from package.json

### DIFF
--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -54,23 +54,27 @@ export async function getInstallTargets(
         isImportOfPackage(dep.specifier, packageName),
       ),
   );
-  return new Promise((resolve) => {
-    installTargets.map((t, index) => {
-      const pPath = path.join(config.root, 'node_modules', t.specifier, 'package.json')
-      if (existsSync(pPath)) {
-        readPackageJsonFast(pPath).then((pkg) => {
-          pkg.unpkg && (t.specifier = `${t.specifier}/${pkg.unpkg}`)
+  if (process.env.NODE_ENV === 'production') {
+    return installTargets;
+  } else {
+    return new Promise((resolve) => {
+      installTargets.map((t, index) => {
+        const pPath = path.join(config.root, 'node_modules', t.specifier, 'package.json')
+        if (existsSync(pPath)) {
+          readPackageJsonFast(pPath).then((pkg) => {
+            pkg.unpkg && (t.specifier = `${t.specifier}/${pkg.unpkg}`)
+            if (installTargets.length === index + 1) {
+              resolve(installTargets)
+            }
+          })
+        } else {
           if (installTargets.length === index + 1) {
             resolve(installTargets)
           }
-        })
-      } else {
-        if (installTargets.length === index + 1) {
-          resolve(installTargets)
         }
-      }
+      })
     })
-  })
+  }
 }
 
 export function matchDynamicImportValue(importStatement: string) {

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -7,6 +7,9 @@ import path from 'path';
 import stripComments from 'strip-comments';
 import {logger} from './logger';
 import {SnowpackConfig, SnowpackSourceFile} from './types';
+const {existsSync} = require('fs');
+const readPackageJsonFast = require('read-package-json-fast')
+
 import {
   createInstallTarget,
   CSS_REGEX,
@@ -45,12 +48,29 @@ export async function getInstallTargets(
   } else {
     installTargets.push(...(await scanImports(config.mode === 'test', config)));
   }
-  return installTargets.filter(
+  installTargets = installTargets.filter(
     (dep) =>
       !config.packageOptions.external.some((packageName) =>
         isImportOfPackage(dep.specifier, packageName),
       ),
   );
+  return new Promise((resolve) => {
+    installTargets.map((t, index) => {
+      const pPath = path.join(config.root, 'node_modules', t.specifier, 'package.json')
+      if (existsSync(pPath)) {
+        readPackageJsonFast(pPath).then((pkg) => {
+          t.specifier = `${t.specifier}/${pkg.unpkg || pkg.main}`
+          if (installTargets.length === index + 1) {
+            resolve(installTargets)
+          }
+        })
+      } else {
+        if (installTargets.length === index + 1) {
+          resolve(installTargets)
+        }
+      }
+    })
+  })
 }
 
 export function matchDynamicImportValue(importStatement: string) {

--- a/snowpack/src/scan-imports.ts
+++ b/snowpack/src/scan-imports.ts
@@ -59,7 +59,7 @@ export async function getInstallTargets(
       const pPath = path.join(config.root, 'node_modules', t.specifier, 'package.json')
       if (existsSync(pPath)) {
         readPackageJsonFast(pPath).then((pkg) => {
-          t.specifier = `${t.specifier}/${pkg.unpkg || pkg.main}`
+          pkg.unpkg && (t.specifier = `${t.specifier}/${pkg.unpkg}`)
           if (installTargets.length === index + 1) {
             resolve(installTargets)
           }


### PR DESCRIPTION
## Changes
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
when snowpack scans an ESM package, we check if there is 'xx.min.js' file from package.json, if there is, change the specifier of item  of installTargets.
(but if 'xx.min.js' imports an ESM package, it does nothing...., so it's just a little bit optimized)
![image](https://user-images.githubusercontent.com/20119779/119597237-38b56480-be13-11eb-9eb3-744aae87d0fb.png)


## Testing
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
![image](https://user-images.githubusercontent.com/20119779/119596221-597cba80-be11-11eb-85cd-695629cd7c39.png)

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
