### PR TITLE
fix #3653

### DIFF
--- a/snowpack/src/logger.ts
+++ b/snowpack/src/logger.ts
@@ -59,7 +59,7 @@ class SnowpackLogger {
     if (level === 'error') text = colors.red(text);
     const time = new Date();
     const log = `${colors.dim(
-      `[${String(time.getHours() + 1).padStart(2, '0')}:${String(time.getMinutes() + 1).padStart(
+      `[${String(time.getHours()).padStart(2, '0')}:${String(time.getMinutes()).padStart(
         2,
         '0',
       )}:${String(time.getSeconds()).padStart(2, '0')}]`,


### PR DESCRIPTION
Fixes an error causing logger timestamps to be an hour and a minute fast