### PR TITLE
[PostCSS] Support `glob` property in `dir-dependency` messages

### DIFF
--- a/plugins/plugin-postcss/package.json
+++ b/plugins/plugin-postcss/package.json
@@ -13,6 +13,8 @@
     "access": "public"
   },
   "dependencies": {
+    "minimatch": "^3.0.4",
+    "normalize-path": "^3.0.0",
     "postcss-load-config": "^3.0.1",
     "workerpool": "^6.1.2"
   },

--- a/plugins/plugin-postcss/plugin.js
+++ b/plugins/plugin-postcss/plugin.js
@@ -55,7 +55,7 @@ module.exports = function postcssPlugin(snowpackConfig, options) {
         if (message.type === 'dependency') {
           patterns.add(normalizePath(message.file));
         } else if (message.type === 'dir-dependency') {
-          patterns.add(normalizePath(`${message.dir}/${message.glob ?? '**/*'}`));
+          patterns.add(normalizePath(`${message.dir}/${message.glob || '**/*'}`));
         }
       }
       dependencies.set(id, patterns);

--- a/plugins/plugin-postcss/plugin.js
+++ b/plugins/plugin-postcss/plugin.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const workerpool = require('workerpool');
 const minimatch = require('minimatch');
-const normalizePath = require('normalize-path')
+const normalizePath = require('normalize-path');
 
 module.exports = function postcssPlugin(snowpackConfig, options) {
   // options validation


### PR DESCRIPTION
## Changes

Following on from #3309, this pull request updates `@snowpack/plugin-postcss` to add support for the `glob` property of `dir-dependency` messages registered by PostCSS plugins. Relevant documentation: https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies

## Testing

No tests added, discussed in #3309.

## Docs

No docs added as this is not a user-facing change. The messages are created by PostCSS plugins and handled internally by `@snowpack/plugin-postcss`