### PR TITLE
Add community app template for Typescript, Rust, and WebAssembly

### DIFF
--- a/create-snowpack-app/cli/README.md
+++ b/create-snowpack-app/cli/README.md
@@ -40,4 +40,5 @@ npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-ya
 - [snowpack-cycle](https://github.com/rajasegar/snowpack-cycle) (A pre-configured Snowpack app template for [Cycle.js](https://cycle.js.org))
 - [@snowpack-angular/template](https://github.com/YogliB/snowpack-angular/tree/main/templates/base) (A preconfigured template for Snowpack with [Angular](https://angular.io))
 - [snowpack-solid](https://github.com/amoutonbrady/snowpack-solid) (A pre-configured Snowpack app template for [Solid](https://github.com/ryansolid/solid))
+- [snowpack-template-ts-rust-wasm](https://github.com/jake-pauls/snowpack-template-ts-rust-wasm) (Snowpack + Typescript + Rust + WebAssembly)
 - PRs that add a link to this list are welcome!


### PR DESCRIPTION
## Changes
Adds new community template: `snowpack-template-ts-rust-wasm`.

Currently features use of the [snowpack-plugin-wasm-pack](https://www.npmjs.com/package/snowpack-plugin-wasm-pack) plugin, Prettier, and a small set of tests for Rust/WebAssembly modules.

## Testing
Readme/Documentation change, no testing required.

## Docs
Updated the CSA CLI Readme.
