### PR TITLE
(attempt 3) Dev server support for customizing headers

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -101,3 +101,121 @@ export default {
 ### Scenario 4: Custom Server Rendering
 
 If you only use Snowpack to build assets and rely on your own custom server (ex: Rails, Laravel, etc) for serving HTML, then you probably have no use for routing. Consider reading our guide on [Server-Side Rendering (SSR)](/guides/server-side-render) which explains how to integrate Snowpack into your own server as middleware.
+
+### Scenario 5: Customize Response Headers
+
+Sometimes you need to tweak the response headers with which Snowpack dev server serves assets. `transformHeaders` is provided for these use-cases; it enables you to peek at the response headers just before Snowpack dev server writes the response, and override those response headers if desired.
+
+#### Apply a security policy
+
+If you wish to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), then you may want to serve your HTML assets with a custom security policy:
+
+```js
+// snowpack.config.mjs
+export default {
+  routes: [
+    {
+      match: 'routes',
+      src: '.*',
+      /**
+       * @param {import('snowpack').HttpRequestData} _req
+       * @param {import('snowpack').DevServerResponseHeaders} proposed
+       * @returns {import('snowpack').DevServerResponseHeaders}
+       */
+      transformHeaders: (_req, proposed) => {
+        /** @type {import('snowpack').DevServerResponseHeaders} */
+        const extraHeaders = {
+          'Cross-Origin-Opener-Policy': 'same-origin',
+          'Cross-Origin-Embedder-Policy': 'require-corp'
+        }
+        return {
+          ...proposed,
+          // note: for headers defined as comma-separated lists
+          // (such as Cache-control), you'll have to decide whether you want to
+          // overwrite (like we do here) or concatenate.
+          // https://stackoverflow.com/a/4371395/5257399
+          ...extraHeaders
+        }
+      }
+    },
+  ],
+};
+```
+
+The `match: 'routes'` above ensures that this applies only to URLs which lack a file extension, or to `.html` assets. Remove `match: 'routes'` or set it to its default of `match: 'all'` if you wish to modify response headers on **all** assets (e.g. css, js).
+
+#### Modify Content-Type
+
+You may wish to customize response headers based on the details of the request used to retrieve that asset.
+
+If all you're interested in is the file extension, then a simple technique is to use the RegEx capabilities of `src` matching:
+
+```js
+// snowpack.config.mjs
+export default {
+  routes: [
+    {
+      // snowpack will automatically surround your regex with ^ and $
+      // if you haven't done so yourself
+      src: '.*\\.wasm',
+      /**
+       * @param {import('snowpack').HttpRequestData} _req
+       * @param {import('snowpack').DevServerResponseHeaders} proposed
+       * @returns {import('snowpack').DevServerResponseHeaders}
+       */
+      transformHeaders: (_req, proposed) => ({
+        ...proposed,
+        'Content-Type': 'application/wasm'
+      })
+    },
+  ],
+};
+```
+
+However, if you wish to employ more complex conditions, then you can interrogate the `req` parameter.
+
+The `isHttp2RequestData` helper is provided to help you access the additional properties that HTTP/2 requests expose (namely `authority` and `scheme`). It narrows the type of `HttpRequestData` to either `Http2RequestData` or `Http1RequestData`. You can skip using this helper if you're not interested in the difference.
+
+```js
+// snowpack.config.mjs
+import { isHttp2RequestData } from 'snowpack'
+
+export default {
+  routes: [
+    {
+      src: '.*',
+      /**
+       * @param {import('snowpack').HttpRequestData} req
+       * @param {import('snowpack').DevServerResponseHeaders} proposed
+       * @returns {import('snowpack').DevServerResponseHeaders}
+       */
+      transformHeaders: (req, proposed) => {
+        if (isHttp2RequestData(req)) {
+          /**
+           * inside here, type is narrowed to:
+           * {@link import('snowpack').Http2RequestData}
+           */
+          if (req.url.endsWith('.wasm')) {
+            return {
+              ...proposed,
+              'Content-Type': 'application/wasm'
+            }
+          }
+          return proposed
+        }
+        /**
+         * from here, type is narrowed to:
+         * {@link import('snowpack').Http1RequestData}
+         */
+        if (req.url?.endsWith('.wasm')) {
+          return {
+            ...proposed,
+            'Content-Type': 'application/wasm'
+          }
+        }
+        return proposed
+      }
+    },
+  ],
+};
+```

