### PR TITLE
Pass packageOptions.external to esinstall

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -506,6 +506,7 @@ export class PackageSourceLocal implements PackageSource {
           .map((spec) => spec.substr(packageUID.length + 1));
         // TODO: external should be a function in esinstall
         const externalPackages = [
+          ...config.packageOptions.external,
           ...Object.keys(packageManifest.dependencies || {}),
           ...Object.keys(packageManifest.peerDependencies || {}),
         ].filter((ext) => ext !== _packageName && !NEVER_PEER_PACKAGES.includes(ext));


### PR DESCRIPTION
## Changes
This change fixes https://github.com/snowpackjs/snowpack/issues/3241
There was a regression going from snowpack 2.x to 3.x where the visual regression plugin for web test runner did no longer work.
It affects all web test runner plugins using a server command.
The fix was suggested/discovered by @IanVS 

## Testing
This was only verified manually - I could not find a good way of testing this behavior. 
I would love to add a test for this, but I can not figure out how to add it correctly, as the web test runner, is a dev server on its own, and therefore the normal test-fixture pattern does not work.

## Docs
Bugfix only
