### PR TITLE
Ensure remote package fetches always use the configured origin

### DIFF
--- a/docs/guides/streaming-imports.md
+++ b/docs/guides/streaming-imports.md
@@ -28,6 +28,8 @@ The translation is done by the web server, so your source file will still contai
 
 `pkg.snowpack.dev` is our ESM Package CDN, powered by [Skypack](https://www.skypack.dev/). Every npm package is hosted as ESM, and any legacy non-ESM packages are upconverted to ESM on the CDN itself.
 
+> _**Note:** In some rare cases, a nested import from a package will result in an invalid resource reference on Skypack.  Explicitly setting the `packageOptions.origin` to `"https://cdn.skypack.dev"` (rather than using the default `pkg.snowpack.dev` shim) seems to resolve the issue._
+
 ## Benefits of Streaming Imports
 
 Streaming dependencies have several benefits over the traditional "npm install + local bundling" approach:

--- a/skypack/src/index.ts
+++ b/skypack/src/index.ts
@@ -9,7 +9,7 @@ import {IncomingHttpHeaders} from 'http';
 import {ImportMap, RESOURCE_CACHE, HAS_CDN_HASH_REGEX} from './util';
 
 export {rollupPluginSkypack} from './rollup-plugin-remote-cdn';
-export const SKYPACK_ORIGIN = `https://cdn.skypack.dev`;
+export const SKYPACK_ORIGIN = 'https://cdn.skypack.dev';
 
 function parseRawPackageImport(spec: string): [string, string | null] {
   const impParts = spec.split('/');
@@ -25,7 +25,7 @@ export class SkypackSDK {
   origin: string;
 
   constructor(options: {origin?: string} = {}) {
-    this.origin = options.origin || `https://cdn.skypack.dev`;
+    this.origin = options.origin || SKYPACK_ORIGIN;
   }
 
   async generateImportMap(

--- a/snowpack/src/commands/add-rm.ts
+++ b/snowpack/src/commands/add-rm.ts
@@ -8,7 +8,7 @@ import {
   convertSkypackImportMapToLockfile,
   LOCKFILE_NAME,
   writeLockfile,
-  remotePackageSDK,
+  createRemotePackageSDK,
 } from '../util';
 import {getPackageSource} from '../sources/util';
 
@@ -28,6 +28,7 @@ export async function addCommand(addValue: string, commandOptions: CommandOption
   if (config.packageOptions.source !== 'remote') {
     throw new Error(`add command requires packageOptions.source="remote".`);
   }
+  const remotePackageSDK = createRemotePackageSDK(config);
   let [pkgName, pkgSemver] = pkgInfoFromString(addValue);
   const installMessage = pkgSemver ? `${pkgName}@${pkgSemver}` : pkgName;
   logger.info(`fetching ${cyan(installMessage)} from CDN...`);
@@ -71,6 +72,7 @@ export async function rmCommand(addValue: string, commandOptions: CommandOptions
   if (config.packageOptions.source !== 'remote') {
     throw new Error(`rm command requires packageOptions.source="remote".`);
   }
+  const remotePackageSDK = createRemotePackageSDK(config);
   let [pkgName] = pkgInfoFromString(addValue);
   logger.info(`removing ${cyan(pkgName)} from project lockfile...`);
   const newLockfile: LockfileManifest = convertSkypackImportMapToLockfile(

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -84,7 +84,7 @@ export const DEFAULT_PACKAGES_LOCAL_CONFIG: PackageOptionsLocal = {
   knownEntrypoints: [],
 };
 
-const REMOTE_PACKAGE_ORIGIN = 'https://pkg.snowpack.dev';
+export const REMOTE_PACKAGE_ORIGIN = 'https://pkg.snowpack.dev';
 
 const DEFAULT_PACKAGES_REMOTE_CONFIG: PackageOptionsRemote = {
   source: 'remote',

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -13,6 +13,7 @@ import getDefaultBrowserId from 'default-browser-id';
 import type {ImportMap, LockfileManifest, SnowpackConfig} from './types';
 import type {InstallTarget} from 'esinstall';
 import {SkypackSDK} from 'skypack';
+import {REMOTE_PACKAGE_ORIGIN} from './config';
 
 // (!) Beware circular dependencies! No relative imports!
 // Because this file is imported from so many different parts of Snowpack,
@@ -31,7 +32,19 @@ export const REQUIRE_OR_IMPORT: (
   id: string,
 ) => Promise<any> = require('../assets/require-or-import.js');
 
-export const remotePackageSDK = new SkypackSDK({origin: 'https://pkg.snowpack.dev'});
+export function createRemotePackageSDK(config: SnowpackConfig) {
+  // This should only be called when config.packageOptions.source is 'remote'.
+  if (config.packageOptions.source !== 'remote') {
+    throw new Error('expected "remote" packageOptions.source');
+  }
+
+  // For consistency with previous behavior, we default to REMOTE_PACKAGE_ORIGIN
+  // if no origin is provided.  We could simply leave it undefined and allow
+  // SkypackSDK to use its own default.
+  return new SkypackSDK({
+    origin: config.packageOptions.origin || REMOTE_PACKAGE_ORIGIN,
+  });
+}
 
 // A note on cache naming/versioning: We currently version our global caches
 // with the version of the last breaking change. This allows us to re-use the

--- a/test/snowpack/config/packageOptions.source/index.test.js
+++ b/test/snowpack/config/packageOptions.source/index.test.js
@@ -1,10 +1,17 @@
 const {testFixture} = require('../../../fixture-utils');
 const dedent = require('dedent');
+const snowpackLogger = require('snowpack').logger;
 
 describe('packageOptions.source', () => {
+  const prevLoggerLevel = snowpackLogger.level;
+
   beforeAll(() => {
     // Needed until we make Snowpack's JS Build Interface quiet by default
-    require('snowpack').logger.level = 'error';
+    snowpackLogger.level = 'error';
+  });
+
+  afterAll(() => {
+    snowpackLogger.level = prevLoggerLevel;
   });
 
   it('Loads modules into cache when source is remote-next', async () => {
@@ -32,5 +39,73 @@ describe('packageOptions.source', () => {
     expect(result['../.snowpack/source/package.json']).toBeDefined();
     expect(result['../.snowpack/source/package-lock.json']).toBeDefined();
     expect(result['../.snowpack/source/node_modules/array-flatten/package.json']).toBeDefined();
+  });
+
+  describe('source: "remote"', () => {
+    let loggerInfos = [];
+
+    beforeEach(() => {
+      // We don't have a great way to introspect the streaming resolution, so we
+      // sniff the logging messages.
+      loggerInfos = [];
+      snowpackLogger.level = 'info';
+      snowpackLogger.on('info', (message) => {
+        loggerInfos.push(message);
+      });  
+    });
+
+    it('streams from pkg.snowpack.dev by default', async () => {
+      await testFixture({
+        'index.js': dedent`
+          import { flatten } from "array-flatten";
+        `,
+        'package.json': dedent`
+          {
+            "version": "1.0.1",
+            "name": "@snowpack/test-package-source-remote",
+            "dependencies": {
+            }
+          }
+        `,
+        'snowpack.config.js': dedent`
+          module.exports = {
+            packageOptions: {
+              source: 'remote',
+            },
+          };
+        `,
+      });
+
+      expect(loggerInfos).toEqual(expect.arrayContaining([expect.stringMatching(/import array-flatten@latest → https:\/\/pkg.snowpack.dev\/array-flatten/)]));
+    });
+
+    it('streams package from the requested origin', async () => {
+      // NOTE: There is some caching issue that prevents re-acquisition of a
+      // package acquired in the 'default origin' case above, so we use a
+      // different package name here.
+      await testFixture({
+        'index.js': dedent`
+          import skypack from "skypack";
+        `,
+        'package.json': dedent`
+          {
+            "version": "1.0.1",
+            "name": "@snowpack/test-package-source-remote",
+            "dependencies": {
+            }
+          }
+        `,
+        'snowpack.config.js': dedent`
+          module.exports = {
+            packageOptions: {
+              source: 'remote',
+              origin: 'https://cdn.skypack.dev',
+            },
+          };
+        `,
+      });
+
+      expect(loggerInfos).toEqual(expect.arrayContaining([expect.stringMatching(/import skypack@latest → https:\/\/cdn.skypack.dev\/skypack/)]));
+    });
   });
 });


### PR DESCRIPTION
> _**Note:** I know the contribution guidelines suggest opening PRs against a topic branch, but `wip-remote` is seven months old and I didn't see any branch that seemed more appropriate.  Please let me know if there's a specific branch you'd prefer, and I can re-open this against it.  Thanks!_

If a specific `packageOptions.origin` value is provided in a project's `snowpack.config.js` when using remote streaming, that origin was _**not**_ always used when fetching resources, because `snowpack/src/util.ts` had a hard-coded reference to `https://pkg.snowpack.dev` rather than using the containing project's config value.

## Changes

This PR ensures that the `SkypackSDK` instances are _always_ created with the project's snowpack configuration.  It also removes some duplication of the strings that define the two remote streaming origins (`pkg.snowpack.dev` and `cdn.skypack.dev`), just for code cleanliness.

This provides a workaround for #3393 and skypackjs/skypack-cdn#179.

## Testing

Tests (such as they are) have been added to verify that remote streaming is done from `pkg.snowpack.dev` by default, or by the configured origin (`cdn.skypack.dev`).  These tests simply "sniff" the logging output, which is less than ideal, but less invasive than altering snowpack.build to expose internal state.

## Docs

Updated `docs/guides/streaming-imports.md` with a note about needing `cdn.skypack.dev` in some cases, which is more about #3393 and skypackjs/skypack-cdn#179 than the fix itself.  The existing docs adequately describe the `packageOptions.origin` configuration setting, it's more that the code wasn't always respecting it.