### PR TITLE
Set the `preventAssignment` option in the vue plugin

### DIFF
--- a/plugins/plugin-vue/plugin.js
+++ b/plugins/plugin-vue/plugin.js
@@ -48,6 +48,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
     const {optionsApi = true, prodDevtools = false} = pluginOptions;
     packageOptions.rollup.plugins.push(
       replace({
+        preventAssignment: false,
         values: {
           __VUE_OPTIONS_API__: JSON.stringify(optionsApi),
           __VUE_PROD_DEVTOOLS__: JSON.stringify(prodDevtools),


### PR DESCRIPTION
## Changes

This sets the preventAssignment option on `@rollup/plugin-replace`. Omitting this option creates a noisy warning. Set to `false` because that is the default. This only removes the warning, not meant to change what is happening.

https://www.npmjs.com/package/@rollup/plugin-replace#user-content-preventassignment

## Testing

No tests, I couldn't find a way to test dev messages as we don't really have dev server tests.

## Docs

N/A
