### PR TITLE
Fix broken indentation and make lang attribute consistent in svelte-typescript template

### DIFF
--- a/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
+++ b/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
@@ -4,7 +4,6 @@
   let count: number = 0
   onMount(() => {
     const interval = setInterval(() => count++, 1000)
-		debugger
     return () => {
       clearInterval(interval)
     }

--- a/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
+++ b/create-snowpack-app/app-template-svelte-typescript/src/App.svelte
@@ -1,70 +1,77 @@
-<script lang='typescript'>
-	import {onMount} from 'svelte';
-	let count: number = 0;
-	onMount(() => {
-	  const interval = setInterval(() => count++, 1000);
-	  return () => {
-		clearInterval(interval);
-	  };
-	});
-  </script>
-  
-  <style>
-	:global(body) {
-	  margin: 0;
-	  font-family: Arial, Helvetica, sans-serif;
-	}
-	.App {
-	  text-align: center;
-	}
-	.App code {
-	  background: #0002;
-	  padding: 4px 8px;
-	  border-radius: 4px;
-	}
-	.App p {
-	  margin: 0.4rem;
-	}
-  
-	.App-header {
-	  background-color: #f9f6f6;
-	  color: #333;
-	  min-height: 100vh;
-	  display: flex;
-	  flex-direction: column;
-	  align-items: center;
-	  justify-content: center;
-	  font-size: calc(10px + 2vmin);
-	}
-	.App-link {
-	  color: #ff3e00;
-	}
-	.App-logo {
-	  height: 36vmin;
-	  pointer-events: none;
-	  margin-bottom: 3rem;
-	  animation: App-logo-spin infinite 1.6s ease-in-out alternate;
-	}
-	@keyframes App-logo-spin {
-	  from {
-		transform: scale(1);
-	  }
-	  to {
-		transform: scale(1.06);
-	  }
-	}
-  </style>
-  
-  <div class="App">
-	<header class="App-header">
-	  <img src="/logo.svg" class="App-logo" alt="logo" />
-	  <p>Edit <code>src/App.svelte</code> and save to reload.</p>
-	  <p>Page has been open for <code>{count}</code> seconds.</p>
-	  <p>
-		<a class="App-link" href="https://svelte.dev" target="_blank" rel="noopener noreferrer">
-		  Learn Svelte
-		</a>
-	  </p>
-	</header>
-  </div>
-  
+<script lang="ts">
+  import {onMount} from 'svelte'
+
+  let count: number = 0
+  onMount(() => {
+    const interval = setInterval(() => count++, 1000)
+		debugger
+    return () => {
+      clearInterval(interval)
+    }
+  })
+</script>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
+  .App {
+    text-align: center;
+  }
+
+  .App code {
+    background: #0002;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .App p {
+    margin: 0.4rem;
+  }
+
+  .App-header {
+    background-color: #f9f6f6;
+    color: #333;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: calc(10px + 2vmin);
+  }
+
+  .App-link {
+    color: #ff3e00;
+  }
+
+  .App-logo {
+    height: 36vmin;
+    pointer-events: none;
+    margin-bottom: 3rem;
+    animation: App-logo-spin infinite 1.6s ease-in-out alternate;
+  }
+
+  @keyframes App-logo-spin {
+    from {
+      transform: scale(1);
+    }
+    to {
+      transform: scale(1.06);
+    }
+  }
+</style>
+
+<div class="App">
+  <header class="App-header">
+    <img src="/logo.svg" class="App-logo" alt="logo"/>
+    <p>Edit <code>src/App.svelte</code> and save to reload.</p>
+    <p>Page has been open for <code>{count}</code> seconds.</p>
+    <p>
+      <a class="App-link" href="https://svelte.dev" target="_blank" rel="noopener noreferrer">
+        Learn Svelte
+      </a>
+    </p>
+  </header>
+</div>


### PR DESCRIPTION
## Changes

I start from this template often and everytime the broken formatting makes me sad.
No code changes, only removal of extra indents.
