### PR TITLE
Modules marked as `external` should always be treated as external

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -511,7 +511,7 @@ export class PackageSourceLocal implements PackageSource {
           .map((spec) => spec.substr(packageUID.length + 1));
         // TODO: external should be a function in esinstall
 
-        const filteredExternal = (ext: string) => ext !== _packageName && !NEVER_PEER_PACKAGES.has(ext);
+        const filteredExternal = (external: string) => external !== _packageName && !NEVER_PEER_PACKAGES.has(external);
 
         const dependenciesAndPeerDependencies = Object.keys(packageManifest.dependencies || {}).concat(
           Object.keys(packageManifest.peerDependencies || {})

--- a/test/snowpack/config/packageOptions.external/index.test.js
+++ b/test/snowpack/config/packageOptions.external/index.test.js
@@ -64,4 +64,41 @@ describe('packageOptions.external', () => {
 
     expect(result['index.js']).toContain(`import 'some-thing/deep.js';`);
   });
+
+  it('will make node-fetch external if marked as external', async () => {
+    const result = await testFixture({
+      'packages/other/package.json': dedent`
+        {
+          "version": "1.0.0",
+          "name": "other",
+          "module": "main.js"
+        }
+      `,
+      'packages/other/main.js': dedent`
+        export default 'works';
+      `,
+      'package.json': dedent`
+        {
+          "version": "1.0.1",
+          "name": "@snowpack/test-config-external-node-fetch",
+          "dependencies": {
+            "other": "file:./packages/other"
+          }
+        }
+      `,
+      'index.js': dedent`
+        import 'node-fetch';
+        import 'other';
+      `,
+      'snowpack.config.js': dedent`
+        module.exports = {
+          packageOptions: {
+            external: ['node-fetch']
+          }
+        }
+      `
+    });
+
+    expect(result['index.js']).toContain(`import 'node-fetch';`);
+  });
 });


### PR DESCRIPTION
## Changes

Previously `node-fetch` was always being bundled. This was because, as the thought goes, it's small so we should never externalize it.

However if a config *explicitly* marks it as external (rather than being implicitly external through a dependency) we should honor that.

## Testing

Adds a test for the scenario.

## Docs

N/A, bug fix.