--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -51,7 +51,6 @@ import {
 import {getPort, startDashboard, paintEvent} from './paint';
 import {cssModuleJSON} from '../build/import-css';
 import {runPipelineCleanupStep} from '../build/build-pipeline';
-import { parseObjectLiteralOrPattern } from 'meriyah/dist/src/parser';
 
 export class OneToManyMap {
   readonly keyToValue = new Map<string, string[]>();

--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -407,7 +407,7 @@ function normalizeMount(config: SnowpackConfig) {
 }
 
 function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
-  return routes.map(({src, dest, upgrade, match}, i) => {
+  return routes.map(({src, dest, match, ...rest}, i) => {
     // Normalize
     if (typeof dest === 'string') {
       dest = addLeadingSlash(dest);
@@ -420,7 +420,7 @@ function normalizeRoutes(routes: RouteConfigObject[]): RouteConfigObject[] {
     }
     // Validate
     try {
-      return {src, dest, upgrade, match: match || 'all', _srcRegex: new RegExp(src)};
+      return {...rest, src, dest, match: match || 'all', _srcRegex: new RegExp(src)};
     } catch (err) {
       throw new Error(`config.routes[${i}].src: invalid regular expression syntax "${src}"`);
     }

--- a/snowpack/src/index.ts
+++ b/snowpack/src/index.ts
@@ -15,7 +15,7 @@ import {getUrlsForFile} from './build/file-urls';
 export * from './types';
 
 // Stable API
-export {startServer, NotFoundError} from './commands/dev';
+export {startServer, NotFoundError, isHttp2RequestData} from './commands/dev';
 export {build} from './commands/build';
 export {loadConfiguration, createConfiguration} from './config.js';
 export {readLockfile as loadLockfile} from './util.js';

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -225,9 +225,16 @@ export interface OptimizeOptions {
   target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
 }
 
+export type DevServerResponseHeaders = http.OutgoingHttpHeaders;
+export type HeadersTransformer = (
+  req: http.IncomingMessage,
+  proposed: DevServerResponseHeaders
+) => DevServerResponseHeaders;
+
 export interface RouteConfigObject {
   src: string;
   dest: string | ((req: http.IncomingMessage, res: http.ServerResponse) => void) | undefined;
+  transformHeaders: HeadersTransformer;
   upgrade: ((req: http.IncomingMessage, socket: net.Socket, head: Buffer) => void) | undefined;
   match: 'routes' | 'all';
   _srcRegex: RegExp;
@@ -324,7 +331,7 @@ export type SnowpackUserConfig = {
   testOptions?: Partial<SnowpackConfig['testOptions']>;
   packageOptions?: Partial<SnowpackConfig['packageOptions']>;
   optimize?: Partial<SnowpackConfig['optimize']>;
-  routes?: Pick<RouteConfigObject, 'src' | 'dest' | 'match'>[];
+  routes?: Pick<RouteConfigObject, 'src' | 'dest' | 'match' | 'transformHeaders'>[];
   experiments?: {
     /* intentionally left blank */
   };

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -225,16 +225,52 @@ export interface OptimizeOptions {
   target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
 }
 
+/**
+ * {@link http.IncomingMessage} as a value type -- exposes data properties
+ * without exposing access to sockets, streams, methods or iterators.
+ */
+export type Http1RequestData = Pick<
+http.IncomingMessage,
+'aborted' | 'httpVersion' | 'httpVersionMajor' | 'httpVersionMinor' | 'complete' | 'headers' | 'rawHeaders' | 'trailers' | 'rawTrailers' | 'method' | 'url'
+>
+/**
+ * {@link http2.Http2ServerRequest} as a value type -- exposes data properties
+ * without exposing access to sockets, streams, methods or iterators.
+ */
+export type Http2RequestData = Pick<
+http2.Http2ServerRequest,
+'aborted' | 'httpVersion' | 'httpVersionMajor' | 'httpVersionMinor' | 'complete' | 'headers' | 'rawHeaders' | 'trailers' | 'rawTrailers' | 'method' | 'url' | 'authority' | 'scheme'
+>
+/**
+ * {@link http.IncomingMessage} or {@link http2.Http2ServerRequest} as a value type -- exposes data properties
+ * without exposing access to sockets, streams, methods or iterators.
+ * This is provided so that users of dev-server APIs may make decisions about
+ * how to route a request (or transform its response), without being able to perform
+ * side-effects upon the request handle.
+ */
+export type HttpRequestData = Http1RequestData | Http2RequestData;
 export type DevServerResponseHeaders = http.OutgoingHttpHeaders;
+
+/**
+ * @param req the HTTP request. you can use this to check (for example) the file extension of the asset being requested.
+ * @param proposed the HTTP response headers with which snowpack dev server intends to serve the asset
+ * @returns your preferred HTTP response headers (snowpack dev server will serve the asset with these instead)
+ * See {@link import('./commands/dev').isHttp2RequestData} for how to narrow the type of {@link HttpRequestData}.
+ */
 export type HeadersTransformer = (
-  req: http.IncomingMessage,
+  req: HttpRequestData,
   proposed: DevServerResponseHeaders
 ) => DevServerResponseHeaders;
 
 export interface RouteConfigObject {
   src: string;
   dest: string | ((req: http.IncomingMessage, res: http.ServerResponse) => void) | undefined;
-  transformHeaders: HeadersTransformer;
+  /**
+   * This callback (if supplied) will be invoked immediately prior to snowpack dev server's
+   * writing of HTTP response headers. Use it to override the response headers, for example
+   * to change the Content-Type or CORS policies with which assets are served.
+   */
+  transformHeaders?: HeadersTransformer;
   upgrade: ((req: http.IncomingMessage, socket: net.Socket, head: Buffer) => void) | undefined;
   match: 'routes' | 'all';
   _srcRegex: RegExp;


### PR DESCRIPTION
_Incorporates review feedback from https://github.com/snowpackjs/snowpack/pull/3357;  
Eliminates monkey-patch of `HttpServerResponse#writeHead` in favour of augmenting response with additional `writeTransformedHeaders` method.  
Avoids exposing underlying HTTP request handle to user.  
Accommodates HTTP/2 in typings.  
Adds documentation._

This enables me to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer); I needed my index.html served with additional response headers.

This also resolves @denis-sokolov's request:  
https://github.com/snowpackjs/snowpack/discussions/2420

I can also see its being useful for [serving WebAssembly assets with the appropriate headers](https://emscripten.org/docs/compiling/WebAssembly.html?highlight=fastcomp#web-server-setup).

## Changes

Exposes via `RouteConfigObject` an API for customizing the response headers on assets returned by dev server:

```ts
/**
 * {@link http.IncomingMessage} as a value type -- exposes data properties
 * without exposing access to sockets, streams, methods or iterators.
 */
export type Http1RequestData = Pick<
http.IncomingMessage,
'aborted' | 'httpVersion' | 'httpVersionMajor' | 'httpVersionMinor' | 'complete' | 'headers' | 'rawHeaders' | 'trailers' | 'rawTrailers' | 'method' | 'url'
>
/**
 * {@link http2.Http2ServerRequest} as a value type -- exposes data properties
 * without exposing access to sockets, streams, methods or iterators.
 */
export type Http2RequestData = Pick<
http2.Http2ServerRequest,
'aborted' | 'httpVersion' | 'httpVersionMajor' | 'httpVersionMinor' | 'complete' | 'headers' | 'rawHeaders' | 'trailers' | 'rawTrailers' | 'method' | 'url' | 'authority' | 'scheme'
>

/**
 * {@link http.IncomingMessage} or {@link http2.Http2ServerRequest} as a value type -- exposes data properties
 * without exposing access to sockets, streams, methods or iterators.
 * This is provided so that users of dev-server APIs may make decisions about
 * how to route a request (or transform its response), without being able to perform
 * side-effects upon the request handle.
 */
export type HttpRequestData = Http1RequestData | Http2RequestData;
export type DevServerResponseHeaders = http.OutgoingHttpHeaders;

/**
 * @param req the HTTP request. you can use this to check (for example) the file extension of the asset being requested.
 * @param proposed the HTTP response headers with which snowpack dev server intends to serve the asset
 * @returns your preferred HTTP response headers (snowpack dev server will serve the asset with these instead)
 * See {@link import('./commands/dev').isHttp2RequestData} for how to narrow the type of {@link HttpRequestData}.
 */
export type HeadersTransformer = (
  req: HttpRequestData,
  proposed: DevServerResponseHeaders
) => DevServerResponseHeaders;

export interface RouteConfigObject {
  // (other properties omitted)
  /**
   * This callback (if supplied) will be invoked immediately prior to snowpack dev server's
   * writing of HTTP response headers. Use it to override the response headers, for example
   * to change the Content-Type or CORS policies with which assets are served.
   */
  transformHeaders?: HeadersTransformer;
}
```

When `createServer`'s RequestListener handles a request, we adapt the response handle into a `SnowpackHttpServerResponse`. This is a union type (with one variant for HTTP/1, one for HTTP/2). It adds a method `writeTransformedHeaders()`, which is more restricted than `writeHead()` (enforces that headers be truthy and in dictionary format). Prior to writing headers, it consults `RouteConfigObject` to determine whether any `transformHeaders` callbacks are applicable. If so, it applies the user-defined transformation to the headers, then writes them.

Every `res.writeHead()` has been updated to prefer the new `res.writeTransformedHeaders()` method.

The method signatures of `handleRequest`, `sendResponseFile`, `handleResponseError`, `sendResponseError` have been updated to reflect the fact that they now handle our `SnowpackHttpServerResponse` type.

Where possible to do so, I also updated those signatures to document the fact that they handle a union of HTTP/1 and HTTP/2 types. I added TODOs wherever non-trivial changes would be required to achieve this typesafety.

## Testing

I wrote a sample application, with the following routes configured in snowpack.config.js:

```js
// snowpack.config.mjs
export default {
  routes: [
    {
      match: 'routes',
      src: '.*',
      /**
       * @param {import('snowpack').HttpRequestData} _req
       * @param {import('snowpack').DevServerResponseHeaders} proposed
       * @returns {import('snowpack').DevServerResponseHeaders}
       */
      transformHeaders: (_req, proposed) => ({
        ...proposed,
        'Cross-Origin-Opener-Policy': 'same-origin',
        'Cross-Origin-Embedder-Policy': 'require-corp'
      })
    },
  ],
};
```

With that change made to my [liquidfun-play](https://github.com/Birch-san/liquidfun-play) repository: my `index.html` is served with served with `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers, which makes `console.log(window.crossOriginIsolated)` return `true` (previously `false`).

A few more configurations which I tested manually are documented in `routing.md`.

## Docs

Updated `routing.md`. Added JSDoc to new types in `types.ts`.