### PR TITLE
fix: don't destroy the socket for upgrade handlers

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -863,8 +863,6 @@ export async function startServer(
     const matchedRouteHandler = matchRouteHandler(reqUrl, 'upgrade');
     if (matchedRouteHandler) {
       matchedRouteHandler(req, socket, head);
-      // NOTE(fks): Why do we destory the socket here? Is it so that HMR client doesn't hijack?
-      socket.destroy();
       return;
     }
   }


### PR DESCRIPTION
## Changes

The [documentation for proxying a WebSocket](https://www.snowpack.dev/guides/routing#scenario-3%3A-proxy-websocket-requests) (e.g. if you have a websocket-based API server) does not work for me.

At the moment, when an upgrade route proxies to a websocket the socket is destroyed immediately.

## Testing

I'm not sure what tests are required for this change.

## Docs

This is a bugfix, the existing documentation for proxying a WebSocket are [here](https://www.snowpack.dev/guides/routing#scenario-3%3A-proxy-websocket-requests), are complete, but do not currently work.
