### PR TITLE
Make import.meta.url be the file URL in SSR

### DIFF
--- a/snowpack/assets/require-or-import.js
+++ b/snowpack/assets/require-or-import.js
@@ -10,6 +10,10 @@ const r = require('resolve');
  */
 module.exports = async function requireOrImport(filepath, { from = process.cwd() } = {}) {
     return new Promise((resolve, reject) => {
+        if(filepath.startsWith('node:')) {
+          return NATIVE_IMPORT(filepath).then(mdl => resolve(mdl), err => reject(err));
+        }
+
         // Resolve path based on `from`
         const resolvedPath = r.sync(filepath, {
             basedir: from

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -27,7 +27,7 @@ export type DeepPartial<T> = {
 
 export interface ServerRuntimeConfig {
   config: SnowpackConfig;
-  load: (url: string) => Promise<{contents: string}>;
+  load: (url: string) => Promise<LoadResult<string>>;
 }
 export interface ServerRuntime {
   importModule: <T = any>(url: string) => Promise<ServerRuntimeModule<T>>;

--- a/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
+++ b/test/create-snowpack-app/__snapshots__/create-snowpack-app.test.js.snap
@@ -631,7 +631,7 @@ a {
 `;
 
 exports[`create-snowpack-app app-template-blank > build: dist/index.js 1`] = `
-"const counter = document.querySelector(\\"#counter\\")
+"const counter = document.querySelector('#counter');
 let seconds = 0;
 setInterval(() => {
   seconds += 1;

--- a/test/snowpack/runtime/runtime.test.js
+++ b/test/snowpack/runtime/runtime.test.js
@@ -47,4 +47,47 @@ describe('runtime', () => {
       await fixture.cleanup();
     }
   });
+
+  // This test is skipped due to the way Jest runs tests, you can't use dynamic import
+  // which this test depends on. See:
+  // https://github.com/nodejs/node/issues/35889
+  it.skip('Provides import.meta.fileURL in SSR', async () => {
+    const fixture = await testRuntimeFixture({
+      'main.js': dedent`
+        import fs from 'node:fs/promises';
+
+        const url = new URL('./data.json', import.meta.url);
+
+        export async function getData() {
+          const json = await fs.readFile(url, 'utf-8');
+          const data = JSON.parse(json);
+          return data;
+        }
+      `,
+      'data.json': dedent`
+        [ 1, 2 ]
+      `,
+      'package.json': dedent`
+        {
+          "version": "1.0.1",
+          "name": "@snowpack/test-runtime-invalidate"
+        }
+      `,
+      'snowpack.config.json': dedent`
+        {
+          "packageOptions": {
+            "external": ["node:fs/promises"]
+          }
+        }
+      `
+    });
+
+    try {
+      let mod = await fixture.runtime.importModule('/main.js');
+
+      expect(await mod.exports.getData()).toStrictEqual([1, 2]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Changes

This fixes SSR which previously was the mounted path to the file (just the path, so not a valid URL). It is now the actual file as a URL. This allows you to do relative lookups.

This also adds support for importing via the `node:` prefix.

## Testing

A test was added, but had to be skipped because Jest runs your code with the `vm` module and that module has a bug that prevents usage of `import()`, which this code relies on.

## Docs

N/A