### PR TITLE
Fix `external` behavior for local package source and SSR.

### DIFF
--- a/snowpack/assets/require-or-import.js
+++ b/snowpack/assets/require-or-import.js
@@ -2,24 +2,33 @@
 const { pathToFileURL } = require('url');
 const NATIVE_REQUIRE = eval('require');
 const NATIVE_IMPORT = (filepath) => import(filepath);
+const r = require('resolve');
 
 /**
  * A utility function to use Node's native `require` or dynamic `import` to load CJS or ESM files
  * @param {string} filepath 
  */
-module.exports = async function requireOrImport(filepath) {
+module.exports = async function requireOrImport(filepath, { from = process.cwd() } = {}) {
     return new Promise((resolve, reject) => {
+        // Resolve path based on `from`
+        const resolvedPath = r.sync(filepath, {
+            basedir: from
+        });
         try {
-            let mdl = NATIVE_REQUIRE(filepath);
-            resolve(mdl);
+          const mdl = NATIVE_REQUIRE(resolvedPath);
+          resolve(mdl);
         } catch (e) {
-            if (e instanceof SyntaxError && /export|import/.test(e.message)) {
-              console.error(`Failed to load "${filepath}"!\nESM format is not natively supported in "node@${process.version}".\nPlease use CommonJS or upgrade to an LTS version of node above "node@12.17.0".`)
-            } else if (e.code === 'ERR_REQUIRE_ESM') {
-                const url = pathToFileURL(filepath);
-                return NATIVE_IMPORT(url).then(mdl => resolve(mdl.default ? mdl.default : mdl));
-            };
-            reject(e);
+          if (e instanceof SyntaxError && /export|import/.test(e.message)) {
+            console.error(`Failed to load "${filepath}"!\nESM format is not natively supported in "node@${process.version}".\nPlease use CommonJS or upgrade to an LTS version of node above "node@12.17.0".`)
+          } else if (e.code === 'ERR_REQUIRE_ESM') {
+              const url = pathToFileURL(resolvedPath);
+              return NATIVE_IMPORT(url).then(mdl => resolve(mdl.default ? mdl.default : mdl));
+          };
+          try {
+            return NATIVE_IMPORT(pathToFileURL(resolvedPath)).then(mdl => resolve(mdl.default ? mdl.default : mdl));
+          } catch (e) {
+            reject(e);  
+          }
         }
     })
 }

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -32,6 +32,7 @@ import {
   OnFileChangeCallback,
   RouteConfigObject,
   ServerRuntime,
+  SnowpackConfig,
   SnowpackDevServer,
 } from '../types';
 import {
@@ -229,9 +230,11 @@ function handleResponseError(req, res, err: Error | NotFoundError) {
 
 function getServerRuntime(
   sp: SnowpackDevServer,
+  config: SnowpackConfig,
   options: {invalidateOnChange?: boolean} = {},
 ): ServerRuntime {
   const runtime = createServerRuntime({
+    config,
     load: async (url) => {
       const result = await sp.loadUrl(url, {isSSR: true, allowStale: false, encoding: 'utf8'});
       if (!result) throw new NotFoundError(url);
@@ -1012,7 +1015,7 @@ export async function startServer(
       return result ? result[0] : null;
     },
     onFileChange: (callback) => (onFileChangeCallback = callback),
-    getServerRuntime: (options) => getServerRuntime(sp, options),
+    getServerRuntime: (options) => getServerRuntime(sp, config, options),
     async shutdown() {
       watcher && (await watcher.close());
       await runPipelineCleanupStep(config);

--- a/snowpack/src/sources/local-install.ts
+++ b/snowpack/src/sources/local-install.ts
@@ -50,6 +50,8 @@ export async function installPackages({
     },
     ...installOptions,
     stats: false,
+    // Important! Pass `external` packages to `esinstall`
+    external: config.packageOptions.external,
     rollup: {
       plugins: [
         ...(installOptions?.rollup?.plugins ?? []),

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -513,6 +513,7 @@ export class PackageSourceLocal implements PackageSource {
           .map((spec) => spec.substr(packageUID.length + 1));
         // TODO: external should be a function in esinstall
         const externalPackages = [
+          ...config.packageOptions.external,
           ...Object.keys(packageManifest.dependencies || {}),
           ...Object.keys(packageManifest.peerDependencies || {}),
         ].filter((ext) => ext !== _packageName && !NEVER_PEER_PACKAGES.includes(ext));

--- a/snowpack/src/ssr-loader/index.ts
+++ b/snowpack/src/ssr-loader/index.ts
@@ -6,7 +6,7 @@ import {transform} from './transform';
 import {REQUIRE_OR_IMPORT} from '../util';
 
 // This function makes it possible to load modules from the snowpack server, for the sake of SSR.
-export function createLoader({load}: ServerRuntimeConfig): ServerRuntime {
+export function createLoader({config,load}: ServerRuntimeConfig): ServerRuntime {
   const cache = new Map();
   const graph = new Map();
 
@@ -17,7 +17,7 @@ export function createLoader({load}: ServerRuntimeConfig): ServerRuntime {
       graph.get(pathname).add(importer);
       return _load(pathname, urlStack);
     }
-    const mod = await REQUIRE_OR_IMPORT(imported);
+    const mod = await REQUIRE_OR_IMPORT(imported, { from: config.root || config.workspaceRoot || process.cwd() });
 
     return {
       exports: mod,

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -25,6 +25,7 @@ export type DeepPartial<T> = {
 };
 
 export interface ServerRuntimeConfig {
+  config: SnowpackConfig;
   load: (url: string) => Promise<{contents: string}>;
 }
 export interface ServerRuntime {

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -29,6 +29,7 @@ export const NATIVE_REQUIRE = eval('require');
 // NOTE: revisit this when `node@10` reaches EOL. Can we move everything to ESM and just use `import`?
 export const REQUIRE_OR_IMPORT: (
   id: string,
+  opts?: { from?: string }
 ) => Promise<any> = require('../assets/require-or-import.js');
 
 export const remotePackageSDK = new SkypackSDK({origin: 'https://pkg.snowpack.dev'});


### PR DESCRIPTION
## Changes

There were a few edge cases where `esinstall` was attempting to run on packages marked as `external` through `packageOptions.external`. This fixes #3241 and closes #3369 by @hklsiteimprove, who originally raised these issues.

There were also cases where `esinstall` would fail opaquely without giving a helpful error message. While we can't always point exactly to the package that caused a failure, we can at least give users the information _we do know_, which should help narrow down the problem.  

## Testing

Manually tested as these behaviors are difficult to test.

## Docs

Bug fix only