### PR TITLE
Fix race condition reading existing import-map.json files

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -493,9 +493,15 @@ export class PackageSourceLocal implements PackageSource {
       const lineBullet = colors.dim(depth === 0 ? '+' : '└──'.padStart(depth * 2 + 1, ' '));
       let packageFormatted = spec + colors.dim('@' + packageVersion);
       const existingImportMapLoc = path.join(installDest, 'import-map.json');
-      const existingImportMap: ImportMap | null =
-        (await fs.stat(existingImportMapLoc).catch(() => null)) &&
-        JSON.parse(await fs.readFile(existingImportMapLoc, 'utf8'));
+      const importMapHandle = await fs.open(existingImportMapLoc, 'r+').catch(() => null);
+
+      let existingImportMap: ImportMap | null = null;
+      if(importMapHandle) {
+        const importMapData = await importMapHandle.readFile('utf-8');
+        existingImportMap = JSON.parse(importMapData);
+        await importMapHandle.close();
+      }
+
       // Kick off a build, if needed.
       let importMap = existingImportMap;
       let needsBuild = !existingImportMap?.imports[spec];

--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -498,7 +498,7 @@ export class PackageSourceLocal implements PackageSource {
       let existingImportMap: ImportMap | null = null;
       if(importMapHandle) {
         const importMapData = await importMapHandle.readFile('utf-8');
-        existingImportMap = JSON.parse(importMapData);
+        existingImportMap = importMapData ? JSON.parse(importMapData) : null;
         await importMapHandle.close();
       }
 


### PR DESCRIPTION
When trying to read the import-map.json, if that file is being concurrently written using `fs.stat` won't tell you that. Using `fs.open` gives you a handle with `r+` (read and write) permission, which throws if it's open somewhere else for writing. If not, you get a handle and can read the data.

Fixes https://github.com/snowpackjs/astro/issues/468

## Changes

Changes the logic in reading import-map.json to use a filehandle.

## Testing

Did not, this would be hard to recreate because it's a race condition.

## Docs

N/A
