### PR TITLE
Pass real filepath to transform plugins

### DIFF
--- a/plugins/plugin-postcss/plugin.js
+++ b/plugins/plugin-postcss/plugin.js
@@ -23,7 +23,7 @@ module.exports = function postcssPlugin(snowpackConfig, options) {
 
   return {
     name: '@snowpack/postcss-transform',
-    async transform({id, fileExt, contents}) {
+    async transform({id, srcPath, fileExt, contents}) {
       let {input = ['.css'], config} = options;
 
       if (!input.includes(fileExt) || !contents) return;
@@ -37,7 +37,7 @@ module.exports = function postcssPlugin(snowpackConfig, options) {
 
       const encodedResult = await worker.transformAsync(contents, {
         config,
-        filepath: id,
+        filepath: srcPath,
         cwd: snowpackConfig.root || process.cwd(),
         map:
           snowpackConfig.buildOptions && snowpackConfig.buildOptions.sourceMaps

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -182,6 +182,7 @@ async function runPipelineTransformStep(
           isPackage,
           fileExt: destExt,
           id: filePath,
+          srcPath,
           // @ts-ignore: Deprecated
           filePath: fileName,
           // @ts-ignore: Deprecated

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -137,8 +137,10 @@ export interface PluginLoadOptions {
 }
 
 export interface PluginTransformOptions {
-  /** The absolute file path of the source file, on disk. */
+  /** The final build file path (note: this may differ from the source, e.g. `.vue` will yield `.js` and `.css` IDs) */
   id: string;
+  /** The original source location on disk (it may differ from ID) */
+  srcPath: string;
   /** The extension of the file */
   fileExt: string;
   /** Contents of the file to transform */


### PR DESCRIPTION
## Changes

In the dev server, our `transform` plugins receive a pseudo-URL, which neither exists on disk nor really at the final URL (but probably closer to the latter). The root cause here is when working with PostCSS on transformed files, you’ll get the following error:

```
Error: ENOENT: no such file or directory, stat '{projectRoot}/src/components/Button2.css'
```

More details here: https://github.com/snowpackjs/astro/issues/481

Because we weren’t passing a real location on disk to PostCSS, it would fail running on any CSS that was generated from a non-`.css` file (e.g. `.astro`, `.pcss`, `.vue`, etc.)

This PR adds a new `srcPath` option to plugins which is backwards-compatible, and fixes the original error.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Tested manually; fixes the error and doesn’t cause any other known issues.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs

No docs changes needed

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
