### PR TITLE
Remove postcss-cli from plugin-postcss docs

### DIFF
--- a/docs/guides/tailwind-css.md
+++ b/docs/guides/tailwind-css.md
@@ -19,7 +19,7 @@ Tailwind’s [JIT mode][tailwind-jit] is the new, recommended way to use Tailwin
 From the root of your project, install tailwindcss, PostCSS, and the Snowpack PostCSS plugin.
 
 ```
-npm install --save-dev tailwindcss @snowpack/plugin-postcss postcss postcss-cli
+npm install --save-dev tailwindcss @snowpack/plugin-postcss postcss
 ```
 
 #### 2. Configure

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -6,11 +6,9 @@
     "start": "snowpack dev",
     "build": "snowpack build"
   },
-  "dependencies": {},
   "devDependencies": {
     "@snowpack/plugin-postcss": "^1.3.0",
     "postcss": "^8.2.15",
-    "postcss-cli": "^8.3.1",
     "snowpack": "^3.4.0",
     "tailwindcss": "^2.1.2"
   }

--- a/plugins/plugin-postcss/README.md
+++ b/plugins/plugin-postcss/README.md
@@ -7,7 +7,7 @@ Run [PostCSS](https://github.com/postcss/postcss) on all `.css` files, including
 From a terminal, run the following:
 
 ```
-npm install --save-dev @snowpack/plugin-postcss postcss postcss-cli
+npm install --save-dev @snowpack/plugin-postcss postcss
 ```
 
 Then add this plugin to your Snowpack config:


### PR DESCRIPTION
## Changes

As changed in #2165, plugin-postcss does not need postcss-cli any more. 
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

<!-- Was public documentation updated? -->
This PR removes postcss-cli from the documentation.
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
