### PR TITLE
Handle runtime invalidation for proxy files

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -241,6 +241,7 @@ function getServerRuntime(
       return result;
     },
   });
+
   if (options.invalidateOnChange !== false) {
     sp.onFileChange(({filePath}) => {
       const url = sp.getUrlForFile(filePath);
@@ -1022,6 +1023,10 @@ export async function startServer(
       server && server.close();
       hmrEngine && (await hmrEngine.stop());
     },
+    markChanged(fileLoc) {
+      knownETags.clear();
+      onWatchEvent(fileLoc);
+    }
   };
   return sp;
 }

--- a/snowpack/src/ssr-loader/index.ts
+++ b/snowpack/src/ssr-loader/index.ts
@@ -28,6 +28,11 @@ export function createLoader({config, load}: ServerRuntimeConfig): ServerRuntime
   }
 
   function invalidateModule(path) {
+    // If the cache doesn't have this path, check if it's a proxy file.
+    if(!cache.has(path) && cache.has(path + '.proxy.js')) {
+      path = path + '.proxy.js';
+    }
+
     cache.delete(path);
     const dependents = graph.get(path);
     graph.delete(path);

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -87,6 +87,7 @@ export interface SnowpackDevServer {
   getUrlForPackage: (packageSpec: string) => Promise<string>;
   onFileChange: (callback: OnFileChangeCallback) => void;
   shutdown(): Promise<void>;
+  markChanged: (fileLoc: string) => void;
 }
 
 export type SnowpackBuildResultFileManifest = Record<

--- a/test/fixture-utils.js
+++ b/test/fixture-utils.js
@@ -96,3 +96,84 @@ exports.testPrepareFixture = async function testPrepareFixture(testFiles, option
     return snowpack.preparePackages({config});
   });
 };
+
+exports.testRuntimeFixture = async function testRuntimeFixture(testFiles, {absolute = false, overrides = {}} = {}) {
+  const inDir = await fs.mkdtemp(path.join(__dirname, '__temp__', 'snowpack-fixture-'));
+
+  if (typeof testFiles === 'string') {
+    testFiles = {'index.js': testFiles};
+  }
+  for (const [fileLoc, fileContents] of Object.entries(testFiles)) {
+    await writeFile(
+      path.join(inDir, fileLoc),
+      fileContents.replace(/%TEMP_TEST_DIRECTORY%/g, inDir.split(path.sep).join(path.posix.sep)),
+    );
+  }
+
+  // Install any dependencies
+  const hasPackageJson = testFiles['package.json'];
+  hasPackageJson &&
+    require('child_process').execSync('yarn', {
+      cwd: inDir,
+      stdio: 'ignore',
+    });
+
+  const config = await snowpack.loadConfiguration({root: inDir, ...overrides});
+  const outDir = config.buildOptions.out;
+
+  const server = await snowpack.startServer({
+    config: config,
+    lockfile: null,
+  },
+  {
+    isWatch: false
+  });
+
+  const runtime = server.getServerRuntime();
+
+  return {
+    runtime,
+    async writeFile(fileLoc, fileContents) {
+      await writeFile(
+        path.join(inDir, fileLoc),
+        fileContents.replace(/%TEMP_TEST_DIRECTORY%/g, inDir.split(path.sep).join(path.posix.sep)),
+      );
+      server.markChanged(path.join(inDir, fileLoc));
+    },
+    readFiles() {
+      const result = {};
+      assert(path.isAbsolute(outDir));
+
+      const allFiles = glob.sync(`**/*.{${UTF8_FRIENDLY_EXTS.join(',')}}`, {
+        cwd: outDir,
+        nodir: true,
+        absolute: true,
+        dot: true,
+      });
+
+      for (const fileLoc of allFiles) {
+        result[
+          (absolute ? fileLoc : path.relative(outDir, fileLoc)).split(path.sep).join(path.posix.sep)
+        ] = require('fs').readFileSync(fileLoc, 'utf8');
+      }
+
+      const snowpackCache = glob.sync(`.snowpack/**/*.{${UTF8_FRIENDLY_EXTS.join(',')}}`, {
+        cwd: inDir,
+        nodir: true,
+        absolute: true,
+      });
+
+      for (const fileLoc of snowpackCache) {
+        result[
+          (absolute ? fileLoc : path.relative(outDir, fileLoc)).split(path.sep).join(path.posix.sep)
+        ] = require('fs').readFileSync(fileLoc, 'utf8');
+      }
+    },
+
+    async cleanup() {
+      // TODO: Make it easier to turn this off when debugging.
+      await rimraf.sync(inDir);
+      await server.shutdown();
+    }
+  };
+}

--- a/test/snowpack/runtime/runtime.test.js
+++ b/test/snowpack/runtime/runtime.test.js
@@ -1,0 +1,47 @@
+const {testRuntimeFixture} = require('../../fixture-utils');
+const dedent = require('dedent');
+
+describe('runtime', () => {
+  beforeAll(() => {
+    // Needed until we make Snowpack's JS Build Interface quiet by default
+    require('snowpack').logger.level = 'error';
+  });
+
+  it('Can invalidate proxy files', async () => {
+    const fixture = await testRuntimeFixture({
+      'main.js': dedent`
+        import data from './data.json';
+
+        export function getData() {
+          return data;
+        }
+      `,
+      'data.json': dedent`
+        [ 1, 2 ]
+      `,
+      'package.json': dedent`
+        {
+          "version": "1.0.1",
+          "name": "@snowpack/test-runtime-invalidate"
+        }  
+      `,
+    });
+
+    let mod = await fixture.runtime.importModule('/main.js');
+
+    expect(mod.exports.getData()).toStrictEqual([1, 2]);
+
+    // Change the file
+    await fixture.writeFile('data.json', dedent`
+      [ 1, 2, 3 ]
+    `);
+
+    try {
+      fixture.runtime.invalidateModule('/data.json');
+      mod = await fixture.runtime.importModule('/main.js');
+      expect(mod.exports.getData()).toStrictEqual([1, 2, 3]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION


## Changes

The file watcher reports the actual file name. We need to check for proxy files to properly invalidate the graph.

## Testing

Test added, first runtime test.

## Docs

N/A
