### PR TITLE
[#3188] Add ant-design/icons to NEVER_PEER_PACKAGES

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -53,6 +53,7 @@ const NEVER_PEER_PACKAGES: Set<string> = new Set([
   'whatwg-fetch',
   'tslib',
   '@ant-design/icons-svg',
+  '@ant-design/icons',
 ]);
 
 function isPackageCJS(manifest: any): boolean {


### PR DESCRIPTION
this fix is related to https://github.com/snowpackjs/snowpack/issues/3188

## Changes
If an application depends on ant-design/icons package, snowpack dev takes around 5-7 mins to build all icons.
with this package added in this list, `snowpack dev` definitely not take 5 mins..
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing
I couldn't find any test related to NEVER_PEER_PACKAGES list.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
bug fix only
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
