### PR TITLE
dry up headers object, support COOP/COEP/CORP

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -85,6 +85,16 @@ interface FoundFile {
 
 const FILE_BUILD_RESULT_ERROR = `Build Result Error: There was a problem with a file build result.`;
 
+const COMMON_HEADERS: http.OutgoingHttpHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Accept-Ranges': 'bytes',
+  'Content-Type': 'application/octet-stream',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Resource-Policy': 'cross-origin',
+  Vary: 'Accept-Encoding',
+};
+
 /**
  * If encoding is defined, return a string. Otherwise, return a Buffer.
  */
@@ -129,12 +139,10 @@ function sendResponseFile(
 ) {
   const body = Buffer.from(contents);
   const ETag = etag(body, {weak: true});
-  const headers: Record<string, string> = {
-    'Accept-Ranges': 'bytes',
-    'Access-Control-Allow-Origin': '*',
+  const headers: http.OutgoingHttpHeaders = {
+    ...COMMON_HEADERS,
     'Content-Type': contentType || 'application/octet-stream',
     ETag,
-    Vary: 'Accept-Encoding',
   };
 
   if (req.headers['if-none-match'] === ETag) {
@@ -199,11 +207,9 @@ function sendResponseFile(
 
 function sendResponseError(req: http.IncomingMessage, res: http.ServerResponse, status: number) {
   const contentType = mime.contentType(path.extname(req.url!) || '.html');
-  const headers: Record<string, string> = {
-    'Access-Control-Allow-Origin': '*',
-    'Accept-Ranges': 'bytes',
+  const headers: http.OutgoingHttpHeaders = {
+    ...COMMON_HEADERS,
     'Content-Type': contentType || 'application/octet-stream',
-    Vary: 'Accept-Encoding',
   };
   res.writeHead(status, headers);
   res.end();


### PR DESCRIPTION
> Note: I accidentally closed [my previous PR](https://github.com/snowpackjs/snowpack/pull/3666), so I opened this one instead, with the requested changes made. 😅

## Changes

Hello everyone, first time contributor here. ヾ(•ω•`)o

Featurewise, this change adds the following default headers to the dev server:
- Cross-Origin Embedder Policy (COEP)
- Cross-Origin Opener Policy (COOP)
- Cross-Origin Resource Policy (CORP)

The two duplicated headers objects were also DRYed up into a single "common headers" object.

This feature enables anyone using SharedArrayBuffers (or in my case: using Three.js) to choose snowpack as their dev server.

## Testing

Installing, building, and executing tests behaved the same before and after the change.

## Docs

No docs are required, as this change merely widens the default support in the dev server.
