### PR TITLE
Update dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: 'javascript'
-    directory: '/'
-    update_schedule: 'live'
-    automerged_updates:
-      - match:
-          dependency_type: 'all'
-          update_type: 'all'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,19 @@
 version: 2
 updates:
-    - package-ecosystem: npm
-      directory: /
-      schedule:
-          interval: daily
-          time: '08:00'
-          timezone: Asia/Ho_Chi_Minh
-      versioning-strategy: increase
-      open-pull-requests-limit: 50
-      pull-request-branch-name:
-          separator: '-'
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Asia/Ho_Chi_Minh
+    versioning-strategy: increase
+    open-pull-requests-limit: 50
+    pull-request-branch-name:
+      separator: '-'
 
-    - package-ecosystem: github-actions
-      directory: /
-      schedule:
-          interval: daily
-          time: '08:00'
-          timezone: Asia/Ho_Chi_Minh
-
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: Asia/Ho_Chi_Minh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: daily
+          time: '08:00'
+          timezone: Asia/Ho_Chi_Minh
+      versioning-strategy: increase
+      open-pull-requests-limit: 50
+      pull-request-branch-name:
+          separator: '-'
+
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: daily
+          time: '08:00'
+          timezone: Asia/Ho_Chi_Minh
+


### PR DESCRIPTION
## Changes

I just remove the old dependabot v1 and update it into dependabot v2
I also add support for updating github-actions and update in subdirectory
Before (in your repo):

![image](https://user-images.githubusercontent.com/64778285/123030534-2710ae00-d40d-11eb-87c6-e6ab2cbe7ea7.png)

After (in my repo):

![image](https://user-images.githubusercontent.com/64778285/123030567-3263d980-d40d-11eb-814c-09a7f5d98ea0.png)

These pictures are taken in the same time (you can see the left bottom for time)
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

There isn't any changes with the code in webpack (only dependabot)
Let me know if you want me to change the schedule:
```yaml
schedule:
          interval: daily
          time: '08:00'
          timezone: Asia/Ho_Chi_Minh
```

## Docs

Update dependabot only so no docs change
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
