### PR TITLE
Expanded 'No such file or directory' error

### DIFF
--- a/docs/reference/common-error-details.md
+++ b/docs/reference/common-error-details.md
@@ -14,7 +14,7 @@ ENOENT: no such file or directory, open …/node_modules/csstype/index.js
 
 This error message would sometimes occur in older versions of Snowpack.
 
-**To solve this issue:** Upgrade to Snowpack `v2.6.0` or higher. If you continue to see this unexpected error in newer versions of Snowpack, please file an issue.
+**To solve this issue:** Upgrade to Snowpack `v2.6.0` or higher. If you continue to see this unexpected error in newer versions of Snowpack, try deleting `node_modules` folder and reinstall dependencies with `npm install`. If this didn't solve the problem, please file an issue.
 
 ### Package exists but package.json "exports" does not include entry
 


### PR DESCRIPTION
Proposed reinstallation of node_modules as first step in 'No such file or directory' error.

## Changes

Added solution to common error details ('No such file or directory' error)

## Testing

No testing required, only documentation update.

## Docs

I encountered this error and solved it by reinstalling node_modules. Thought it would be ideal first step before 
submitting an issue since it's quick and easy (and it helped my problem).
