### PR TITLE
Docs: Remove devOptions.fallback from configuration reference

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -215,17 +215,6 @@ The port the dev server runs on.
 
 Optional path to append to dev server url. May also include querystring parameters, example: `test/foo.html?bar=123`.
 
-### devOptions.fallback
-
-**Type**: `string`
-**Default**: `"index.html"`
-
-The HTML file to serve for non-resource routes.
-
-When using the Single-Page Application (SPA) pattern, this is the HTML "shell" file that gets served for every (non-resource) user route.
-
-⚠️ Make sure that you configure your production servers to serve this.
-
 ### devOptions.open
 
 **Type**: `string`


### PR DESCRIPTION
## Changes

After reading the configuration docs, I tried using the `devOptions.fallback` option as described, but saw the following error when starting the snowpack dev server:

```
[16:29:33] [snowpack] [v3.0] Deprecated! "devOptions.fallback" is now replaced by "routes".
More info: https://www.snowpack.dev/guides/routing
See https://www.snowpack.dev for more info.

Error: [v3.0] Deprecated! "devOptions.fallback" is now replaced by "routes".
More info: https://www.snowpack.dev/guides/routing
See https://www.snowpack.dev for more info.
    at handleDeprecatedConfigError (/Users/David/code/fast-faction/node_modules/snowpack/lib/index.js:122187:11)
    at valdiateDeprecatedConfig (/Users/David/code/fast-faction/node_modules/snowpack/lib/index.js:122234:9)
    at Object.loadConfiguration (/Users/David/code/fast-faction/node_modules/snowpack/lib/index.js:122430:5)
    at async cli (/Users/David/code/fast-faction/node_modules/snowpack/lib/index.js:183658:22)
```

I thought removing this from the docs would help others avoid the same error. Brand new to snowpack, so forgive me if I'm missing something!

## Testing

No tests - documentation change only.

## Docs

N/A
