### PR TITLE
Allow specifying if dependency is CJS module in config

### DIFF
--- a/snowpack/src/config.ts
+++ b/snowpack/src/config.ts
@@ -82,6 +82,7 @@ export const DEFAULT_PACKAGES_LOCAL_CONFIG: PackageOptionsLocal = {
   external: [],
   packageLookupFields: [],
   knownEntrypoints: [],
+  externalCjs: [],
 };
 
 const REMOTE_PACKAGE_ORIGIN = 'https://pkg.snowpack.dev';

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -573,7 +573,15 @@ export class PackageSourceLocal implements PackageSource {
           externalEsm: (imp) => {
             const [packageName] = parsePackageImportSpecifier(imp);
             const result = resolveDependencyManifest(packageName);
-            return !result || !isPackageCJS(result);
+            if (!result) {
+              return true;
+            } else if (config.packageOptions.source === 'local') {
+              const id = `${result.name}@${result.version}`;
+              if (config.packageOptions.externalCjs.includes(id)) {
+                return false;
+              }
+            }
+            return !isPackageCJS(result);
           },
         };
         if (config.packageOptions.source === 'local') {

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -241,6 +241,7 @@ export interface PackageOptionsLocal
   source: 'local' | 'remote-next' | {[key: string]: string};
   external: string[];
   knownEntrypoints: string[];
+  externalCjs: string[];
 }
 
 export interface PackageOptionsRemote {

--- a/test-dev/__snapshots__/dev.test.ts.snap
+++ b/test-dev/__snapshots__/dev.test.ts.snap
@@ -4,7 +4,7 @@ exports[`snowpack dev smoke: about 1`] = `
 "<!DOCTYPE html>
 <html>
   <head><script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
-<script type=\\"module\\" integrity=\\"sha384-y8il70JD9siKrwwsMhcx99P7XKCWpwH7DWMCPklzJJeQBV6Y4OY9RpL+HlYJlW2r\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
+<script type=\\"module\\" integrity=\\"sha384-UOe2dHGqFm+/be4Oh7BAtM9P+jtUT9bk/vX7I1ywZAfX9snRhwKsMHxF/cumKNXP\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <p>this is a template in some language that builds to .html</p>
   </body>
@@ -22,7 +22,7 @@ exports[`snowpack dev smoke: html 1`] = `
     <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"/index.css\\" />
     <title>Snowpack App</title>
   <script type=\\"text/javascript\\">window.HMR_WEBSOCKET_PORT=8080</script>
-<script type=\\"module\\" integrity=\\"sha384-y8il70JD9siKrwwsMhcx99P7XKCWpwH7DWMCPklzJJeQBV6Y4OY9RpL+HlYJlW2r\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
+<script type=\\"module\\" integrity=\\"sha384-UOe2dHGqFm+/be4Oh7BAtM9P+jtUT9bk/vX7I1ywZAfX9snRhwKsMHxF/cumKNXP\\" src=\\"/_snowpack/hmr-client.js\\"></script><script type=\\"module\\" integrity=\\"sha384-LH/mFhEGRB4jHedP0nqOoIUwc4VX8eWJxEL+qTGWtroqiLJ2vxX169J0oSBMHL5o\\" src=\\"/_snowpack/hmr-error-overlay.js\\"></script></head>
   <body>
     <img id=\\"img\\" src=\\"/logo.svg\\" />
     <canvas id=\\"canvas\\"></canvas>


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Snowpack in `"local"` configuration prebuilds dependencies using rollup-commonjs plugin. To allow interop between CJS and ESM modules correct configuration needs to be passed to commonjs plugin - one of which is `esmExternals` which tells the plugin if given external dependency is a CommonJS module.

There is a function provided by snowpack to compute (based on package manifest) the module type:
https://github.com/snowpackjs/snowpack/blob/59b503e1eb7b92b60c0509e2c1b01e64b9cb1fd3/snowpack/src/sources/local.ts#L573-L577
https://github.com/snowpackjs/snowpack/blob/59b503e1eb7b92b60c0509e2c1b01e64b9cb1fd3/snowpack/src/sources/local.ts#L58-L69

For some dependencies (ex. `call-bind`) the `isPackageCJS` may fail, as some of the condition assumptions won't hold - in this case `call-bind` provides `exports` in `package.json` but does not export ESM wrapper.
The obvious solution is to fix dependency - which is not always feasible.

I would like to propose an escape hatch for such situations that allows the user to specify if dependency is a CJS module (in my understanding it's easier for CJS package to "pretend" to be ESM than other way around - that's why specifying only that something is CJS would probably suffice).

What it changes:

- **When not using the additional option:** nothing, it works just like before
- **When CJS dependencies are explicitly defined:** some dependencies will be transpiled by commonjs plugin with assumption that they are CJS packages - without other checks to determine the module type
  - This should allow for some projects to be able to upgrade to newer version of snowpack

Similar issues/discussions:
https://github.com/snowpackjs/snowpack/issues/3295
https://github.com/snowpackjs/snowpack/discussions/2820
https://github.com/snowpackjs/snowpack/discussions/3011

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

As this is an idea to be verified: no tests for now. When this is approved to implement I'll add tests for those cases.
I've reproduced the application state from one of the issues and applied changes - the project compiled correctly.
I've done the same for a commercial project that I work on - the project also compiled correctly.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

As this is an idea to be verified: no docs update for now. When this is approved to implement I'll update the config section.