### PR TITLE
Check externals before resolving entrypoint

### DIFF
--- a/snowpack/src/sources/local.ts
+++ b/snowpack/src/sources/local.ts
@@ -677,6 +677,13 @@ export class PackageSourceLocal implements PackageSource {
       spec = spec.replace(from, to);
     }
 
+    const [packageName] = parsePackageImportSpecifier(spec);
+
+    // If this import is marked as external, do not transform the original spec
+    if (this.isExternal(packageName, spec)) {
+      return spec;
+    }
+
     const entrypoint = resolveEntrypoint(spec, {
       cwd: source,
       packageLookupFields: [
@@ -693,12 +700,6 @@ export class PackageSourceLocal implements PackageSource {
       if (memoizedResolve[entrypoint]) {
         return path.posix.join(config.buildOptions.metaUrlPath, 'pkg', memoizedResolve[entrypoint]);
       }
-    }
-    const [packageName] = parsePackageImportSpecifier(spec);
-
-    // If this import is marked as external, do not transform the original spec
-    if (this.isExternal(packageName, spec)) {
-      return spec;
     }
 
     const isSymlink = !entrypoint.includes(path.join('node_modules', packageName));


### PR DESCRIPTION
## Changes

When resolving package imports we should check external as soon as possible to avoid unnecessary work. The `resolve` package doesn't support the `node:` prefix at the moment. If you want to make that `external` it needs to not go through the resolve flow (which is unnecessary anyways.

## Testing

Test is added, but is skipped due to this bug: https://github.com/nodejs/node/issues/35889 and the way that Jest runs code.

## Docs

Bug fix only, N/A.
