### PR TITLE
Fix links to plugin search results

### DIFF
--- a/www/src/components/PluginSearchPage.jsx
+++ b/www/src/components/PluginSearchPage.jsx
@@ -34,7 +34,7 @@ function Card({ result }) {
         {result.description.split('. ')[0]}
       </p>
       <p class={Styles.CardSubtitle}>
-        Updated
+        Updated&nbsp;
         <time class="" datetime={result.updatedAt}>
           {updatedAtFormatted}
         </time>

--- a/www/src/components/PluginSearchPage.jsx
+++ b/www/src/components/PluginSearchPage.jsx
@@ -25,7 +25,7 @@ function Card({ result }) {
       <img class={Styles.Icon__Plugin} src="/img/plug-light.svg" />
       <header class={Styles.CardHeader}>
         <h3 class={Styles.CardName}>
-          <a href="https://www.npmjs.com/package/{result.name}" target="_blank">
+          <a href={`https://www.npmjs.com/package/${result.name}`} target="_blank">
             <span itemprop="name">{result.name}</span>
           </a>
         </h3>


### PR DESCRIPTION
## Changes

This PR fixes links to plugin search results, currently each link is pointing to `https://www.npmjs.com/package/{result.name}`.

## Testing

It was tested manually in my local environment.

## Docs

Bug fix only
