### PR TITLE
fix: thrown NotFoundError constructor

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -110,7 +110,7 @@ function encodeResponse(
 /**
  * A helper class for "Not Found" errors, storing data about what file lookups were attempted.
  */
-class NotFoundError extends Error {
+export class NotFoundError extends Error {
   constructor(url: string, lookups?: string[]) {
     if (!lookups) {
       super(`Not Found (${url})`);
@@ -234,7 +234,7 @@ function getServerRuntime(
   const runtime = createServerRuntime({
     load: async (url) => {
       const result = await sp.loadUrl(url, {isSSR: true, allowStale: false, encoding: 'utf8'});
-      if (!result) throw NotFoundError;
+      if (!result) throw new NotFoundError(url);
       return result;
     },
   });
@@ -837,7 +837,7 @@ export async function startServer(
     try {
       const result = await loadUrl(reqUrl, {allowStale: true, encoding: null});
       if (!result) {
-        throw NotFoundError;
+        throw new NotFoundError(reqUrl);
       }
       sendResponseFile(req, res, result);
       if (result.checkStale) {

--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -15,7 +15,7 @@ import {getUrlsForFile} from './build/file-urls';
 export * from './types';
 
 // Stable API
-export {startServer} from './commands/dev';
+export {startServer, NotFoundError} from './commands/dev';
 export {build} from './commands/build';
 export {loadConfiguration, createConfiguration} from './config.js';
 export {readLockfile as loadLockfile} from './util.js';


### PR DESCRIPTION
## Changes

In a few spots, Snowpack was doing `throw NotFoundError` directly instead of `throw new NotFoundError(reqUrl)`. This made for some weird error messages!

I also exported `NotFoundError` so that integrators can check `err instanceof NotFoundError` if they want to.

## Testing

`yarn link` and run in Astro

## Docs

Bug fix
