### PR TITLE
[#3427] Add scopeId to exported components

### DIFF
--- a/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
+++ b/plugins/plugin-vue/test/__snapshots__/plugin.test.js.snap
@@ -105,6 +105,37 @@ export default defaultExport;",
 }
 `;
 
+exports[`plugin base style scoped 1`] = `
+Object {
+  ".css": Object {
+    "code": "
+h1[data-v-XXXXXXXX] {
+  color: red;
+}
+",
+    "map": "",
+  },
+  ".js": Object {
+    "code": "
+const defaultExport = {};
+
+import { openBlock as _openBlock, createBlock as _createBlock, withScopeId as _withScopeId } from \\"vue\\"
+const _withId = /*#__PURE__*/_withScopeId(\\"data-v-XXXXXXXX\\")
+
+export const render = /*#__PURE__*/_withId((_ctx, _cache) => {
+  return (_openBlock(), _createBlock(\\"h1\\", null, \\"Vue Content Style Scoped\\"))
+});
+
+defaultExport.render = render;
+
+defaultExport.__scopeId = \\"data-v-XXXXXXXX\\";
+
+export default defaultExport;",
+    "map": "",
+  },
+}
+`;
+
 exports[`plugin base with sourceMap 1`] = `
 Object {
   ".css": Object {

--- a/plugins/plugin-vue/test/plugin.test.js
+++ b/plugins/plugin-vue/test/plugin.test.js
@@ -54,5 +54,9 @@ test('plugin base style scoped', async () => {
   const resultContent = await pluginLoad({
     filePath: codeFilePath,
   });
-  expect(resultContent['.css'].code).toMatch(/h1\[data-v-.*\]/);
+  ['.css', '.js'].forEach(key => {
+    const code = resultContent[key].code;
+    resultContent[key].code = code.replace(/data-v-[a-z0-9]+/g, 'data-v-XXXXXXXX');
+  });
+  expect(resultContent).toMatchSnapshot();
 });


### PR DESCRIPTION
## Changes

This fixes an issue where scoped styles were not being applied to non-hoisted elements due to a lack of `v-data-{id}` attributes. This seems to be related to a change in the Vue compiler (starting in `3.0.8`) where `withId` is effectively no-op'ed in favor of `withCtx`, which looks for a `__scopeId` property on the root component (or something like that. tbh i'm not really trying to become a Vue compiler expert rn—i just need my styles to work).

## Testing

Patched `node_modules` in a local project and verified that `data-v-{id}` gets added and styles are applied.

## Docs

No docs needed. Bug fix only.
