### PR TITLE
allow configuring loader

### DIFF
--- a/docs/guides/optimize-and-bundle.md
+++ b/docs/guides/optimize-and-bundle.md
@@ -34,7 +34,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
-  loader?: { [ext: string]: Loader; };
+  loader?: {[ext: string]: Loader};
   sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;

--- a/docs/guides/optimize-and-bundle.md
+++ b/docs/guides/optimize-and-bundle.md
@@ -34,6 +34,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
+  loader?: { [ext: string]: Loader; };
   sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;

--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -56,7 +56,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
-  loader?: { [ext: string]: Loader; };
+  loader?: {[ext: string]: Loader};
   sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;

--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -56,6 +56,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
+  loader?: { [ext: string]: Loader; };
   sourcemap: boolean | 'external' | 'inline' | 'both';
   splitting: boolean;
   treeshake: boolean;

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -396,7 +396,7 @@ async function runEsbuildOnBuildDirectory(
     outbase: config.buildOptions.out,
     write: false,
     bundle: true,
-    loader:  config.optimize!.loader,
+    loader: config.optimize!.loader,
     sourcemap: config.optimize!.sourcemap,
     splitting: config.optimize!.splitting,
     format: 'esm',

--- a/snowpack/src/build/optimize.ts
+++ b/snowpack/src/build/optimize.ts
@@ -396,6 +396,7 @@ async function runEsbuildOnBuildDirectory(
     outbase: config.buildOptions.out,
     write: false,
     bundle: true,
+    loader:  config.optimize!.loader,
     sourcemap: config.optimize!.sourcemap,
     splitting: config.optimize!.splitting,
     format: 'esm',

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -213,6 +213,7 @@ const configSchema = {
       properties: {
         preload: {type: 'boolean'},
         bundle: {type: 'boolean'},
+        loader: {type: 'object'},
         splitting: {type: 'boolean'},
         treeshake: {type: 'boolean'},
         manifest: {type: 'boolean'},
@@ -465,6 +466,7 @@ function normalizeConfig(_config: SnowpackUserConfig): SnowpackConfig {
       entrypoints: config.optimize.entrypoints ?? 'auto',
       preload: config.optimize.preload ?? false,
       bundle: config.optimize.bundle ?? false,
+      loader: config.optimize.loader,
       sourcemap: config.optimize.sourcemap ?? true,
       splitting: config.optimize.splitting ?? false,
       treeshake: config.optimize.treeshake ?? true,

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -1,4 +1,5 @@
 import type {InstallOptions as EsinstallOptions, InstallTarget} from 'esinstall';
+import type { Loader } from 'esbuild';
 import type * as net from 'net';
 import type * as http from 'http';
 import type * as http2 from 'http2';
@@ -216,6 +217,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
+  loader?: { [ext: string]: Loader; };
   sourcemap: boolean | 'both' | 'inline' | 'external';
   splitting: boolean;
   treeshake: boolean;

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -1,5 +1,5 @@
 import type {InstallOptions as EsinstallOptions, InstallTarget} from 'esinstall';
-import type { Loader } from 'esbuild';
+import type {Loader} from 'esbuild';
 import type * as net from 'net';
 import type * as http from 'http';
 import type * as http2 from 'http2';
@@ -217,7 +217,7 @@ export interface OptimizeOptions {
   entrypoints: 'auto' | string[] | ((options: {files: string[]}) => string[]);
   preload: boolean;
   bundle: boolean;
-  loader?: { [ext: string]: Loader; };
+  loader?: {[ext: string]: Loader};
   sourcemap: boolean | 'both' | 'inline' | 'external';
   splitting: boolean;
   treeshake: boolean;


### PR DESCRIPTION
## Changes

Allows configuring loader option for esbuild in optimize

## Testing

<!-- How was this change tested? -->
I tested building my failed build that failed because of this error `error: No loader is configured for ".woff" files`

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I'm not sure how I would add tests for this but with some guidance I would be happy to add them.

## Docs

<!-- Was public documentation updated? -->
Yes
